### PR TITLE
chore(config): re-pin vendored engineering configs to v0.120.0

### DIFF
--- a/config/engineering/citations/check-citations.mjs
+++ b/config/engineering/citations/check-citations.mjs
@@ -54,6 +54,11 @@
 
 import { readFile, readdir, stat } from 'node:fs/promises';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// This file lives in scripts/, so the repository root is one level up. Used to
+// map tag-pinned URLs into this repo back onto the local checkout.
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
 // Two non-empty lines either side of the citing line, skipping blanks rather
 // than spending the budget on them. Returns the citing line too, so callers can
@@ -175,6 +180,74 @@ async function loadIndex(source) {
   return new Map(principles.map((p) => [p.id, p]));
 }
 
+/**
+ * GitHub's heading-anchor algorithm: lowercase, strip anything that is not a
+ * word character, space or hyphen, then convert spaces to hyphens. Inline
+ * markdown is stripped first so `## The \`typeAware\` flag` slugifies the way
+ * GitHub renders it rather than keeping the backticks.
+ *
+ * Returns null when the file cannot be read, which the caller treats as "not
+ * my defect to report" rather than as a missing anchor.
+ */
+async function readHeadingSlugs(file) {
+  let text;
+  try {
+    text = await readFile(file, 'utf8');
+  } catch {
+    return null;
+  }
+  const slugs = new Set();
+  let inFence = false;
+  for (const line of text.split(/\r?\n/)) {
+    if (/^\s*(```|~~~)/.test(line)) {
+      inFence = !inFence;
+      continue;
+    }
+    // A `#` inside a fenced block is a shell comment, not a heading.
+    if (inFence) continue;
+    const heading = /^(#{1,6})\s+(.+?)\s*#*\s*$/.exec(line);
+    if (!heading) continue;
+    const slug = heading[2]
+      .replace(/`([^`]*)`/g, '$1')
+      .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+      .replace(/[*_~]/g, '')
+      .trim()
+      .toLowerCase()
+      .replace(/[^\w\s-]/g, '')
+      .replace(/\s/g, '-');
+    // GitHub disambiguates repeats with -1, -2, ... in document order.
+    let candidate = slug;
+    for (let n = 1; slugs.has(candidate); n += 1) candidate = `${slug}-${n}`;
+    slugs.add(candidate);
+  }
+  return slugs;
+}
+
+/**
+ * Map a citation link to a principle file on disk, or null when it cannot be
+ * checked locally.
+ *
+ * Consumers cite absolute, tag-pinned URLs into this repository rather than
+ * relative paths, so resolving only relative links would make the anchor check
+ * vacuous for every repo that actually uses it. A same-repo blob or raw URL is
+ * mapped back onto the local checkout by its path; anything pointing at another
+ * host or repository is left alone.
+ *
+ * Caveat worth knowing: the local checkout is the working tree, not the ref the
+ * URL pins. A citation pinned at an old tag is validated against today's
+ * headings, so this reports the anchor a re-pin would land on — which is the
+ * question worth answering, since a stale pin is read when it is bumped.
+ */
+function resolvePrincipleFile(link) {
+  const remote =
+    /^https?:\/\/(?:github\.com\/jrmoulckers\/engineering\/(?:blob|tree)|raw\.githubusercontent\.com\/jrmoulckers\/engineering)\/[^/]+\/(.+)$/.exec(
+      link.target,
+    );
+  if (remote) return path.resolve(REPO_ROOT, remote[1]);
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(link.target)) return null; // another host
+  return path.resolve(path.dirname(link.file), link.target);
+}
+
 async function collectFiles(target) {
   const info = await stat(target);
   if (info.isFile()) return [target];
@@ -206,11 +279,12 @@ async function scanFile(file) {
       const id = label.match(/\bENG-[A-Z]+-\d{3}\b/)?.[0];
       if (!id) continue;
       const target = href.split('#')[0].trim();
+      const fragment = href.includes('#') ? href.slice(href.indexOf('#') + 1).trim() : '';
       // Only links that aim at a principle source file. A link whose text names
       // an ID but points at a practice guide is citing the technique, not the
       // principle, and is correct as written.
       if (!/(^|\/)principles\//.test(target)) continue;
-      links.push({ file, line: i + 1, id, href, target });
+      links.push({ file, line: i + 1, id, href, target, fragment });
     }
 
     for (const match of text.matchAll(CITATION)) {
@@ -328,12 +402,38 @@ async function main() {
     .map((t) => ({ ...t, want: known.get(t.id).title }))
     .filter((t) => normalizeTitle(t.claimed) !== normalizeTitle(t.want));
 
+  // A fragment cannot 404. `principles/foo.md#no-such-heading` serves 200 and
+  // lands at the top of the file, so retitling a heading silently degrades
+  // every citation of it from "this specific rule" to "this file, somewhere".
+  // There is no error to observe, which is why the link check above — which
+  // discards the fragment — cannot see it. Raised by a consumer who verified
+  // all 11 of their own anchors by hand after reaching the same conclusion.
+  const badAnchors = [];
+  if (opts.links) {
+    const headingCache = new Map();
+    for (const l of links.filter((x) => x.fragment && known.has(x.id))) {
+      const abs = resolvePrincipleFile(l);
+      if (abs === null) continue;
+      if (!headingCache.has(abs)) headingCache.set(abs, await readHeadingSlugs(abs));
+      const slugs = headingCache.get(abs);
+      // A file that could not be read is already reported by the link check;
+      // reporting a missing anchor as well would be the same defect twice.
+      if (slugs === null) continue;
+      if (!slugs.has(l.fragment)) badAnchors.push({ ...l, known: [...slugs] });
+    }
+  }
+
   if (opts.json) {
     console.log(
       JSON.stringify(
         {
           checkerVersion: TOOL_VERSION,
-          checksRun: ['ids', 'statedNames', 'rangeMembers', ...(opts.links ? ['linkPaths'] : [])],
+          checksRun: [
+            'ids',
+            'statedNames',
+            'rangeMembers',
+            ...(opts.links ? ['linkPaths', 'linkAnchors'] : []),
+          ],
           index: opts.index,
           scanned: files.length,
           citations: citations.map((c) => ({
@@ -342,13 +442,19 @@ async function main() {
           })),
           unknown,
           badLinks,
+          badAnchors,
           badTitles,
         },
         null,
         2,
       ),
     );
-    return unknown.length > 0 || badLinks.length > 0 || badTitles.length > 0 ? 1 : 0;
+    return unknown.length > 0 ||
+      badLinks.length > 0 ||
+      badAnchors.length > 0 ||
+      badTitles.length > 0
+      ? 1
+      : 0;
   }
 
   if (citations.length === 0) {
@@ -485,6 +591,24 @@ async function main() {
 
   const distinct = new Set(citations.map((c) => c.id));
 
+  if (badAnchors.length > 0) {
+    console.error(
+      `${badAnchors.length} citation link(s) point at a heading that does not exist:\n`,
+    );
+    for (const a of badAnchors) {
+      console.error(`  ${a.file}:${a.line}  ${a.id} -> ${a.href}`);
+      const near = a.known.filter((s) => s.includes(a.fragment) || a.fragment.includes(s));
+      if (near.length > 0) console.error(`      did you mean: ${near.slice(0, 3).join(', ')}`);
+    }
+    console.error(
+      '\nA fragment cannot 404. The file serves 200 and the reader lands at the\n' +
+        'top, so this degrades silently from "this specific rule" to "this file,\n' +
+        'somewhere" — with no error anywhere to observe. Retitling a heading\n' +
+        'breaks every citation of it and nothing says so.',
+    );
+    return 1;
+  }
+
   if (badTitles.length > 0) {
     console.error(`${badTitles.length} citation(s) state the wrong principle name:\n`);
     for (const t of badTitles) {
@@ -509,7 +633,7 @@ async function main() {
   );
   console.log(
     `checker v${TOOL_VERSION}; checks run: IDs, stated names, range members` +
-      (opts.links ? ', link paths' : ' (link paths SKIPPED via --no-links)') +
+      (opts.links ? ', link paths, link anchors' : ' (link paths SKIPPED via --no-links)') +
       `. Index: ${opts.index}`,
   );
   if (!opts.review) {
@@ -521,12 +645,22 @@ async function main() {
   return 0;
 }
 
-main().then(
-  (code) => {
-    process.exitCode = code;
-  },
-  (err) => {
-    console.error(`check-citations: ${err.message}`);
-    process.exitCode = 2;
-  },
-);
+// Exported for direct unit testing. The slug algorithm has cases no fixture in
+// this repository exercises — fenced code, duplicate headings, inline markdown —
+// and an end-to-end test of those passes for the wrong reason: a nonexistent
+// anchor fails identically whether or not the fence was handled.
+export { readHeadingSlugs };
+
+// Only run the CLI when invoked as one. Without this, importing the module to
+// test a helper executes a full scan.
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().then(
+    (code) => {
+      process.exitCode = code;
+    },
+    (err) => {
+      console.error(`check-citations: ${err.message}`);
+      process.exitCode = 2;
+    },
+  );
+}

--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -5685,6 +5685,109 @@ The cheap remedy is `git stash --include-untracked` before any sync, or `git sta
 _before_ rather than after. The durable one is the same rule as everywhere else: a command whose
 safety depends on an unstated precondition should state it.
 
+## Re-pinning across 34 tags, and what actually changed
+
+Upstream reported that `publish.yml` triggers only on tag push, tagging was manual, and **30 PRs
+merged without a tag** — so `releases/latest` served a stale script and fixes reported as shipped
+were unreachable from any ref a consumer could pin.
+
+Measured before re-pinning. The claim understates it:
+
+| ref        | `scripts/vendor-configs.mjs` | sha256 (first 16)  |
+| ---------- | ---------------------------- | ------------------ |
+| `v0.86.0`  | 303 lines                    | `35241DC829A49D63` |
+| `v0.100.0` | 303 lines                    | `35241DC829A49D63` |
+| `v0.110.0` | 303 lines                    | `35241DC829A49D63` |
+| `v0.115.0` | 303 lines                    | `35241DC829A49D63` |
+| `v0.116.0` | 873 lines                    | `04B70C5F5BBA4F00` |
+| `v0.120.0` | 903 lines                    | `2054166291D5F983` |
+
+**Byte-identical across 29 tags.** Three distinct scripts across the six sampled tags. So the
+`v0.15.x` pin cluster recorded earlier in this document was not the failure it looked like — for
+`vendor-configs.mjs`, `v0.86.0` and `v0.115.0` were _the same artifact_, and re-pinning between
+them would have changed nothing while appearing to be diligence.
+
+**The notice was itself stale on arrival.** It announced `v0.116.0` as the head; `releases/latest`
+resolved to **`v0.120.0`**, four tags further on. This is the fourth stale literal recorded here and
+the first to appear inside a message _about_ stale literals. Re-pinned to the resolved ref, not the
+quoted one — the habit the upstream doc itself prescribes.
+
+### What actually changed, which is the question that was asked
+
+finance vendors **3 files**. Across 34 tags, **exactly 1 changed**:
+
+| vendored file                                      | v0.86.0 → v0.120.0            |
+| -------------------------------------------------- | ----------------------------- |
+| `config/engineering/prettier/index.js`             | unchanged                     |
+| `config/engineering/prettier/svelte.js`            | unchanged                     |
+| `config/engineering/citations/check-citations.mjs` | **changed** (532 → 666 lines) |
+
+The two unchanged files are the control: had the hashing pipeline been wrong, all three would have
+differed. The vendoring tool independently reported `1 file(s) changed content`, agreeing with the
+measurement.
+
+The checker's delta is `+147 / -13`, and every one of the 13 removals is upstream evolution, not a
+finance-local edit — so the file was a clean vendored copy and replacing it lost nothing. Its
+self-reported version string is **`v9` before and after**, so the version is not a usable signal for
+what a re-pin brings.
+
+The one observable capability gain is a new check: **`link anchors`**.
+
+### The new check is vacuous in every consumer repo
+
+`--check` and the citation gate both went green, and the parent's own caution applies: _a
+newly-silent tool and a broken tool look identical from outside_. Tested rather than assumed.
+
+A citation with a correct file path and a deliberately nonexistent `#fragment`:
+
+```
+node config/engineering/citations/check-citations.mjs .
+  142 citation(s) ... checks run: IDs, stated names, range members, link paths, link anchors
+  exit 0
+```
+
+**Silent.** The mechanism is one line:
+
+```js
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+```
+
+In the engineering repo the script lives in `scripts/`, so `..` is the repo root and
+`principles/operations/observability.md` resolves. Vendored into
+`config/engineering/citations/`, `..` is **`config/engineering/`**, and the checker looks for
+`config/engineering/principles/operations/observability.md` — which no consumer has.
+`readHeadingSlugs` returns `null` on a failed read, the caller treats that as "not my defect to
+report", and the check silently does nothing while continuing to advertise itself as run.
+
+Proved by supplying exactly that file — a stub with one real heading — and re-running the identical
+probe:
+
+```
+1 citation link(s) point at a heading that does not exist:
+  docs/guides/tmp-anchor-probe.md:3  <principles path>#this-anchor-does-not-exist-anywhere
+exit 1
+```
+
+Same input, same checker, opposite result — the difference is entirely whether a path derived from
+the _script's own location_ happens to exist. The stub and probe were removed after measuring.
+
+The sharp edge is that the source comment two lines above reasons about precisely this risk:
+
+> resolving only relative links would make the anchor check vacuous for every repo that actually
+> uses it
+
+The author identified the failure, chose absolute-URL mapping to avoid it, and the mapping is
+anchored to a path that is only correct in the repo where the check is **least** needed. **A check
+that is vacuous where it is used and live where it is authored will always be observed working.**
+
+This is the fifth vacuous pass catalogued in this document, and the first where the vacuity is a
+function of _file layout_ rather than of an empty input set — which makes it invisible to the
+denominator discipline, because the denominator is non-zero (141 citations) and every one of them
+is skipped.
+
+Reported upstream as a defect in the engineering repo rather than worked around here: the fix is to
+resolve the principle root from the lock or a flag, not from `import.meta.url`.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:

--- a/engineering-configs.lock.json
+++ b/engineering-configs.lock.json
@@ -1,7 +1,7 @@
 {
   "repository": "jrmoulckers/engineering",
-  "ref": "v0.86.0",
-  "fetchedAt": "2026-08-12T04:12:35.679Z",
+  "ref": "v0.120.0",
+  "fetchedAt": "2026-08-12T16:17:11.071Z",
   "refresh": "node scripts/vendor-configs.mjs <newer-ref>",
   "files": {
     "config/engineering/prettier/index.js": {
@@ -14,7 +14,7 @@
     },
     "config/engineering/citations/check-citations.mjs": {
       "source": "scripts/check-citations.mjs",
-      "sha256": "4bc850401c2fa188a80cb7597d873ffd27311940030e51c4eedf006d13b19dd4"
+      "sha256": "f5f3998b277dad0c3c576eef7ef65a4a308f9bb605aff717c16e0154ca52d24a"
     }
   }
 }


### PR DESCRIPTION
## Summary

Upstream reported 30 PRs merged without a tag, leaving `releases/latest` serving a stale script and
"this shipped" claims unreachable from any pinnable ref. **Measured before re-pinning, and the
claim understates it.**

| ref | `vendor-configs.mjs` | sha256 (first 16) |
| --- | --- | --- |
| `v0.86.0` | 303 lines | `35241DC829A49D63` |
| `v0.100.0` | 303 lines | `35241DC829A49D63` |
| `v0.110.0` | 303 lines | `35241DC829A49D63` |
| `v0.115.0` | 303 lines | `35241DC829A49D63` |
| `v0.116.0` | 873 lines | `04B70C5F5BBA4F00` |
| `v0.120.0` | 903 lines | `2054166291D5F983` |

**Byte-identical across 29 tags.** So the `v0.15.x` pin cluster recorded earlier was not the failure
it looked like — re-pinning anywhere in that range changes nothing while looking like diligence.

The notice announced `v0.116.0`; `releases/latest` resolves to **`v0.120.0`**. Pinned to the
resolved ref, not the quoted literal.

## What actually changed

Of the **3** files finance vendors, **exactly 1** differs across 34 tags:

| file | v0.86.0 → v0.120.0 |
| --- | --- |
| `prettier/index.js` | unchanged |
| `prettier/svelte.js` | unchanged |
| `citations/check-citations.mjs` | **changed**, 532 → 666 lines |

The two unchanged files are the control for the hash pipeline; the tool independently agreed
(`1 file(s) changed content`). All 13 removed lines are upstream evolution, not finance-local edits.
Self-reported version is **`v9` before and after**, so version is not a usable signal.

The single capability gain is a `link anchors` check.

## The new check is vacuous in every consumer repo

Green is not evidence here — *a newly-silent tool and a broken tool look identical from outside*. A
citation with a correct path and a nonexistent `#fragment` passes **silently, exit 0**, while the
checker still advertises `link anchors` as run.

```js
const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
```

In engineering the script sits in `scripts/`, so `..` is the repo root. Vendored into
`config/engineering/citations/`, `..` is `config/engineering/` — so it looks for
`config/engineering/principles/**`, the read fails, `readHeadingSlugs` returns `null`, and the
caller treats that as "not my defect to report".

Proved in both directions: supplying that exact stub file makes the identical probe fail with
`1 citation link(s) point at a heading that does not exist`, exit 1. Same input, same checker,
opposite result. Stub and probe removed after measuring.

The source comment two lines above reasons about precisely this risk ("would make the anchor check
vacuous for every repo that actually uses it") and then anchors the mapping to a path correct only
in the repo where the check is least needed. **A check that is vacuous where it is used and live
where it is authored will always be observed working.**

Reported upstream rather than worked around — the fix is to resolve the principle root from the
lock or a flag, not from `import.meta.url`.

## Testing

- [x] `npx eslint . --max-warnings 0` exit 0
- [x] `npx prettier --check` (config, docs, lock) clean
- [x] `npm run eng:citations` 141/40/806/44, exit 0
- [x] `npm run eng:vendor:check` clean at `v0.120.0`
- [x] `npm run workflow:security:test` 21/21
- [x] `node tools/check-workflow-security.mjs` exit 0

Refs #4029
