### PR TITLE
fix(tools): exclude action pin rotations from reviewed reusable baselines

### DIFF
--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -5408,6 +5408,101 @@ daily; "that version is not what I am pinned to" does not. **Prefer the durable 
 remains pinned at `v0.86.0` because its three vendored files are byte-identical there, which is a
 statement about content and does not expire when a tag lands.
 
+## Two correct controls, deadlocked: a security update blocked for four days
+
+Chasing the claim that skip tolerance is _conserved_ rather than eliminated, I measured the
+gatekeeper's dependency set and then its actual outcomes. The tolerance question resolved
+immediately and unremarkably; the outcome tally did not.
+
+**The tolerance is forced for two of eight.** Of the gatekeeper's 8 `needs:`, only
+`codeql-java-kotlin` and `dependency-review` carry an `if:` at all. The other six —
+`codeql-javascript`, `secret-scanning`, `gitleaks`, `npm-audit`, `gradle-dependency-check`,
+`license-check` — are unconditional, and across 40 runs every one of them concluded `success`
+40/40. So blanket `success|skipped` tolerance is load-bearing for 25% of the set and pure slack
+for the rest. That is a real if minor widening, and it is _not_ what the runs were failing on.
+
+**A 12/12 coincidence that wasn't a correlation.** `Dependency Review` was `skipped` 12 times and
+`Required Checks Gatekeeper` failed 12 times, which looked like the documented tolerance not
+working. Crosstabulating refuted it outright: `dr=skipped → gk=success` ×11 (all `push`), and all
+12 gatekeeper failures were `pull_request` runs where dependency-review **succeeded**. The
+tolerance does exactly what its comment claims. Two equal counts, zero overlap — worth recording
+because the matching totals were the entire basis for suspecting it.
+
+**What the failures actually were.** All 8 required checks green, gatekeeper red. The failing step
+is a different one in the same job:
+
+```
+Workflow security regression check failed:
+- reusable-detect-changes.yml: reviewed local reusable drifted
+    (expected f67ce0e2…, found 642d6e29…)
+- reusable-release-smoke-test.yml: reviewed local reusable drifted
+    (expected 74ff29d0…, found bba5f8f3…)
+```
+
+10 of the 12 failures are the **same pull request** — #4012, a Dependabot bump of 12 actions
+across 28 workflow files, open since 2026-08-08 and still failing on the most recent run in the
+sample. The other two were transient and self-healed on the next push.
+
+### The deadlock
+
+`tools/check-workflow-security.mjs` freezes two privileged `workflow_call` targets to a reviewed
+SHA-256 of their **whole file** (`localReusableBaselines`, added in `517d0116` / #4025 — this
+predates the engineering-practice adoption and is not something this work introduced).
+`GH-ACT-003` requires every `uses:` to be pinned to a full 40-character commit SHA. Dependabot's
+entire function is to rotate those pins. Both files contain pinned actions.
+
+So: the pinning rule mandates the pins, Dependabot updates the pins, and the freeze reads a pin
+update as an unreviewed edit to a privileged workflow. Each control is correct in isolation and
+neither can yield to the other. The result is that **a security-relevant dependency update is
+blocked by a security control**, and the longer it stays blocked the staler the pins it was
+trying to refresh — the failure mode compounds in the direction of less security, not more.
+
+This is the sibling session's structural finding in a second instance, and a stronger one: there
+the mandatory remedy for one trap _manufactured the condition_ of another. Here two mandatory
+controls manufacture a deadlock with no third position available.
+
+### The fix, and precisely what it gives up
+
+`normalizeReviewedPins()` elides an already-pinned reference before the baseline hash is taken,
+so the baseline tracks a workflow's **logic** rather than the specific SHAs it pins:
+
+```
+uses: actions/checkout@11bd71901bbe…  # v4.2.2   →   uses: actions/checkout@<PINNED>
+```
+
+Four properties, each held by a test:
+
+- **`owner/repo` is preserved.** Repointing a step at a different action still drifts. Verified by
+  mutating a real pin to `attacker/evil` — exit 1.
+- **Only a full 40-hex reference is elided.** A pin replaced by `@v4` does not match, so it drifts
+  here _and_ is independently reported by `findMutableReferenceViolations`, which runs over every
+  workflow at L416 and requires a 40-hex SHA on every `uses:`.
+- **The trailing `# vX.Y.Z` comment is elided with the reference,** because Dependabot rewrites it
+  in the same edit. Leaving it in would have reintroduced exactly the drift being removed — the
+  normalisation would have looked right and changed nothing.
+- **Non-`uses:` lines are untouched,** so a SHA appearing in a `run:` is still hashed.
+
+Residual risk, stated plainly: an in-place rotation of a valid 40-hex SHA on an
+**already-trusted `owner/repo`** is no longer caught by _this_ control. That is the exact change
+Dependabot makes, which is why the deadlock existed. It remains covered by the 40-hex pin
+requirement, by dependency-review and CodeQL on the same PR, and by the canonical-comparison
+assertion these two files also carry.
+
+### Verified against the real failing input, not an analogue
+
+The raw hashes computed locally reproduce the CI log **exactly** — `f67ce0e2…` expected /
+`642d6e29…` found, and `74ff29d0…` / `bba5f8f3…` — so this was measured on the input that failed
+rather than a reconstruction of it. Under normalisation, `main` and #4012 produce an identical
+hash for both files, which also establishes that the entire delta in those files was pin
+rotation and nothing structural.
+
+Six directions checked end to end: `main` → 0; #4012's content → **0** (deadlock resolved);
+injected job → 1; restored → 0; repointed action → 1; final → 0. 17/17 unit tests.
+
+**The portable form:** a content freeze over a file that a bot is _required_ to edit is a deadlock
+with a delay fuse. It passes review, passes CI, and passes every run until the bot's first edit —
+and the component that finally reports red is neither of the two controls that conflict.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:

--- a/tools/check-workflow-security.mjs
+++ b/tools/check-workflow-security.mjs
@@ -36,9 +36,9 @@ const privilegedWorkflows = new Set([
 ]);
 
 const localReusableBaselines = {
-  'reusable-detect-changes.yml': 'f67ce0e29f90d0d9a73e7db3155ba8ccec3525e2eb8a2730ed9337a3ef614ade',
+  'reusable-detect-changes.yml': '73a26b45af9ff6254e6982b63b336dc4a9a2bdd785d7ffbdaae4094d2ae90697',
   'reusable-release-smoke-test.yml':
-    '74ff29d0ee4a028db9ceb804eb3b662bfbb3595dc21563438768bc39991b3e6e',
+    '170107646a35e855dbfc9b95aaa395da41ccab84cad70f1bdc559448e8c603df',
 };
 
 const requiredEnvironmentJobs = {
@@ -137,6 +137,30 @@ function normalize(text) {
 
 function sha256(text) {
   return createHash('sha256').update(normalize(text)).digest('hex');
+}
+
+/**
+ * Elide already-pinned action references so the reviewed-reusable baseline tracks a
+ * workflow's logic rather than the specific SHAs it pins.
+ *
+ * Only a full 40-hex reference is elided, and only the reference itself — `owner/repo`
+ * is preserved, so repointing a step at a different action still drifts the baseline.
+ * A pin replaced by a tag or branch does not match, so it drifts here and is reported
+ * separately by findMutableReferenceViolations, which requires a 40-hex SHA on every
+ * `uses:` in every workflow (ENG-SEC-004, GH-ACT-003).
+ *
+ * The trailing `# vX.Y.Z` comment is elided with the reference because Dependabot
+ * rewrites it in the same edit; leaving it in the hash would reintroduce the drift
+ * this normalisation exists to remove.
+ *
+ * @param {string} text Raw workflow source.
+ * @returns {string} Source with pinned references reduced to `owner/repo@<PINNED>`.
+ */
+export function normalizeReviewedPins(text) {
+  return normalize(text).replace(
+    /^(\s*(?:-\s*)?uses:\s*)([^@\s]+)@[0-9a-f]{40}[^\n]*$/gm,
+    '$1$2@<PINNED>',
+  );
 }
 
 export function extractJob(workflow, jobName) {
@@ -528,11 +552,13 @@ export function scanWorkflowSecurity(workflows, productionCompose = '') {
     if (!workflow.includes(`Canonical comparison: jrmoulckers/.github@${canonicalWorkflowSha}`)) {
       report(file, `must document canonical comparison at ${canonicalWorkflowSha}`);
     }
-    const actualHash = sha256(workflow);
+    const actualHash = sha256(normalizeReviewedPins(workflow));
     if (actualHash !== expectedHash) {
       report(
         file,
-        `reviewed local reusable drifted (expected ${expectedHash}, found ${actualHash})`,
+        `reviewed local reusable drifted (expected ${expectedHash}, found ${actualHash}); ` +
+          'action pin rotations are excluded from this baseline, so this reflects a change ' +
+          'to the workflow itself and needs review',
       );
     }
   }

--- a/tools/check-workflow-security.test.mjs
+++ b/tools/check-workflow-security.test.mjs
@@ -8,6 +8,7 @@ import {
   findInheritingJobs,
   findMutableReferenceViolations,
   findRunExpressionViolations,
+  normalizeReviewedPins,
   pureEventDisjunction,
   scanWorkflowSecurity,
 } from './check-workflow-security.mjs';
@@ -210,4 +211,35 @@ test('scanWorkflowSecurity does not flag jobs recorded in the inheritance baseli
     errors.some((error) => /omits permissions:/.test(error)),
     false,
   );
+});
+
+test('normalizeReviewedPins elides a pinned reference and its version comment', () => {
+  const before = '      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2';
+  const after = '      - uses: actions/checkout@50b1a1e0dc63b1bbecac6b0c8a1a1e3a30e6f4b1 # v5.0.0';
+  assert.equal(normalizeReviewedPins(before), normalizeReviewedPins(after));
+  assert.equal(normalizeReviewedPins(before), '      - uses: actions/checkout@<PINNED>');
+});
+
+test('normalizeReviewedPins preserves owner/repo so repointing an action still drifts', () => {
+  const genuine =
+    '      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2';
+  const swapped =
+    '      - uses: attacker/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2';
+  assert.notEqual(normalizeReviewedPins(genuine), normalizeReviewedPins(swapped));
+});
+
+test('normalizeReviewedPins leaves unpinned references intact so they still drift', () => {
+  const tagged = '      - uses: actions/checkout@v4';
+  assert.equal(normalizeReviewedPins(tagged), tagged);
+  assert.equal(
+    findMutableReferenceViolations(`${tagged}\n`).some((violation) =>
+      /not pinned by full SHA/.test(violation.reason),
+    ),
+    true,
+  );
+});
+
+test('normalizeReviewedPins does not elide a non-uses line that contains a SHA', () => {
+  const line = '      run: echo 11bd71901bbe5b1630ceea73d27597364c9af683';
+  assert.equal(normalizeReviewedPins(line), line);
 });


### PR DESCRIPTION
## Summary

`Required Checks Gatekeeper` — a required check — has been failing on Dependabot PR #4012 since
**2026-08-08**. All 8 of its `needs:` are green; the failure is a different step in the same job.

Two correct controls deadlock:

- `localReusableBaselines` (added in `517d0116` / #4025) freezes two privileged `workflow_call`
  targets to a SHA-256 of their **whole file**.
- `GH-ACT-003` requires every `uses:` to be pinned to a full 40-char SHA, and Dependabot's job is
  to rotate those pins.

So a pin bump reads as an unreviewed edit to a privileged workflow. Neither control can yield, and
a **security update is blocked by a security control** — with the pins going staler the longer it
holds.

## Fix

`normalizeReviewedPins()` elides an already-pinned reference before hashing, so the baseline
tracks logic rather than pin values:

```
uses: actions/checkout@11bd7190… # v4.2.2   →   uses: actions/checkout@<PINNED>
```

What is deliberately retained (each covered by a test):

- **`owner/repo` preserved** — repointing an action still drifts (verified: exit 1).
- **Only full 40-hex elided** — an unpinned `@v4` still drifts *and* is reported by
  `findMutableReferenceViolations`, which runs on every workflow and requires a 40-hex SHA.
- **Trailing `# vX.Y.Z` elided with the ref** — Dependabot rewrites it in the same edit; leaving
  it in would have reintroduced the drift and made the change a silent no-op.
- **Non-`uses:` lines untouched.**

**Residual risk, stated plainly:** an in-place rotation of a valid SHA on an already-trusted
`owner/repo` is no longer caught by *this* control — which is exactly the edit Dependabot makes.
Still covered by the 40-hex pin requirement, dependency-review/CodeQL on the same PR, and the
canonical-comparison assertion.

## Verified against the real failing input

Locally recomputed raw hashes reproduce the CI log exactly (`f67ce0e2…`/`642d6e29…` and
`74ff29d0…`/`bba5f8f3…`). Under normalisation `main` and #4012 hash identically, which also proves
the whole delta in those files was pin rotation, nothing structural.

| # | Input | Exit |
| --- | --- | --- |
| 1 | `main` | 0 |
| 2 | **#4012 content** | **0 — deadlock resolved** |
| 3 | injected job | 1 |
| 4 | restored | 0 |
| 5 | repointed to `attacker/evil` | 1 |
| 6 | final | 0 |

Also corrects a near-miss recorded in the guide: `Dependency Review` skipped ×12 and the
gatekeeper failed ×12 looked like the documented skip tolerance failing. Crosstab refutes it —
`dr=skipped → gk=success` ×11, and all 12 failures were PR runs where dependency-review
succeeded. Equal counts, zero overlap.

## Issues

Refs #4029, unblocks #4012

## Testing

- [x] 17/17 `npm run workflow:security:test`
- [x] `node tools/check-workflow-security.mjs` exit 0
- [x] prettier + eslint clean
- [x] citations gate 141/40/806/44 exit 0