### PR TITLE
chore(config): bring the module-type marker under the vendoring lock

### DIFF
--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -5896,6 +5896,100 @@ repetition, because each individual disclaimer is true and only the sequence cre
 inference.** No single message is wrong, so no single message is challengeable. The remedy is to
 name the owner positively rather than to decline in turn.
 
+## Dropping the unhashed marker, and the check I nearly disabled to do it
+
+Upstream fixed the `"type": "module"` gap and asked finance to drop its workaround file. Doing so
+took three changes to the local vendoring fork, and the second one would have silently disabled
+staleness reporting for every vendored file — the exact class of defect the fix was meant to close.
+
+### Why port rather than converge
+
+Upstream's script is now 1,023 lines to finance's 418, so replacing the fork wholesale looks like
+the obvious move. It isn't: upstream has **no `citations` set** and no reference to
+`check-citations.mjs` at all. Converging would drop the vendoring of the checker that runs on every
+PR here. So the module-type behaviour was ported into the fork instead, and the fork's divergence is
+now a deliberate superset rather than lag.
+
+### The marker is now under the lock
+
+Previously `config/engineering/prettier/package.json` was hand-written, tracked by git, and **absent
+from `engineering-configs.lock.json`** — so `--check` reported the tree clean regardless of what the
+marker said. Now it is generated and staged like any other file, with a distinct source key:
+
+```json
+"config/engineering/prettier/package.json": {
+  "source": "packages/prettier-config/package.json#type",
+  "sha256": "3ca9d4af…"
+}
+```
+
+Mutation-tested in both directions: editing the marker to `"commonjs"` now fails
+`--check` with `content differs from the lock`, exit 1; restoring it returns exit 0. That is the
+whole difference between a marker and a locked marker.
+
+The emitted type is verified against the ref rather than trusted, because a marker stating the
+_wrong_ type is worse than none — an explicit type overrides Node's own CJS/ESM detection fallback,
+converting a runtime that would have coped into one that cannot.
+
+### The defect I nearly shipped
+
+`changedFilesAt()` fetches `entry.source` for every lock entry, and reads any failure as "no
+signal", returning `null` for the whole set. A derived entry whose source key is
+`packages/prettier-config/package.json#type` has no fetchable file — so adding one entry to the lock
+would have made the staleness comparison return `null` **for all four files, permanently**, while
+printing a cheerful "unknown" rather than an error.
+
+That is this document's recurring shape once more: a correct-looking green produced by a check that
+no longer runs. It would have been introduced _by_ the fix for an unhashed file, in the function
+whose own comment (six lines above) already warns that this path "swallows throws and reports no
+signal".
+
+**My stated mechanism for it was wrong, and measuring corrected me.** I claimed the fetch would 404. It does not:
+
+| step                      | actual behaviour                                                   |
+| ------------------------- | ------------------------------------------------------------------ |
+| `fetch(url + '#type')`    | WHATWG fetch **strips the fragment** → HTTP **200**, real manifest |
+| `path.endsWith('.json')`  | **false** — the path ends `#type`, so the JSON branch is skipped   |
+| else-branch `/^export /m` | manifest has no `export ` → `fail('exports nothing')` → throw      |
+| caller                    | catches → `null` → "no signal"                                     |
+
+Same outcome, different route, and the route matters: a 404 would have been visible in any network
+log, whereas a 200 whose payload is then rejected on a shape rule looks like a content problem with
+upstream. Fixed by splitting the source key on `#` and comparing the derived field — so the marker's
+staleness stays _live_, tracking upstream's declared `type` rather than being skipped.
+
+### A guard that outlived its assumption
+
+Fetching the manifest also tripped `assertPayload`, which required `compilerOptions` of every
+`.json` — true while the only JSON upstream served was a tsconfig, false the moment a manifest had
+to be read. Narrowed to exempt `package.json` while keeping the JSON.parse guard that catches an
+HTML error page served as 200, which is what the function exists for.
+
+### Two measurements on upstream's message
+
+**The pagination finding reproduces, and is worse than reported.** They cited 154 tags with 30
+visible; measured here:
+
+| instrument                   | tags    |
+| ---------------------------- | ------- |
+| `gh api .../tags` (page 1)   | **30**  |
+| `gh api --paginate .../tags` | **160** |
+| `git ls-remote --tags`       | **160** |
+
+An 81% false-negative rate, biased entirely toward _old_ tags — precisely the population a stale-pin
+audit examines.
+
+**So I audited my own published figure with the sound instrument.** This document claims a re-pin
+"across 34 tags". Against the full 159-tag semver list, tags in `(v0.86.0, v0.120.0]` number
+**exactly 34**. The figure survives; had it been derived from page 1 it would have been silently
+capped. Worth stating because the correct response to someone else's instrument defect is to check
+whether your own numbers came from the same well, not to note that theirs did.
+
+**Their announcement was stale on arrival, again.** It announced `v0.118.0`; `releases/latest`
+resolved to `v0.122.0` — four tags ahead, minutes later. Vendored at the resolved ref, not the
+quoted literal. Fifth instance recorded, and consistent with their own root cause: tag-triggered
+publishing plus manual tagging means any literal ages faster than the doc quoting it.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:

--- a/engineering-configs.lock.json
+++ b/engineering-configs.lock.json
@@ -1,7 +1,7 @@
 {
   "repository": "jrmoulckers/engineering",
-  "ref": "v0.120.0",
-  "fetchedAt": "2026-08-12T16:17:11.071Z",
+  "ref": "v0.122.0",
+  "fetchedAt": "2026-08-12T16:58:24.150Z",
   "refresh": "node scripts/vendor-configs.mjs <newer-ref>",
   "files": {
     "config/engineering/prettier/index.js": {
@@ -11,6 +11,10 @@
     "config/engineering/prettier/svelte.js": {
       "source": "packages/prettier-config/svelte.js",
       "sha256": "6901f8eb670b4ce68ecac86fd7da37ec7f81227ad55e99df13106f54d521332f"
+    },
+    "config/engineering/prettier/package.json": {
+      "source": "packages/prettier-config/package.json#type",
+      "sha256": "3ca9d4afd21425087cf31893b8f9f63c81b0b8408db5e343ca76e5f8aa26ab9a"
     },
     "config/engineering/citations/check-citations.mjs": {
       "source": "scripts/check-citations.mjs",

--- a/scripts/vendor-configs.mjs
+++ b/scripts/vendor-configs.mjs
@@ -31,7 +31,7 @@
 
 import { mkdir, writeFile, readFile } from 'node:fs/promises';
 import { createHash } from 'node:crypto';
-import { join, dirname } from 'node:path';
+import { join, dirname, basename } from 'node:path';
 
 const REPO = 'jrmoulckers/engineering';
 const LOCK = 'engineering-configs.lock.json';
@@ -53,6 +53,16 @@ const SETS = {
   prettier: {
     from: 'packages/prettier-config',
     files: ['index.js', 'svelte.js'],
+    // These files are ESM, and upstream says so via `"type": "module"` in the
+    // package it publishes. Vendoring copies the files and leaves that behind,
+    // so in a consumer whose root package.json has no `type` field they are
+    // nominally CommonJS and `export default` is a syntax error. Node >=22.7
+    // masks it by retrying a failed CJS parse as ESM, so it works while warning.
+    //
+    // Emitting the marker here rather than hand-maintaining it beside the files
+    // is what puts it under the lock: an unhashed marker is invisible to
+    // `--check`, which is the whole point of having a lock.
+    moduleType: 'module',
   },
   // Not a config — the ENG-* citation checker. It is vendored rather than copied
   // because upstream owns it and its header says it is "fetched over the network
@@ -265,13 +275,32 @@ async function missingModuleMarkers(files) {
 async function changedFilesAt(ref, lock) {
   const changed = [];
   for (const [dest, entry] of Object.entries(lock.files)) {
+    // A derived entry has no upstream file to fetch — its source key carries a
+    // `#fragment`. Fetching it verbatim would 404, and the caller reads a failed
+    // fetch as "no signal", so a single derived entry would silently disable
+    // staleness reporting for every other file in the lock.
+    const [sourcePath, derivedFrom] = entry.source.split('#');
     let text;
     try {
-      text = await fetchFile(ref, entry.source);
+      text = await fetchFile(ref, sourcePath);
     } catch {
       return null;
     }
     if (text === null || text === undefined) return null;
+    if (derivedFrom === 'type') {
+      // The marker mirrors one field of upstream's manifest, so it is stale
+      // exactly when that field changes — not when the manifest changes.
+      let declared;
+      try {
+        declared = JSON.parse(text).type;
+      } catch {
+        return null;
+      }
+      if (sha256(`${JSON.stringify({ type: declared }, null, 2)}\n`) !== entry.sha256) {
+        changed.push(dest);
+      }
+      continue;
+    }
     if (sha256(text) !== entry.sha256) changed.push(dest);
   }
   return changed;
@@ -305,7 +334,15 @@ function assertPayload(path, text) {
         'This is usually an HTML error page served with status 200.',
       );
     }
-    if (!parsed || typeof parsed !== 'object' || !parsed.compilerOptions) {
+    if (!parsed || typeof parsed !== 'object') {
+      fail(`${path} is not a JSON object`, 'It parsed, but it is not a configuration file.');
+    }
+    // A package manifest is fetched to read its declared module type, not to be
+    // vendored as a config. Requiring `compilerOptions` of every .json assumed
+    // the only JSON upstream serves is a tsconfig, which stopped being true the
+    // moment the module-type marker needed verifying. Parsing still guards the
+    // HTML-error-page case, which is what this function exists for.
+    if (basename(path) !== 'package.json' && !parsed.compilerOptions) {
       fail(
         `${path} has no "compilerOptions"`,
         'It parsed, but it is not a TypeScript configuration.',
@@ -316,15 +353,17 @@ function assertPayload(path, text) {
   }
 }
 
-async function fetchFile(ref, path) {
+async function fetchFile(ref, path, required = true) {
   const url = `https://raw.githubusercontent.com/${REPO}/${ref}/${path}`;
   let response;
   try {
     response = await fetch(url);
   } catch (cause) {
+    if (!required) return null;
     fail(`could not reach ${url}`, String(cause.message ?? cause));
   }
   if (!response.ok) {
+    if (!required) return null;
     fail(
       `${url} returned HTTP ${response.status}`,
       `Check that ref '${ref}' exists in ${REPO} and contains this path.`,
@@ -361,11 +400,49 @@ async function main() {
   // report success.
   const staged = [];
   for (const name of names) {
-    const { from, files } = SETS[name];
+    const { from, files, moduleType } = SETS[name];
     for (const file of files) {
       const path = `${from}/${file}`;
       const text = await fetchFile(ref, path);
       staged.push({ name, path, file, text, dest: join(dest, name, file) });
+    }
+    if (moduleType) {
+      // `moduleType` is a literal, and literals silently diverge from the thing
+      // they claim to mirror. Verify it against the ref rather than trusting it:
+      // a marker stating the WRONG type is worse than no marker at all, because
+      // an explicit type overrides Node's own CJS/ESM detection fallback and
+      // converts a runtime that would have coped into one that cannot.
+      const manifest = await fetchFile(ref, `${from}/package.json`, false);
+      if (manifest === null) {
+        process.stderr.write(
+          `\nwarning: could not read ${from}/package.json at ${ref}.\n` +
+            `Emitting "type": "${moduleType}" unverified.\n`,
+        );
+      } else {
+        let declared;
+        try {
+          declared = JSON.parse(manifest).type;
+        } catch {
+          declared = undefined;
+        }
+        if (declared !== moduleType) {
+          fail(
+            `${from} declares type '${declared ?? 'none'}' at ${ref}, but this script emits '${moduleType}'`,
+            'Upstream changed its module type. Update SETS to match before vendoring.',
+          );
+        }
+      }
+      staged.push({
+        name,
+        // Derived from upstream's package.json rather than copied from it, so it
+        // carries a distinct source key. Staged like any other file so the lock
+        // covers it — a marker outside the lock is the unhashed workaround this
+        // replaces, and `--check` would report it clean forever.
+        path: `${from}/package.json#type`,
+        file: 'package.json',
+        text: `${JSON.stringify({ type: moduleType }, null, 2)}\n`,
+        dest: join(dest, name, 'package.json'),
+      });
     }
   }
 


### PR DESCRIPTION
## Summary

Upstream fixed the `"type": "module"` vendoring gap and asked finance to drop its unhashed
workaround file. Porting it surfaced two defects, one of which would have silently disabled
staleness reporting for every vendored file.

## Ported, not converged

Upstream's script is now 1,023 lines to finance's 418, but it has **no `citations` set** and no
reference to `check-citations.mjs`. Converging wholesale would drop vendoring of the checker that
runs on every PR here, so the module-type behaviour was ported into the fork instead.

## The marker is now under the lock

`config/engineering/prettier/package.json` was hand-written, tracked, and **absent from the lock** —
so `--check` reported clean regardless of its contents. It is now generated and staged like any
other file:

```json
"source": "packages/prettier-config/package.json#type"
```

Mutation-tested both directions: editing it to `"commonjs"` fails `--check` with
`content differs from the lock` (exit 1); restoring returns exit 0. The file's *bytes* did not
change — what changed is that they are now generated and hashed.

## The defect I nearly shipped

`changedFilesAt()` fetches `entry.source` per lock entry and reads any failure as "no signal",
returning `null` for the whole set. A derived key with no fetchable file would have made staleness
return `null` for **all four files, permanently**, while printing a cheerful "unknown".

Introduced *by* the fix for an unhashed file, in the function whose own comment six lines above
warns that this path "swallows throws and reports no signal".

**My stated mechanism was wrong and measuring corrected it.** I claimed a 404:

| step | actual |
| --- | --- |
| `fetch(url + '#type')` | fragment **stripped** → HTTP **200**, real manifest |
| `path.endsWith('.json')` | **false** — path ends `#type`, JSON branch skipped |
| else-branch `/^export /m` | no `export ` → `fail('exports nothing')` → throw |
| caller | catches → `null` → "no signal" |

A 404 would show in any network log; a 200 rejected on a shape rule looks like an upstream content
problem. Fixed by splitting on `#` so the marker's staleness stays **live**, tracking upstream's
declared `type`.

## A guard that outlived its assumption

`assertPayload` required `compilerOptions` of every `.json` — true while the only JSON upstream
served was a tsconfig. Narrowed to exempt `package.json`, keeping the JSON.parse guard that catches
an HTML error page served as 200.

## Pagination, and auditing my own figure

| instrument | tags |
| --- | --- |
| `gh api .../tags` (page 1) | **30** |
| `gh api --paginate` | **160** |
| `git ls-remote --tags` | **160** |

81% false-negative, biased toward *old* tags. So I re-audited this repo's own published "34 tags"
figure with the sound instrument: tags in `(v0.86.0, v0.120.0]` number **exactly 34**. It survives.
The right response to someone else's instrument defect is to check whether your own numbers came
from the same well.

Upstream announced `v0.118.0`; `releases/latest` resolved to `v0.122.0`. Vendored at the resolved
ref.

## Testing

- [x] `npm run eng:vendor:check` — 4 files match at `v0.122.0`, exit 0
- [x] marker mutation → exit 1; restore → exit 0
- [x] `npm run eng:citations` 141/40/806/44, exit 0
- [x] `node tools/check-workflow-security.mjs` exit 0
- [x] `npx eslint scripts/vendor-configs.mjs --max-warnings 0` exit 0
- [x] `npx prettier --check` clean

Refs #4029
