### PR TITLE
fix(tools): walk the whole repo for canonical provenance (#4217)

### DIFF
--- a/tools/check-ai-manifest.js
+++ b/tools/check-ai-manifest.js
@@ -25,6 +25,19 @@ const ACTIVATION_DOC = 'docs/ai/README.md';
 // file is the likeliest to quote it.
 const PROVENANCE_LINE =
   /^(?:<!--|\/\*|#) (?:generated \+ )?synced from jrmoulckers\/[^\n]*?do not edit here(?: -->| \*\/)?$/m;
+// A substring the regex above cannot match without. Used only as a fast prescreen before the
+// line-anchored test, which is the expensive part over a repo-wide walk: without it the walk
+// runs a multiline regex over ~44 MB and takes ~59s; with it the regex sees only the ~68 files
+// that contain the literal, and the walk costs ~4s.
+//
+// This is a filter, and filters are precisely what hid the token corpus for the life of this
+// check (#4204). It is safe only because it is *implied by* the pattern rather than an
+// independent guess about the corpus -- every string PROVENANCE_LINE accepts contains it by
+// construction -- and there is a test asserting exactly that, over all delivered stamp forms.
+// A prefix-read optimization was considered and rejected for failing this standard: the largest
+// stamp offset in this repo is 37,605 bytes, in AGENTS.md, so any plausible prefix window would
+// have silently dropped one of the three files this issue exists to reach.
+const PROVENANCE_HINT = 'synced from jrmoulckers/';
 const GENERATED_AGENTS = [
   'accessibility-reviewer',
   'ai-ops-engineer',
@@ -428,7 +441,18 @@ function validateSyncLock() {
   }
 
   findings.push(...verifyManagedContent(lock));
-  findings.push(...verifyLockCoverage(lock));
+  const coverage = lockCoverage(lock);
+  findings.push(...coverage.findings);
+  // The walk's breadth is stated, not implied. The claim this check makes is repo-wide -- no
+  // stamped file anywhere is missing from the lock -- so the number of files it actually
+  // entered belongs next to it. A large stamped count reads as thorough and is exactly what
+  // stopped anyone asking which directories were never entered (#4217).
+  process.stdout.write(
+    `  [coverage] walked ${coverage.walked} file(s); ` +
+      `${coverage.visitedRecorded} of ${coverage.recordedPresent} present recorded targets visited` +
+      (coverage.skipped ? `; ${coverage.skipped} unreadable or past the size cap` : '') +
+      '\n',
+  );
   const source = verifySourceReproduction(lock);
   findings.push(...source.findings);
   const total = source.reproduced + source.unreproduced.length + source.knownUnreproduced.length;
@@ -514,13 +538,10 @@ function managedDigest(text) {
 // Counts alone cannot catch this: they count lock entries, not files.
 const PENDING_SYNC = /(^|\/)vendor\/@jrm\/tokens\//;
 
-// Bases whose contents the sync engine may own. Used only to bound the coverage walk below.
-const MANAGED_BASES = [
-  '.github/agents',
-  '.github/skills',
-  '.github/prompts',
-  '.github/instructions',
-];
+// The engine's own delivered bases, kept only as documentation of what it owns. The coverage
+// walk no longer bounds itself by them (#4217): deriving roots from the lock made the check
+// blind exactly where it was interesting, and all four bases live under `.github`, a directory
+// the lock already supplied, so the union contributed nothing it did not already have.
 
 // The inverse of verifyManagedContent: that asks "entry present, is the file there?", this
 // asks "file present, is it recorded?". A lock-iterating check cannot reach a canon target
@@ -538,38 +559,74 @@ const MANAGED_BASES = [
 // inventory, which the lock does not record (it stores only version/backbone/generatedAt/
 // entries). Two such files are known today, reported as .github#669; closing that axis needs
 // the backbone at runtime, the owner-gated question in #4141.
-function verifyLockCoverage(lock) {
+// Directories the coverage walk does not enter. Named explicitly and reported, because an
+// unnamed exclusion is how this check spent its whole life blind (#4204, #4217). None of these
+// can hold an engine-written file: the sync engine writes only to paths it records in the lock,
+// and no lock entry has ever named one of them.
+const WALK_SKIP = new Set([
+  '.git',
+  'node_modules',
+  '.gradle',
+  'build',
+  'dist',
+  '.turbo',
+  '.next',
+  'coverage',
+]);
+
+// Reports what the walk saw as well as what it objected to. `verifyLockCoverage` keeps the
+// findings-only signature every existing test uses; `main` reads the counts so the passing
+// summary carries its own measurement rather than asserting coverage it never states.
+function lockCoverage(lock) {
   const findings = [];
   const recorded = new Set(Object.keys(lock.entries || {}));
   const seen = new Set();
+  let walked = 0;
+  let skipped = 0;
   let stampedRecorded = 0;
   let stampedRecordedNonMarkdown = 0;
-  for (const base of coverageRoots(recorded)) {
-    for (const file of walkFiles(path.join(ROOT, base))) {
-      const relPath = path.relative(ROOT, file).split(path.sep).join('/');
-      // Roots may nest -- the lock contributes `.github`, which contains every MANAGED_BASES
-      // entry -- so a file is reachable by more than one root and would otherwise be counted
-      // and reported once per root. The suite's stamped-unrecorded control caught this
-      // immediately as `2 !== 1`, which is what that control is for.
-      if (seen.has(relPath)) continue;
-      seen.add(relPath);
-      const text = readTextForStamp(file);
-      if (text === null) continue;
-      if (!PROVENANCE_LINE.test(text)) continue;
-      if (recorded.has(relPath)) {
-        stampedRecorded += 1;
-        if (!/\.mdx?$/.test(relPath)) stampedRecordedNonMarkdown += 1;
-      } else {
-        findings.push(`carries canonical provenance but is not a lock entry: ${relPath}`);
-      }
+  for (const file of walkFiles(ROOT)) {
+    const relPath = path.relative(ROOT, file).split(path.sep).join('/');
+    if (seen.has(relPath)) continue;
+    seen.add(relPath);
+    walked += 1;
+    const text = readTextForStamp(file);
+    if (text === null) {
+      skipped += 1;
+      continue;
+    }
+    if (!text.includes(PROVENANCE_HINT)) continue;
+    if (!PROVENANCE_LINE.test(text)) continue;
+    if (recorded.has(relPath)) {
+      stampedRecorded += 1;
+      if (!/\.mdx?$/.test(relPath)) stampedRecordedNonMarkdown += 1;
+    } else {
+      findings.push(`carries canonical provenance but is not a lock entry: ${relPath}`);
     }
   }
-  // Premise guard, now two-sided. The first clause is the original: nothing observed means the
-  // walk stopped reaching managed files, and a clean result reports that as complete coverage.
-  // The second exists because this check spent its whole life blind to every non-Markdown
-  // entry -- 23 of 81, the vendored token corpus -- behind three filters that were each a
-  // provable no-op when removed alone (#4204). Only the conjunction was load-bearing, so no
-  // single-variable audit could find it. This clause fails if the walk regresses to Markdown.
+
+  // Conservation, and the clause that would have caught #4217. The walk previously derived its
+  // roots from the lock -- `entry.split('/')[0]`, guarded by `top !== entry` -- so the three
+  // root-level managed files (.gitattributes, AGENTS.md, agency.toml) were structurally
+  // unreachable, and 14 of this repo's 16 top-level directories were never entered at all. The
+  // claim is repo-wide ("no stamped file is unrecorded") while the walk covered two directories,
+  // and the numerator concealed it: 65 stamped files reads as thorough, so nothing invited the
+  // question that a 0 would have. Asserting that the walk REACHES every recorded target that
+  // exists on disk is the property; a count of what it happened to find is not.
+  const recordedPresent = [...recorded].filter((entry) => fs.existsSync(path.join(ROOT, entry)));
+  const unvisited = recordedPresent.filter((entry) => !seen.has(entry));
+  if (unvisited.length) {
+    findings.push(
+      `lock-coverage walk never visited ${unvisited.length} recorded target(s) that exist on ` +
+        `disk: ${unvisited.slice(0, 5).join(', ')}${unvisited.length > 5 ? ', …' : ''}`,
+    );
+  }
+
+  // Premise guard, two-sided. The first clause is the original: nothing observed means the walk
+  // stopped reaching managed files, and a clean result reports that as complete coverage. The
+  // second exists because this check spent its whole life blind to every non-Markdown entry --
+  // 23 of 81, the vendored token corpus -- behind three filters that were each a provable no-op
+  // when removed alone (#4204). Only the conjunction was load-bearing.
   if (stampedRecorded === 0) {
     findings.push('lock-coverage walk found no recorded canonical file — check is not observing');
   } else if (stampedRecordedNonMarkdown === 0) {
@@ -577,20 +634,18 @@ function verifyLockCoverage(lock) {
       'lock-coverage walk observed only Markdown — the non-Markdown corpus is unobserved (#4204)',
     );
   }
-  return findings;
+  return {
+    findings,
+    walked,
+    skipped,
+    stampedRecorded,
+    recordedPresent: recordedPresent.length,
+    visitedRecorded: recordedPresent.length - unvisited.length,
+  };
 }
 
-// Roots are derived from the lock rather than hand-listed, so the walk follows the engine when
-// it delivers somewhere new instead of silently declining to look. MANAGED_BASES stays in the
-// union: those directories must be walked even when nothing in them is recorded yet, which is
-// the only state in which an unrecorded stamped file is the interesting finding.
-function coverageRoots(recorded) {
-  const roots = new Set(MANAGED_BASES);
-  for (const entry of recorded) {
-    const top = entry.split('/')[0];
-    if (top && top !== entry) roots.add(top);
-  }
-  return [...roots];
+function verifyLockCoverage(lock) {
+  return lockCoverage(lock).findings;
 }
 
 // Reads a file only if it is plausibly a stamped text file. The size cap keeps a large
@@ -628,6 +683,7 @@ function readTextForStamp(file) {
 function walkFiles(dir) {
   if (!fs.existsSync(dir)) return [];
   return fs.readdirSync(dir, { withFileTypes: true }).flatMap((item) => {
+    if (WALK_SKIP.has(item.name)) return [];
     const full = path.join(dir, item.name);
     return item.isDirectory() ? walkFiles(full) : [full];
   });
@@ -1008,6 +1064,7 @@ if (require.main === module) {
 module.exports = {
   toLF,
   PROVENANCE_LINE,
+  PROVENANCE_HINT,
   DOC_FILES,
   METRICS,
   scanDoc,
@@ -1016,6 +1073,8 @@ module.exports = {
   managedRegion,
   managedDigest,
   verifyLockCoverage,
+  lockCoverage,
+  WALK_SKIP,
   unstampSource,
   commentFamily,
   verifySourceReproduction,

--- a/tools/check-ai-manifest.test.mjs
+++ b/tools/check-ai-manifest.test.mjs
@@ -20,6 +20,9 @@ const {
   managedRegion,
   managedDigest,
   verifyLockCoverage,
+  lockCoverage,
+  WALK_SKIP,
+  PROVENANCE_HINT,
   unstampSource,
   commentFamily,
   verifySourceReproduction,
@@ -530,4 +533,155 @@ test('inspected counts documents actually read, not documents declared', () => {
   assert.deepEqual(scan.missing, ['docs/does-not-exist-4212.md']);
   assert.equal(scan.declared, 2);
   assert.equal(scan.inspected, 1);
+});
+
+// --- #4217: the walk must reach the population the claim covers -------------------------------
+//
+// verifyLockCoverage claims something repo-wide -- no stamped file anywhere is missing from the
+// lock -- while deriving its walk roots FROM the lock. So a stamped file could only be found in a
+// directory the lock already mentioned, and an unrecorded engine write is by definition the case
+// where it does not. 14 of 16 top-level directories were never entered, and the three root-level
+// managed files were structurally unreachable via `top !== entry`.
+//
+// Nothing asked, because the numerator was large: 65 stamped files reads as thorough. A zero
+// invites the question a 65 closes.
+
+test('the walk reaches every recorded target that exists on disk', () => {
+  const lock = JSON.parse(fs.readFileSync(path.join(ROOT, '.studio-sync.lock.json'), 'utf8'));
+  const coverage = lockCoverage(lock);
+  // Before #4217 this was 65 of 68: .gitattributes, AGENTS.md and agency.toml sit at the repo
+  // root, and `if (top && top !== entry)` excluded exactly the entries with no directory part.
+  assert.equal(
+    coverage.visitedRecorded,
+    coverage.recordedPresent,
+    'every recorded target present on disk must be visited by the walk',
+  );
+  assert.ok(coverage.recordedPresent > 0, 'PREMISE: some recorded target exists on disk');
+});
+
+test('a recorded target the walk cannot reach is reported as unvisited', () => {
+  // DISCLOSURE: the test above asserts the conservation property but does not exercise the
+  // guard -- today every recorded target IS visited, so disabling the guard changed nothing and
+  // the mutant survived. A property that happens to hold is not a pinned guard. This constructs
+  // the state the guard exists for: a recorded entry that is present on disk and structurally
+  // outside the walk, by putting it behind a WALK_SKIP directory.
+  // Must be a real directory: in a git worktree `.git` is a FILE, so existsSync alone picks a
+  // name that cannot hold a probe. The predicate has to match the thing the walk skips.
+  const skipped = [...WALK_SKIP].find((name) => {
+    const candidate = path.join(ROOT, name);
+    return fs.existsSync(candidate) && fs.statSync(candidate).isDirectory();
+  });
+  assert.ok(skipped, 'PREMISE: at least one excluded directory exists to hide a file behind');
+  const rel = `${skipped}/__unvisited_probe_4217__.md`;
+  const lock = JSON.parse(fs.readFileSync(path.join(ROOT, '.studio-sync.lock.json'), 'utf8'));
+  try {
+    // Deliberately unstamped: the finding under test is about reach, not about provenance.
+    fs.writeFileSync(path.join(ROOT, rel), '# probe\n');
+    lock.entries[rel] = { sourceSha256: 'x', targetSha256: 'y', syncedAt: '1970-01-01T00:00:00Z' };
+    const coverage = lockCoverage(lock);
+    assert.ok(
+      coverage.findings.some((f) => f.includes('never visited') && f.includes(rel)),
+      `an unreachable recorded target must be named; got ${JSON.stringify(coverage.findings.slice(0, 3))}`,
+    );
+    assert.ok(
+      coverage.visitedRecorded < coverage.recordedPresent,
+      'the reported numerator must fall short of the population it claims to cover',
+    );
+  } finally {
+    fs.rmSync(path.join(ROOT, rel), { force: true });
+  }
+});
+
+test('root-level managed files are inside the walk', () => {
+  // The three that were unreachable. Named individually rather than counted, so that losing one
+  // is a failure rather than a smaller number.
+  const lock = JSON.parse(fs.readFileSync(path.join(ROOT, '.studio-sync.lock.json'), 'utf8'));
+  const rootLevel = Object.keys(lock.entries).filter((entry) => !entry.includes('/'));
+  assert.ok(rootLevel.length > 0, 'PREMISE: the lock records root-level entries');
+  const stray = path.join(ROOT, '__coverage_root_probe_4217__.md');
+  try {
+    fs.writeFileSync(
+      stray,
+      '<!-- synced from jrmoulckers/.github — canonical source; do not edit here -->\n\n# probe\n',
+    );
+    const findings = verifyLockCoverage(lock);
+    assert.ok(
+      findings.some((f) => f.includes('__coverage_root_probe_4217__')),
+      `a stamped file at the repo root must be reported; got ${JSON.stringify(findings.slice(0, 3))}`,
+    );
+  } finally {
+    fs.rmSync(stray, { force: true });
+  }
+  assert.deepEqual(verifyLockCoverage(lock), [], 'probe must leave no residue');
+});
+
+test('a stamped file in a directory the lock never mentions is caught', () => {
+  // The defect itself. `apps/` holds no lock entry, so the old lock-derived roots could not
+  // reach it -- and `apps/web/vendor/@jrm/tokens` is where this repo's tokens actually lived
+  // until the repo-root migration, so a regressed delivery lands exactly here.
+  const lock = JSON.parse(fs.readFileSync(path.join(ROOT, '.studio-sync.lock.json'), 'utf8'));
+  assert.ok(
+    !Object.keys(lock.entries).some((entry) => entry.startsWith('apps/')),
+    'PREMISE: no lock entry lives under apps/, so only a repo-wide walk reaches it',
+  );
+  const dir = path.join(ROOT, 'apps', '__coverage_probe_4217__');
+  const file = path.join(dir, 'stray.css');
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      file,
+      '/* generated + synced from jrmoulckers/studio @jrm/tokens — do not edit here */\n\na{}\n',
+    );
+    const findings = verifyLockCoverage(lock);
+    assert.ok(
+      findings.some((f) => f.includes('__coverage_probe_4217__')),
+      `a stamped file under apps/ must be reported; got ${JSON.stringify(findings.slice(0, 3))}`,
+    );
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  assert.deepEqual(verifyLockCoverage(lock), [], 'probe must leave no residue');
+});
+
+test('the prescreen is implied by the pattern, not an independent guess', () => {
+  // The prescreen exists for cost: without it the repo-wide walk runs a multiline regex over
+  // ~44 MB. A filter is exactly what hid the token corpus for the life of this check (#4204),
+  // so it is admissible ONLY because every string the regex accepts contains the literal. This
+  // asserts that relation over all delivered stamp forms rather than trusting the reading.
+  const delivered = [
+    '<!-- synced from jrmoulckers/.github — canonical source; do not edit here -->',
+    '/* generated + synced from jrmoulckers/studio @jrm/tokens — do not edit here */',
+    '# synced from jrmoulckers/.github — canonical source; do not edit here',
+    '<!-- generated + synced from jrmoulckers/studio — do not edit here -->',
+  ];
+  for (const stamp of delivered) {
+    assert.ok(PROVENANCE_LINE.test(stamp), `PREMISE: pattern must accept ${stamp.slice(0, 24)}`);
+    assert.ok(
+      stamp.includes(PROVENANCE_HINT),
+      `prescreen would reject a stamp the pattern accepts: ${stamp}`,
+    );
+  }
+  // And the relation must hold structurally, not only on these four samples.
+  assert.ok(
+    PROVENANCE_LINE.source.includes('synced from jrmoulckers'),
+    'the pattern must mandate the prescreen literal',
+  );
+});
+
+test('the walk names its exclusions rather than dropping them silently', () => {
+  // WALK_SKIP is a filter over the walked population and therefore has to be stated. This does
+  // not assert the list is correct -- it asserts it is finite, declared, and cannot quietly
+  // grow to include a directory the engine delivers into.
+  const lock = JSON.parse(fs.readFileSync(path.join(ROOT, '.studio-sync.lock.json'), 'utf8'));
+  const tops = new Set(
+    Object.keys(lock.entries)
+      .map((entry) => entry.split('/')[0])
+      .filter((top) => top),
+  );
+  for (const skipped of WALK_SKIP) {
+    assert.ok(
+      !tops.has(skipped),
+      `WALK_SKIP excludes a directory the lock delivers into: ${skipped}`,
+    );
+  }
 });


### PR DESCRIPTION
## Summary

`verifyLockCoverage` asserts that no file carrying canonical provenance is missing from `.studio-sync.lock.json` — a claim about **the repository**. Its walk covered **2 of 16 top-level directories**, because it derived its own roots from the lock (`entry.split('/')[0]`, guarded by `top !== entry`).

Measured, not read:

```
recorded lock entries present on disk : 68
of those visited by the old walk      : 65      <- the concealing numerator
top-level directories in this repo    : 16
reachable by the old walk             : 2       (.github, vendor)
root-level entries, structurally unvisitable : .gitattributes, AGENTS.md, agency.toml
repo-wide stamped files               : 68
repo-wide stamped UNRECORDED          : 0       <- no live defect
```

The premise guard asked only whether the count was zero. It was armed against the **empty** walk and blind to the **wrong** walk. A small number invites the question; 65 closes it.

`MANAGED_BASES` contributed nothing — all four bases live under `.github`, which the lock already supplies. It is deleted, not kept as reassurance.

## Changes

- Walk repo-wide from `ROOT`; remove the lock-derived roots and `MANAGED_BASES`.
- **Conservation guard**: every recorded entry present on disk must be *visited*. This asserts reach — the property — rather than counting what the walk happened to find.
- `WALK_SKIP` names its exclusions (`.git node_modules .gradle build dist .turbo .next coverage`), with a test that it can never grow to cover a directory the lock delivers into.
- The passing summary now carries its measurement: `walked 5542 file(s); 68 of 68 present recorded targets visited`.
- `lockCoverage` returns counts; `verifyLockCoverage` stays a findings-only wrapper, so every existing test keeps its signature.

## Cost, disclosed

Tool runtime **0.88s → 7.67s**. The cost is the multiline regex over ~44 MB, not I/O — a naive repo-wide walk measured **59s**. `PROVENANCE_HINT = 'synced from jrmoulckers/'` prescreens before the regex and is admissible **only** because `PROVENANCE_LINE` cannot match a string lacking that literal. It is implied by the pattern, not a guess about the corpus, and a test asserts that relation over all four delivered stamp forms plus `PROVENANCE_LINE.source`. A filter is exactly what hid the token corpus for the life of this check (#4204), so this one is justified structurally rather than empirically.

## Alternatives measured and rejected

- **`git ls-files` as the population** — 128ms to enumerate, but it makes untracked files invisible, and several existing tests write untracked probes and assert they are reported. The same blindness in new clothes.
- **Prefix reads** — max stamp offset in this corpus is **37,605 bytes, in `AGENTS.md`**, one of the three files the old walk excluded. Any plausible window would have silently dropped exactly the file motivating the fix, while still reporting 67/68.

## Mutation testing

Each mutant applied at a verified unique source index; each kill confirmed by failing test **name**, not by the aggregate.

| Mutant | Result |
| --- | --- |
| A — walk bounded back to `.github`/`vendor` | 7 FAIL, incl. *the walk reaches every recorded target*, *root-level managed files are inside the walk*, *a stamped file in a directory the lock never mentions is caught* |
| B — conservation guard disabled | **initially SURVIVED (0 FAIL)** — see below; now 1 FAIL, *a recorded target the walk cannot reach is reported as unvisited* |
| C — root-level files excluded from the walk | 1 FAIL, *root-level managed files are inside the walk* |
| D — prescreen literal not implied by the pattern | 5 FAIL, incl. *the prescreen is implied by the pattern, not an independent guess* |
| E — `WALK_SKIP` ignored | 1 FAIL, same test; runtime 6s → 116s |

**Disclosure on B.** My first conservation test asserted `visitedRecorded === recordedPresent` against the real repo. That property holds today, so disabling the guard changed nothing and the mutant survived — the test measured a true state and pinned no guard. Fixed by constructing the state the guard exists for: a recorded entry present on disk and structurally outside the walk (behind a `WALK_SKIP` directory). That test kills B and E both.

A second self-caught error in the same test: it picked the excluded directory with `existsSync`, which selects `.git` — and in a git **worktree** `.git` is a *file*, so the probe write failed with ENOENT. The predicate now matches what the walk actually skips (a directory).

## Testing

- `node --test tools/check-ai-manifest.test.mjs` — **37 pass / 0 fail** (31 → 37).
- `node tools/check-ai-manifest.js --strict` — exit 0, `[coverage] walked 5542 file(s); 68 of 68 present recorded targets visited; 2 unreadable or past the size cap`.
- `npx prettier --check` on both touched files — clean.
- `npx eslint … --max-warnings 0` on both touched files — exit 0.

Repo-wide `format:check` was not run: it hangs monorepo-wide on this box and there is a known pre-existing CRLF artifact across this org. Both files I touched are verified clean individually.

## Scope

`tools/` only. No workflow, no lock hand-edit, no change to `packages/design-tokens`, no change to `vendor/@jrm/tokens`.

Closes #4217
Refs jrmoulckers/.github#669