### PR TITLE
ci(workflows): check that workflow Node pins agree with .nvmrc

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -122,6 +122,9 @@ jobs:
       - name: Validate financial-terminology glossary
         run: node scripts/i18n/validate-glossary.js
 
+      - name: Workflow Node pins agree with .nvmrc
+        run: npm run node:version:check
+
   pr-title:
     name: Semantic PR Title
     needs: changes

--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -6066,6 +6066,108 @@ it.
 under `npm ci`, it is correct for the paths where the lock is not authoritative, and aligning with
 upstream is worth more than defending a form whose practical difference here is near zero.
 
+## The runtime nothing reads
+
+A sibling session reported running Node 24 against CI's Node 20 all session, with no `.nvmrc` to
+consult — only `engines: { node: ">=20" }`, which its runtime satisfies. Its corollary is the
+finding: **a repo with no runtime pin cannot be mismatched, and that is not the same as being
+matched.** A constraint you can violate is worth more than one you cannot state.
+
+finance was cited there as the repo where the pin existed and made the diagnosis a one-step
+comparison. Measuring that claim rather than accepting the compliment:
+
+|                                        | finance                           | sibling |
+| -------------------------------------- | --------------------------------- | ------- |
+| `.nvmrc`                               | `22`                              | absent  |
+| `engines.node`                         | `>=22.0.0`                        | `>=20`  |
+| workflow `node-version:` literals      | **36**, all `22`, across 20 files | —       |
+| workflows reading `node-version-file:` | **0**                             | —       |
+| local runtime                          | Node 24                           | Node 24 |
+
+The pin exists and CI agrees with it — and **nothing connects the two**. There are 36 independent
+restatements of the major and one `.nvmrc`, and they agree by maintenance rather than by
+construction. Editing `.nvmrc` to `24` leaves all 36 literals at `22`, produces no diff to any of
+them, and turns nothing red.
+
+So the inversion runs the other way from the compliment. The sibling's runtime divergence is
+**unrepresentable** — there is no pin to disagree with. finance's is **representable and
+unchecked** — there are two pins and no comparison. Both arrive at "nothing verifies the runtime";
+one has no artifact to check, the other has one nobody reads. `engines.node` closes neither, because
+`>=22.0.0` is satisfied by Node 24 and so cannot express the runtime CI uses.
+
+### Exposure is not exhibition
+
+The sibling checked its lockfile for the specific construct behind the npm-major trap recorded
+earlier in this guide, and found none — clean by a property of its dependency graph rather than by
+any control. The same measurement here:
+
+|                                       | finance | sibling |
+| ------------------------------------- | ------- | ------- |
+| lockfile entries                      | 838     | 140     |
+| `optional: true` **and** `peer: true` | **1**   | 0       |
+
+The one is `node_modules/git-raw-commits/node_modules/conventional-commits-parser` — the exact
+entry npm 11 prunes and npm 10 keeps. finance is not exposed-but-clean; it is **exhibiting**, which
+is why the trap cost real CI runs here and cannot fire there today. Neither repo has a control; only
+one has a dependency graph that makes the absence visible.
+
+### The control, and what it may not do
+
+`tools/check-node-version-consistency.mjs` makes the disagreement expressible.
+
+**Fatal** — a workflow literal whose major differs from `.nvmrc`. Only a local edit creates this,
+so failing on it can never redden a build that nobody here changed.
+
+**Notice, exit 0** — an `engines.node` range that admits majors above `.nvmrc`, and a running
+runtime whose major differs from it. Both are true of this repo right now, and neither is a defect:
+the range is deliberate and the developer runtime is not CI's to dictate. This is the same split
+`--check` applies to drift versus staleness, under the same discriminator — _can something outside
+this tree turn it red?_ — and the same asymmetry: **under-decide, never over-report.** A literal
+whose major cannot be read (`lts/*`) is left undecided rather than flagged, for the same reason.
+
+The second notice reproduces, as a standing check, the observation that cost four CI runs: it says
+`this runtime is Node 24 but .nvmrc declares 22` on every local run.
+
+### A negative row that passed for the wrong reason
+
+The sibling's other finding was that a control row protects against a predicate that over-matches
+and never against one that under-matches. Both classes appeared while building this, in the same
+hour.
+
+Mutation testing the new checker killed four of five mutants. The survivor deleted the guard
+exempting `node-version-file` pins — and the test named _"never flags a node-version-file pin"_ kept
+passing, because its input was `.nvmrc`, whose leading character is not a digit, so the
+unparsed-literal guard caught it instead. **Two guards, one input, and the test could not say which
+one it was exercising** — the _duplicated_ relation from the coverage table, now in a suite written
+by someone who had already written that table down.
+
+The fix was not to delete a guard but to construct the separating input: `node-version-file:
+20/.nvmrc`, a path whose first character parses as a major. It does not occur in this tree and does
+not need to — the standard settled earlier is **constructible and reachable, not naturally
+occurring**. With that row the mutant dies and both guards are independently observable.
+
+### Four zeros, four instruments
+
+Every zero this turn was a property of the instrument before it was a property of the repo:
+
+| reported                                | actual       | defect in the instrument                                       |
+| --------------------------------------- | ------------ | -------------------------------------------------------------- |
+| 3 of 4 checker predicates match nothing | 3 of 4 match | `^`-anchored patterns tested against a joined blob without `m` |
+| 0 of 239 action refs are 40-hex         | 236 of 239   | PowerShell consumed the `$` anchor inside a double-quoted `-e` |
+| 3 unpinned action refs                  | 0            | unanchored `uses:` matched commented-out examples              |
+| 5 of 5 mutants survived                 | 1 of 5       | scorer grepped `# fail` where the runner prints `ℹ fail`       |
+
+Two under-reported and two over-reported, and **the third is the one that would have been published**
+— an unpinned-action finding is exactly the shape a reviewer accepts without re-deriving. It was
+caught only because the real checker disagreed, and the real checker was right: it anchors
+`^\s*(?:-\s*)?uses:`, so a line beginning `#` cannot reach the key. The ad-hoc probe written to audit
+it was weaker than the thing being audited.
+
+The fourth is the sharpest. A mutation scorer whose failure mode is "everything survived" reports
+the suite as worthless, which is the direction that gets a suite rewritten rather than trusted. It
+was caught by calibrating on the unmutated tree first — the baseline row that costs one run and
+turns a scorer into a measured instrument.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:

--- a/package.json
+++ b/package.json
@@ -56,7 +56,9 @@
     "powersync:logs": "node tools/powersync-local.mjs logs",
     "prepare": "husky",
     "changeset": "changeset",
-    "version": "changeset version"
+    "version": "changeset version",
+    "node:version:check": "node tools/check-node-version-consistency.mjs",
+    "node:version:test": "node --test tools/check-node-version-consistency.test.mjs"
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx,mjs}": [

--- a/tools/check-node-version-consistency.mjs
+++ b/tools/check-node-version-consistency.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+/**
+ * Usage: npm run node:version:check
+ *
+ * Fails when a workflow pins a Node major that disagrees with `.nvmrc`.
+ *
+ * `.nvmrc` is the repository's declared runtime, but no workflow reads it --
+ * every `setup-node` step restates the major as a literal. The literals and
+ * `.nvmrc` therefore agree by maintenance rather than by construction, and a
+ * change to one leaves the others silently behind. This check makes that
+ * disagreement expressible, which is the precondition for noticing it.
+ *
+ * Fatal findings are limited to disagreements a local edit causes. Conditions
+ * an outside change can create -- an `engines` range that admits majors above
+ * `.nvmrc`, or a developer runtime ahead of it -- are reported as notices and
+ * do not fail the check.
+ */
+
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const workflowDirectory = join(repositoryRoot, '.github', 'workflows');
+
+/** Reads the major version declared by `.nvmrc` text, or null when absent. */
+export function parseNvmrc(text) {
+  const match = String(text ?? '')
+    .trim()
+    .match(/^v?(\d+)/);
+  return match ? match[1] : null;
+}
+
+/**
+ * Collects Node runtime pins from workflow text.
+ *
+ * The `^\s*` anchor keeps commented-out examples out of the result: a line
+ * whose first non-space character is `#` cannot reach the key.
+ */
+export function findNodeVersionPins(text) {
+  const pins = [];
+  const lines = String(text ?? '').split(/\r?\n/);
+  for (const [index, line] of lines.entries()) {
+    const literal = line.match(/^\s*(?:-\s*)?node-version:\s*['"]?([^\s'"#]+)/);
+    if (literal) {
+      pins.push({ kind: 'literal', value: literal[1], line: index + 1 });
+      continue;
+    }
+    const fromFile = line.match(/^\s*(?:-\s*)?node-version-file:\s*['"]?([^\s'"#]+)/);
+    if (fromFile) {
+      pins.push({ kind: 'file', value: fromFile[1], line: index + 1 });
+    }
+  }
+  return pins;
+}
+
+/** Extracts the major from a `setup-node` version literal such as `22.11.0`. */
+export function pinMajor(value) {
+  const match = String(value ?? '').match(/^v?(\d+)/);
+  return match ? match[1] : null;
+}
+
+/**
+ * Reports literals whose major disagrees with `.nvmrc`.
+ *
+ * A `node-version-file` pin is single-sourced and never reported. A literal
+ * whose major cannot be read (`lts/*`, an expression) is left undecided rather
+ * than reported, so an unparsed form stays silent instead of failing a tree the
+ * check cannot judge.
+ */
+export function findNodeVersionMismatches(file, text, expectedMajor) {
+  if (!expectedMajor) return [];
+  const violations = [];
+  for (const pin of findNodeVersionPins(text)) {
+    if (pin.kind !== 'literal') continue;
+    const major = pinMajor(pin.value);
+    if (major === null) continue;
+    if (major !== expectedMajor) {
+      violations.push(
+        `${file}:${pin.line} pins Node ${pin.value} but .nvmrc declares ${expectedMajor}`,
+      );
+    }
+  }
+  return violations;
+}
+
+/**
+ * True when an `engines.node` range admits a major above the declared one.
+ *
+ * A range such as `>=22.0.0` is satisfied by Node 24, so it cannot express the
+ * runtime CI actually uses. Reported as a notice: the range is deliberate, and
+ * failing on it would punish a correct tree.
+ */
+export function enginesAdmitsAbove(range, expectedMajor) {
+  if (!range || !expectedMajor) return false;
+  const lowerBoundOnly = /^\s*>=?\s*v?\d+/.test(range);
+  const hasUpperBound = /<\s*v?\d+/.test(range);
+  return lowerBoundOnly && !hasUpperBound;
+}
+
+function main() {
+  const expectedMajor = parseNvmrc(readFileSync(join(repositoryRoot, '.nvmrc'), 'utf8'));
+  if (!expectedMajor) {
+    console.error('Could not read a Node major from .nvmrc.');
+    process.exitCode = 2;
+    return;
+  }
+
+  const files = readdirSync(workflowDirectory).filter((name) => /\.ya?ml$/.test(name));
+  const violations = [];
+  let literalCount = 0;
+  let fileCount = 0;
+
+  for (const file of files) {
+    const text = readFileSync(join(workflowDirectory, file), 'utf8');
+    for (const pin of findNodeVersionPins(text)) {
+      if (pin.kind === 'literal') literalCount += 1;
+      else fileCount += 1;
+    }
+    violations.push(...findNodeVersionMismatches(file, text, expectedMajor));
+  }
+
+  const notices = [];
+  const engines = JSON.parse(readFileSync(join(repositoryRoot, 'package.json'), 'utf8')).engines;
+  if (enginesAdmitsAbove(engines?.node, expectedMajor)) {
+    notices.push(
+      `package.json engines.node is "${engines.node}", which admits majors above ${expectedMajor}; it cannot express the runtime CI uses.`,
+    );
+  }
+  const runningMajor = process.versions.node.split('.')[0];
+  if (runningMajor !== expectedMajor) {
+    notices.push(
+      `this runtime is Node ${runningMajor} but .nvmrc declares ${expectedMajor}; local results may not describe CI.`,
+    );
+  }
+
+  if (violations.length > 0) {
+    console.error('Node runtime pins disagree with .nvmrc:\n');
+    for (const violation of violations) console.error(`  - ${violation}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(
+    `Node runtime pins agree with .nvmrc (${expectedMajor}): ${literalCount} literal, ${fileCount} via node-version-file, across ${files.length} workflow file(s).`,
+  );
+  for (const notice of notices) console.log(`Notice: ${notice}`);
+}
+
+if (resolve(process.argv[1] ?? '') === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/tools/check-node-version-consistency.test.mjs
+++ b/tools/check-node-version-consistency.test.mjs
@@ -1,0 +1,108 @@
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+  enginesAdmitsAbove,
+  findNodeVersionMismatches,
+  findNodeVersionPins,
+  parseNvmrc,
+  pinMajor,
+} from './check-node-version-consistency.mjs';
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const workflowDirectory = join(repositoryRoot, '.github', 'workflows');
+
+test('parseNvmrc reads a bare major and a v-prefixed one', () => {
+  assert.equal(parseNvmrc('22\n'), '22');
+  assert.equal(parseNvmrc('v20'), '20');
+  assert.equal(parseNvmrc(''), null);
+});
+
+test('pinMajor reads the major from a full version', () => {
+  assert.equal(pinMajor('22.11.0'), '22');
+  assert.equal(pinMajor('lts/*'), null);
+});
+
+test('findNodeVersionPins ignores a commented-out example', () => {
+  const pins = findNodeVersionPins(
+    ['      # node-version: 18', '      node-version: 22'].join('\n'),
+  );
+  assert.equal(pins.length, 1);
+  assert.equal(pins[0].value, '22');
+});
+
+test('findNodeVersionPins separates a literal from a node-version-file pin', () => {
+  const pins = findNodeVersionPins(
+    ['      node-version: 22', '      node-version-file: .nvmrc'].join('\n'),
+  );
+  assert.deepEqual(
+    pins.map((pin) => pin.kind),
+    ['literal', 'file'],
+  );
+});
+
+test('findNodeVersionMismatches flags a literal that disagrees with .nvmrc', () => {
+  const violations = findNodeVersionMismatches('ci.yml', '      node-version: 20', '22');
+  assert.equal(violations.length, 1);
+  assert.match(violations[0], /ci\.yml:1 pins Node 20 but \.nvmrc declares 22/);
+});
+
+test('findNodeVersionMismatches accepts a literal that agrees', () => {
+  assert.deepEqual(findNodeVersionMismatches('ci.yml', '      node-version: 22.11.0', '22'), []);
+});
+
+test('findNodeVersionMismatches never flags a node-version-file pin', () => {
+  assert.deepEqual(
+    findNodeVersionMismatches('ci.yml', '      node-version-file: .nvmrc', '22'),
+    [],
+  );
+});
+
+test('a node-version-file pin is exempt by kind, not by an unparsable path', () => {
+  // `.nvmrc` exercises the kind guard and the unparsed-literal guard at once,
+  // so it cannot tell them apart: deleting either leaves it passing. A path
+  // whose first character is a digit parses as a major and separates them.
+  assert.deepEqual(
+    findNodeVersionMismatches('ci.yml', '      node-version-file: 20/.nvmrc', '22'),
+    [],
+  );
+});
+
+test('findNodeVersionMismatches leaves an unparsed literal undecided', () => {
+  assert.deepEqual(findNodeVersionMismatches('ci.yml', '      node-version: lts/*', '22'), []);
+});
+
+test('enginesAdmitsAbove separates an open lower bound from a closed range', () => {
+  assert.equal(enginesAdmitsAbove('>=22.0.0', '22'), true);
+  assert.equal(enginesAdmitsAbove('>=22.0.0 <23.0.0', '22'), false);
+  assert.equal(enginesAdmitsAbove(undefined, '22'), false);
+});
+
+test('the pin predicate matches real workflow content, not just fixtures', () => {
+  const literals = readdirSync(workflowDirectory)
+    .filter((name) => /\.ya?ml$/.test(name))
+    .flatMap((name) => findNodeVersionPins(readFileSync(join(workflowDirectory, name), 'utf8')))
+    .filter((pin) => pin.kind === 'literal');
+  assert.ok(
+    literals.length > 0,
+    'a predicate that matches nothing in the tree would pass every other row here',
+  );
+});
+
+test('the real workflow tree agrees with .nvmrc, and a mutated copy does not', () => {
+  const expected = parseNvmrc(readFileSync(join(repositoryRoot, '.nvmrc'), 'utf8'));
+  const files = readdirSync(workflowDirectory).filter((name) => /\.ya?ml$/.test(name));
+  const violations = files.flatMap((name) =>
+    findNodeVersionMismatches(name, readFileSync(join(workflowDirectory, name), 'utf8'), expected),
+  );
+  assert.deepEqual(violations, []);
+
+  const mutated = files
+    .map((name) => readFileSync(join(workflowDirectory, name), 'utf8'))
+    .find((text) => findNodeVersionPins(text).some((pin) => pin.kind === 'literal'))
+    .replace(/node-version:\s*['"]?\d+/, 'node-version: 18');
+  assert.ok(findNodeVersionMismatches('mutated.yml', mutated, expected).length > 0);
+});


### PR DESCRIPTION
## Summary

finance declares its Node runtime in `.nvmrc` (`22`) and restates it as **36 literal
`node-version:` pins across 20 workflow files**. **Zero** workflows use `node-version-file:`. The
two pins agree today by maintenance, not by construction — editing `.nvmrc` leaves all 36 literals
behind with no diff and nothing red.

This adds a check that makes that disagreement expressible.

## Changes

- `tools/check-node-version-consistency.mjs` — fatal on a workflow literal whose major differs from
  `.nvmrc`; warn-only (exit 0) on an `engines.node` range that admits higher majors and on a
  developer runtime ahead of the pin. Unparsable literals (`lts/*`) are left undecided rather than
  flagged.
- `tools/check-node-version-consistency.test.mjs` — 12 tests; all 5 mutants killed.
- `npm run node:version:check` / `node:version:test`, wired into `ci-lint.yml`.
- Guide section recording the measurement.

## Why the fatal/notice split

Same discriminator as `--check`'s drift-versus-staleness split: *can something outside this tree
turn it red?* A literal only changes by local edit, so it is fatal. An `engines` range and a
developer runtime are deliberate and not CI's to dictate, so they speak without failing.

Both notices are true of this repo now:

```
Node runtime pins agree with .nvmrc (22): 36 literal, 0 via node-version-file, across 31 workflow file(s).
Notice: package.json engines.node is ">=22.0.0", which admits majors above 22.
Notice: this runtime is Node 24 but .nvmrc declares 22; local results may not describe CI.
```

The second reproduces, as a standing check, the observation behind the npm-major lockfile trap
(#4216) — finance has **1 of 838** lockfile entries with `optional: true` **and** `peer: true`, the
construct npm 11 prunes and npm 10 keeps.

## Issues

Refs #4029, Refs #4216

## Testing

- [x] `npm run node:version:test` — 12/12
- [x] mutation: 5/5 killed (scorer calibrated on the unmutated tree first)
- [x] `npm run workflow:security:check` + `:test` — 21/21
- [x] `npm run eng:vendor:check` — 4 files at `v0.122.0`
- [x] `npm run eng:citations` — 141/40/806/44, exit 0
- [x] `npx prettier --check` on changed files, `npx eslint --max-warnings 0` on new tools