### PR TITLE
fix(tools): pin the exemption conjunct no test could vary (#4222)

### DIFF
--- a/tools/check-ai-manifest.js
+++ b/tools/check-ai-manifest.js
@@ -473,11 +473,8 @@ function validateSyncLock() {
   // to reproduce is a finding, so it leaves through the verdict rather than through stdout.
   // The old line labelled every unreproduced entry "(#4190)" unconditionally, which would
   // have attributed the next, unrelated failure to an issue that had nothing to do with it.
-  for (const entry of source.knownUnreproduced) {
-    process.stdout.write(
-      `  [source] not reproducible from delivered bytes: ${entry} ` +
-        `(${KNOWN_UNREPRODUCED[entry].issue}, known and pinned)\n`,
-    );
+  for (const line of sourceDisclosureLines(source.knownUnreproduced)) {
+    process.stdout.write(`${line}\n`);
   }
   return findings;
 }
@@ -804,6 +801,39 @@ const KNOWN_UNREPRODUCED = {
   },
 };
 
+// Both hashes, as an exported decision rather than an inline conjunction.
+//
+// The digest half was unpinnable where it stood. `digest` is derived from the delivered bytes
+// of `vendor/@jrm/tokens/css/default/tokens.css` -- the one file in this repo that must not be
+// modified or regenerated -- so every test able to reach this comparison could only vary the
+// OTHER half, the recorded hash. Two tests do exactly that, and one of them is *named* for
+// pinning both. Dropping `known.reproduces === digest` left the suite 37/37 green (#4222).
+//
+// A conjunction whose second conjunct no test can vary is a conjunction in name only. Taking
+// the decision out of the loop makes it answerable from arguments instead of from bytes, so
+// all four quadrants become reachable without touching the file the exemption is about.
+//
+// What the dropped half actually protects: `recorded` alone pins the exemption to a corrupt
+// RECORD, while `reproduces` pins it to the corrupt BYTES. Without the second, the exemption
+// absorbs any future corruption of this path whose record happens to still read 343e10b1 --
+// which is precisely the "second corruption is not inherited" promise made at KNOWN_UNREPRODUCED.
+function exemptionMatches(entry, recordedSource, digest) {
+  const known = KNOWN_UNREPRODUCED[entry];
+  if (!known) return false;
+  return known.recorded === recordedSource && known.reproduces === digest;
+}
+
+// The disclosure the prose promises: one line per path, never a count. Returned rather than
+// written so the promise is assertable -- as a loop inside main() it was reachable by no test,
+// and emptying it left the suite green (#4222). A count cannot grow unnoticed into a set.
+function sourceDisclosureLines(knownUnreproduced) {
+  return knownUnreproduced.map(
+    (entry) =>
+      `  [source] not reproducible from delivered bytes: ${entry} ` +
+      `(${KNOWN_UNREPRODUCED[entry].issue}, known and pinned)`,
+  );
+}
+
 function verifySourceReproduction(lock) {
   const findings = [];
   const unreproduced = [];
@@ -843,8 +873,7 @@ function verifySourceReproduction(lock) {
       reproducedEntries.add(entry);
       continue;
     }
-    const known = KNOWN_UNREPRODUCED[entry];
-    if (known && known.recorded === metadata.sourceSha256 && known.reproduces === digest) {
+    if (exemptionMatches(entry, metadata.sourceSha256, digest)) {
       knownUnreproduced.push(entry);
       continue;
     }
@@ -1079,4 +1108,6 @@ module.exports = {
   commentFamily,
   verifySourceReproduction,
   KNOWN_UNREPRODUCED,
+  exemptionMatches,
+  sourceDisclosureLines,
 };

--- a/tools/check-ai-manifest.test.mjs
+++ b/tools/check-ai-manifest.test.mjs
@@ -27,6 +27,8 @@ const {
   commentFamily,
   verifySourceReproduction,
   KNOWN_UNREPRODUCED,
+  exemptionMatches,
+  sourceDisclosureLines,
   DOC_FILES,
   scanDoc,
   scanDocs,
@@ -433,6 +435,67 @@ test('the exemption self-liquidates: it is a finding once the entry reproduces a
     result.findings.some((f) => f.includes('stale reproduction exemption')),
     `a tolerance outliving its defect must announce itself, got ${JSON.stringify(result.findings)}`,
   );
+});
+
+// --- #4222: the conjunct no test could vary -----------------------------------------------
+//
+// `exemptionMatches` is a conjunction over two hashes. Both existing tests above vary only the
+// RECORDED half, because the digest half is computed from the delivered bytes of the one file
+// this repo must not modify. So the mutant that deleted `known.reproduces === digest` left the
+// suite 37/37 green -- under a test named "pinned to both hashes". The guard that went unpinned
+// was the guard on the file I am forbidden to touch, and the inaccessibility is the reason.
+//
+// Answering the decision from arguments makes all four quadrants reachable without the bytes.
+
+test('the exemption matches on both hashes, exercised in all four quadrants', () => {
+  const known = KNOWN_UNREPRODUCED[KNOWN_ENTRY];
+  const other = 'b'.repeat(64);
+  assert.notEqual(known.recorded, other, 'PREMISE: the wrong value must really differ');
+  assert.notEqual(known.reproduces, other, 'PREMISE: the wrong value must really differ');
+
+  assert.equal(
+    exemptionMatches(KNOWN_ENTRY, known.recorded, known.reproduces),
+    true,
+    'the exact pinned state must be absorbed',
+  );
+  // The quadrant no in-place test could reach: the record still reads as the pinned corruption
+  // while the BYTES have become something else. That is a second, different corruption of this
+  // path -- exactly what KNOWN_UNREPRODUCED promises not to inherit.
+  assert.equal(
+    exemptionMatches(KNOWN_ENTRY, known.recorded, other),
+    false,
+    'a second corruption of the same path must not inherit the exemption',
+  );
+  assert.equal(
+    exemptionMatches(KNOWN_ENTRY, other, known.reproduces),
+    false,
+    'a record the exemption does not name must not be absorbed',
+  );
+  assert.equal(exemptionMatches(KNOWN_ENTRY, other, other), false);
+});
+
+test('the exemption is pinned to a path, and generalises to none', () => {
+  const known = KNOWN_UNREPRODUCED[KNOWN_ENTRY];
+  assert.equal(
+    exemptionMatches('vendor/@jrm/tokens/js/index.js', known.recorded, known.reproduces),
+    false,
+    'an unnamed path must not borrow the pinned hashes',
+  );
+});
+
+test('the disclosure names every path and never collapses to a count', () => {
+  // The prose at KNOWN_UNREPRODUCED promises "listing each path means the set cannot grow
+  // unnoticed, which is the property a bare count lacks". As a loop inside main() that promise
+  // was unreachable by any test, and emptying it left the suite green (#4222).
+  const lines = sourceDisclosureLines(Object.keys(KNOWN_UNREPRODUCED));
+  assert.equal(lines.length, Object.keys(KNOWN_UNREPRODUCED).length, 'one line per exemption');
+  for (const entry of Object.keys(KNOWN_UNREPRODUCED)) {
+    assert.ok(
+      lines.some((l) => l.includes(entry) && l.includes(KNOWN_UNREPRODUCED[entry].issue)),
+      `every exemption must be disclosed by path and issue; ${entry} was not`,
+    );
+  }
+  assert.deepEqual(sourceDisclosureLines([]), [], 'no exemptions discloses nothing, not a zero');
 });
 
 test('an entry stating no source hash is named rather than silently skipped', () => {


### PR DESCRIPTION
## Summary

`KNOWN_UNREPRODUCED` tolerates exactly one lock entry — `vendor/@jrm/tokens/css/default/tokens.css` (#4190) — and its comment promises two properties. Both were unguarded, and each dies to a one-line mutant that left the suite **37/37 green**.

> both hashes are pinned, so **a second corruption of the same file does not inherit the exemption**

> **listing each path** means the set cannot grow unnoticed, which is the property a bare count lacks

## The conjunct no test could vary

```js
if (known && known.recorded === metadata.sourceSha256 && known.reproduces === digest) {
```

Delete `&& known.reproduces === digest` → **0 failures**.

The test that should have caught it is `the exemption is pinned to both hashes, so a second corruption is not inherited`. **It is named for the conjunction and exercises one conjunct.** So does its neighbour. Both vary `sourceSha256`, the *recorded* half.

Neither had a choice. `digest` is computed from the delivered bytes of `vendor/@jrm/tokens/css/default/tokens.css`, and that file **must not be modified or regenerated**. Every test able to reach the comparison in place could only vary the other operand — so the guard that went unpinned was the guard on the one file this repo is forbidden to touch, and the inaccessibility is exactly why.

The half that was droppable is the load-bearing one: `recorded` pins the exemption to a corrupt *record*; `reproduces` pins it to the corrupt *bytes*. Without the second, the exemption absorbs **any** future corruption of that path whose record still reads `343e10b1…`, and reports it as "known and pinned" — the precise scenario the comment promises cannot happen.

## The disclosure that could collapse to nothing

The per-path disclosure was a loop inside `main()`, reachable by no test. Emptying it left the suite green.

## Changes

Two pure, exported judgement seams — the decisions become answerable from **arguments** instead of from bytes:

- `exemptionMatches(entry, recordedSource, digest)` — all four quadrants reachable without touching the file the exemption is about.
- `sourceDisclosureLines(knownUnreproduced)` — returned rather than written, so the promise is assertable.

No behaviour change. `--strict` output is byte-identical, including the `[source] not reproducible from delivered bytes: … (#4190, known and pinned)` line.

## Mutation testing

Each mutant applied at a verified **unique** source index; each kill confirmed by failing test **name**.

| Mutant | Before | After |
| --- | --- | --- |
| drop the `reproduces` conjunct | **SURVIVED — 0 fail** | 1 FAIL — *the exemption matches on both hashes, exercised in all four quadrants* |
| drop the `recorded` conjunct | 1 FAIL | 2 FAIL |
| disclosure collapses to nothing | **SURVIVED — 0 fail** | 1 FAIL — *the disclosure names every path and never collapses to a count* |
| exemption ignores the path | — | 2 FAIL |
| disclosure drops the issue id | — | 1 FAIL |

## Testing

- `node --test tools/check-ai-manifest.test.mjs` — **40 pass / 0 fail** (37 → 40).
- `node tools/check-ai-manifest.js --strict` — exit 0, output byte-identical to `main`.
- `npx prettier --check` on both touched files — clean.
- `npx eslint … --max-warnings 0` — exit 0.

**Environment note, not a repo defect:** eslint initially failed with `Cannot find package 'globals'`. `globals@^17.11.0` is a declared devDependency simply absent from local `node_modules`. Installed with `--no-save`; `package.json` and `package-lock.json` are untouched (verified with `git status`). Worth flagging in case CI images drift the same way.

## Provenance

Found by running the class from jrmoulckers/.github#728 → PR #730 against this repo: *an unguarded behaviour that a load-bearing instruction depends on, killable by a one-line mutant leaving the full suite green.* Their instance was `sameBaseline` in `copier.mjs`. This one adds a cause theirs did not have: the operand was untestable **by construction**, because it derives from a file under a do-not-modify constraint.

## Scope

`tools/` only. No workflow change, no lock edit, no change to `packages/design-tokens`, and no change to `vendor/@jrm/tokens` — the constraint that produced the blind spot is respected by the fix rather than worked around.

Closes #4222
Refs jrmoulckers/.github#728