### PR TITLE
fix(tools): cite engine source by symbol, not by decaying coordinate (#4226)

### DIFF
--- a/tools/check-ai-manifest.js
+++ b/tools/check-ai-manifest.js
@@ -479,7 +479,66 @@ function validateSyncLock() {
   return findings;
 }
 
-// The engine hashes LF-normalized text (`hashText`, lock.mjs:57). Naming it here rather
+// --- Cross-repo citations ---------------------------------------------------------------
+//
+// This file makes claims about jrmoulckers/.github's engine. Every such claim used to carry a
+// line number, and a line number in another repository decays with every PR merged there --
+// silently, because nothing on this side can notice. Measured at backbone `79faef3a`:
+//
+//   `hashText`          cited at line 57, actually at line 68     11 lines stale
+//   `canonicalizeInner` cited at line 165, actually at line 181   17 lines stale
+//   `planFile`, the `apply` drift branch, `inject`, `isUnstampedCanon`   still accurate
+//
+// Those rows are measurements pinned to a commit, not citations: their truth is fixed at
+// `79faef3a` forever, which is exactly why they may state offsets when live citations may not.
+//
+// In both stale cases the CLAIM was true and only the COORDINATE had rotted, which is the
+// property worth designing around: the durable half is the symbol, the fragile half is the
+// offset. So citations name symbols, and the registry records the commit each was verified
+// against. A reader can re-verify any row with one read-only call:
+//
+//   gh api repos/jrmoulckers/.github/contents/sync/lib/<file> --jq .content | base64 -d
+//
+// The guard is deliberately narrower than the claim. Whether the engine still behaves as
+// described cannot be checked from here -- that needs the network at check time, which is
+// owner-gated (#4141). What IS checkable offline is that no citation reverts to a bare
+// coordinate and that every registered row names a symbol and a verification commit. Pinning
+// what is reachable beats asserting what is not (#4222).
+const CANON_CITATIONS = [
+  { file: 'sync/lib/lock.mjs', symbol: 'hashText', verifiedAt: '79faef3a' },
+  { file: 'sync/lib/basemerge.mjs', symbol: 'canonicalizeInner', verifiedAt: '79faef3a' },
+  { file: 'sync/lib/copier.mjs', symbol: 'planFile', verifiedAt: '79faef3a' },
+  { file: 'sync/lib/copier.mjs', symbol: 'apply', verifiedAt: '79faef3a' },
+  { file: 'sync/lib/copier.mjs', symbol: 'isUnstampedCanon', verifiedAt: '79faef3a' },
+  { file: 'sync/lib/provenance.mjs', symbol: 'inject', verifiedAt: '79faef3a' },
+];
+
+// A bare `<file>.mjs:<line>` reference to engine source. Scoped to .mjs because this repo's own
+// files are .js/.ts and self-references are stable -- they move with the edit that moves them.
+const BARE_COORDINATE = /\b[a-z][a-z0-9-]*\.mjs:\d+/g;
+
+// Pure so the rule is assertable over arbitrary text rather than only over the file that
+// happens to be on disk.
+function citationFindings(text, citations = CANON_CITATIONS) {
+  const findings = [];
+  for (const match of text.match(BARE_COORDINATE) || []) {
+    findings.push(
+      `cites engine source by line number, which decays unnoticed: ${match} — ` +
+        `name the symbol and register it in CANON_CITATIONS instead`,
+    );
+  }
+  if (!citations.length) {
+    findings.push('no canon citations registered — the registry is not observing');
+  }
+  for (const row of citations) {
+    if (!row.file || !row.symbol || !row.verifiedAt) {
+      findings.push(`citation row is incomplete: ${JSON.stringify(row)}`);
+    }
+  }
+  return findings;
+}
+
+// The engine hashes LF-normalized text (`hashText` in `lock.mjs`). Naming it here rather
 // than spelling `.replace(/\r\n/g, '\n')` at each call site keeps one word for one rule:
 // three inline spellings is what made this normalization impossible to cite accurately,
 // and impossible to notice was untested (#4201).
@@ -504,7 +563,7 @@ function managedRegion(text) {
 // single rule verifies one group and reports false drift on the other:
 //   marker-managed -> sha256 of the region body, TRAILING whitespace stripped, markers excluded
 //   whole-file     -> sha256 of the whole file, LF-normalized, not stripped
-// The engine is `toLF(inner).replace(/\s+$/, '')` (basemerge.mjs:165, canonicalizeInner).
+// The engine is `toLF(inner).replace(/\s+$/, '')` (`canonicalizeInner` in `basemerge.mjs`).
 // `.trim()` is the natural external guess and is wrong: it strips the leading end too, so the
 // two rules agree on every region body that does not begin with whitespace and diverge on
 // every one that does. This repo's 68 present lock entries contain no instance of that input
@@ -528,7 +587,7 @@ function managedDigest(text) {
 // already run (the lock's generatedAt is that run's output); these paths are absent because
 // the frozen copies were deliberately deleted in #4066/#4076 so the next run repopulates
 // them. Absence is the one state the engine's local-modification guard does not block --
-// copier.mjs:248 plans `add` unconditionally for a missing path -- so the tolerance
+// `planFile` in `copier.mjs` plans `add` unconditionally for a missing path -- so the tolerance
 // self-discharges on the next successful run. Deriving it from the path rather than pinning
 // a count is what makes that automatic, and any other missing managed target -- a deleted
 // skill, prompt, instruction, or root doc -- is reported rather than silently skipped.
@@ -542,7 +601,8 @@ const PENDING_SYNC = /(^|\/)vendor\/@jrm\/tokens\//;
 
 // The inverse of verifyManagedContent: that asks "entry present, is the file there?", this
 // asks "file present, is it recorded?". A lock-iterating check cannot reach a canon target
-// that never became an entry, and the engine can produce one -- copier.mjs:94 leaves the lock
+// that never became an entry, and the engine can produce one -- the `drift` branch of `apply`
+// in `copier.mjs` leaves the lock
 // untouched on drift, so a member file that already differed from canon at first sync is
 // never recorded and is thereafter invisible to every check either side runs.
 //
@@ -696,7 +756,7 @@ const PROVENANCE_STAMP_LINE =
 
 // The engine injects its stamp with a shape chosen by the target's comment syntax, so the
 // inverse is a switch on file extension rather than a guess. Documented upstream in
-// `sync/README.md` and implemented at `provenance.mjs:57-73`:
+// `sync/README.md` and implemented by `inject` in `provenance.mjs`:
 //
 //   hash   `# note\n`     + content -> strip 1   .toml .yml .sh .gitattributes
 //   block  `/* note */\n` + content -> strip 1   .css .js .ts .kt .swift
@@ -777,7 +837,8 @@ function unstampSource(entryPath, text) {
 // keeps a future exclusion from reappearing as a quietly smaller number.
 //
 // For `vendor/@jrm/tokens/css/default/tokens.css` specifically, the engine documents the
-// cause at `copier.mjs:494-499`: an overlapping run reverted that entry to the hash and
+// cause in the `isUnstampedCanon` docblock of `copier.mjs`: an overlapping run reverted that
+// entry to the hash and
 // timestamp of an older revision and the lock was later hand-repaired, so `targetSha256`
 // was corrected to match the bytes while `sourceSha256` and `syncedAt` stayed stale. That
 // makes it an internally inconsistent entry, not a stamping question -- the strip rule is
@@ -1108,6 +1169,9 @@ module.exports = {
   commentFamily,
   verifySourceReproduction,
   KNOWN_UNREPRODUCED,
+  CANON_CITATIONS,
+  citationFindings,
+  BARE_COORDINATE,
   exemptionMatches,
   sourceDisclosureLines,
 };

--- a/tools/check-ai-manifest.test.mjs
+++ b/tools/check-ai-manifest.test.mjs
@@ -27,6 +27,8 @@ const {
   commentFamily,
   verifySourceReproduction,
   KNOWN_UNREPRODUCED,
+  CANON_CITATIONS,
+  citationFindings,
   exemptionMatches,
   sourceDisclosureLines,
   DOC_FILES,
@@ -496,6 +498,68 @@ test('the disclosure names every path and never collapses to a count', () => {
     );
   }
   assert.deepEqual(sourceDisclosureLines([]), [], 'no exemptions discloses nothing, not a zero');
+});
+
+// --- #4226: citations that decay in another repository ------------------------------------
+//
+// Six claims about the engine were pinned by line number. Two had rotted by 11 and 17 lines,
+// and nothing here could notice: the file that moved is in a repository this check never reads.
+// The claims were still TRUE -- only the coordinates were wrong -- so the durable half is the
+// symbol and the fragile half is the offset.
+//
+// The guard is narrower than the claim on purpose. Whether the engine still behaves as
+// described needs the network at check time (#4141, owner-gated). What is checkable offline is
+// that no citation reverts to a coordinate and that every registered row is complete.
+
+test('this file cites engine symbols, never engine line numbers', () => {
+  const source = fs.readFileSync(path.join(ROOT, 'tools', 'check-ai-manifest.js'), 'utf8');
+  assert.deepEqual(
+    citationFindings(source),
+    [],
+    'a line number in another repo decays silently; cite the symbol instead',
+  );
+});
+
+test('the coordinate rule catches a citation, including in its own historical record', () => {
+  // PREMISE: the pattern must actually fire, or the test above passes vacuously over a rule
+  // that matches nothing -- the failure mode this whole exchange keeps producing.
+  const findings = citationFindings('see lock.mjs:57 for the hashing rule');
+  assert.equal(findings.length, 1, 'the rule must fire on a bare coordinate');
+  assert.ok(findings[0].includes('lock.mjs:57'), 'the finding must name the offending citation');
+  // And the SHA-pinned form the registry uses must NOT fire, because a measurement fixed at a
+  // commit does not decay. This is the distinction the fix rests on, so it is asserted.
+  assert.deepEqual(
+    citationFindings('at 79faef3a, `hashText` sits at line 68'),
+    [],
+    'a measurement pinned to a commit is not a decaying citation',
+  );
+});
+
+test('the citation registry is complete and non-empty', () => {
+  assert.deepEqual(citationFindings('', CANON_CITATIONS), [], 'every row needs file, symbol, sha');
+  assert.ok(CANON_CITATIONS.length > 0, 'PREMISE: rows exist to be checked');
+  const empty = citationFindings('', []);
+  assert.ok(
+    empty.some((f) => f.includes('not observing')),
+    'an empty registry must be a finding, not a clean result',
+  );
+  const incomplete = citationFindings('', [{ file: 'sync/lib/lock.mjs', symbol: 'hashText' }]);
+  assert.ok(
+    incomplete.some((f) => f.includes('incomplete')),
+    'a row without a verification commit must be reported',
+  );
+});
+
+test('every registered citation names a symbol this file actually mentions', () => {
+  // Otherwise the registry drifts the other way: rows outliving the comments that motivated
+  // them, which is the stale-exemption shape (#4190) pointed at documentation.
+  const source = fs.readFileSync(path.join(ROOT, 'tools', 'check-ai-manifest.js'), 'utf8');
+  for (const row of CANON_CITATIONS) {
+    assert.ok(
+      source.includes(`\`${row.symbol}\``),
+      `CANON_CITATIONS names ${row.symbol}, but no comment in this file cites it`,
+    );
+  }
 });
 
 test('an entry stating no source hash is named rather than silently skipped', () => {


### PR DESCRIPTION
## Summary

Six comments in `tools/check-ai-manifest.js` explained themselves by pointing at `jrmoulckers/.github`'s sync engine **by line number**. A line number in another repository decays with every PR merged there, and nothing here can notice — this repo never reads that one.

## Measured, not assumed

Read-only against backbone `main @ 79faef3a`:

| cited symbol | cited | actual | drift |
| --- | --- | --- | --- |
| `hashText` (`lock.mjs`) | 57 | 68 | **11 stale** |
| `canonicalizeInner` (`basemerge.mjs`) | 165 | 181 | **17 stale** |
| `planFile` (`copier.mjs`) | 248 | 248 | accurate |
| `apply` drift branch (`copier.mjs`) | 94 | 94 | accurate |
| `inject` (`provenance.mjs`) | 57-73 | 57-73 | accurate |
| `isUnstampedCanon` docblock (`copier.mjs`) | 494-499 | 494-499 | accurate |

**In both stale cases the claim was true and only the pointer had rotted.** The durable half of a cross-repo citation is the symbol; the fragile half is the offset.

My first `grep` pattern found five of six and missed `basemerge.mjs`; a broader `Select-String -AllMatches` caught it. When the population *is* the finding, enumerate broadly.

## Changes

- All six citations rewritten to name symbols.
- `CANON_CITATIONS` — 6 rows of `{file, symbol, verifiedAt}`, so the verification commit is recorded rather than implied.
- `citationFindings(text, citations)` — pure, exported; flags bare `<name>.mjs:<line>`, an empty registry, and incomplete rows.
- Four tests.

## Deliberately narrower than the claim

Whether the engine *still behaves* as described needs a network read at check time — that is #4141 and owner-gated. This ships the offline half. Pinning what is reachable beats asserting what is not (#4222).

## Self-disclosure

The historical drift rows are stated in-file as measurements **pinned to `79faef3a`**, not as citations: their truth is fixed at that commit forever, which is why they may state offsets when live citations may not. That distinction is asserted by a test rather than left to the reader — otherwise it reads as an exemption carved for my own text.

While editing I wrote `planFile` into a comment as a **guess before measuring it**. It happened to be right; shipping it unverified would have been exactly the defect being fixed. Caught and measured before commit.

## Issues

Closes #4226

## Testing

- [x] `node --test tools/check-ai-manifest.test.mjs` — **44 pass, 0 fail** (was 40)
- [x] Mutants, each applied at a verified unique source index, each killed by failing test **name**:
  - `BARE_COORDINATE` never matches → `the coordinate rule catches a citation, including in its own historical record`
  - empty-registry guard disabled → `the citation registry is complete and non-empty`
  - incomplete-row guard disabled → same
  - unmentioned symbol added to registry → `every registered citation names a symbol this file actually mentions`
  - source restored byte-identical after every run
- [x] `npx eslint … --max-warnings 0` — exit 0
- [x] `npx prettier --check` — clean
- [x] `node tools/check-ai-manifest.js --strict` — exit 0, output unchanged