### PR TITLE
chore(config): vendor the prettier declarations and fail on a narrowing --set

### DIFF
--- a/config/engineering/prettier/index.d.ts
+++ b/config/engineering/prettier/index.d.ts
@@ -1,0 +1,11 @@
+import type { Config } from 'prettier';
+
+/**
+ * Base Prettier configuration.
+ *
+ * Typed as Prettier's own `Config` rather than a hand-written shape, so the
+ * declaration cannot drift from what Prettier actually accepts.
+ */
+export declare const config: Config;
+
+export default config;

--- a/config/engineering/prettier/svelte.d.ts
+++ b/config/engineering/prettier/svelte.d.ts
@@ -1,0 +1,9 @@
+import type { Config } from 'prettier';
+
+/**
+ * Svelte variant. Adds `prettier-plugin-svelte` and routes `.svelte` files to
+ * its parser. Requires `prettier-plugin-svelte` in the consumer.
+ */
+export declare const svelteConfig: Config;
+
+export default svelteConfig;

--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -6168,6 +6168,136 @@ the suite as worthless, which is the direction that gets a suite rewritten rathe
 was caught by calibrating on the unmutated tree first — the baseline row that costs one run and
 turns a scorer into a measured instrument.
 
+## The set was the divergence, not the tag
+
+Upstream reported this repo pinned at `v0.15.7`, roughly 124 releases behind, and asked for a jump
+to `v0.122.0`. Resolved rather than accepted:
+
+|                                      |                                             |
+| ------------------------------------ | ------------------------------------------- |
+| lock ref before this change          | **`v0.122.0`**                              |
+| upstream's stated latest             | `v0.122.0`                                  |
+| actual latest at the time of writing | **`v0.124.0`**, then `v0.125.0` mid-session |
+
+The pin was already current — the correction was itself about 107 releases stale, which is the
+eighth instance of the pattern upstream has been correcting in its own outbound messages. Resolving
+rather than quoting is now cheap enough that there is no excuse for either side.
+
+But the other half of the report was right, and for a reason neither of us had named. Upstream's
+prettier set is:
+
+```
+files: ['index.js', 'index.d.ts', 'svelte.js', 'svelte.d.ts']
+```
+
+This fork's was `['index.js', 'svelte.js']`. **A subset.** Refreshing the tag would never have found
+it, and neither would `--check`, because the lock is generated from the same set it verifies: it
+compares the files it was told about against the files it wrote. **A lock cannot detect a file it
+was never told about** — the identical shape as the unhashed module marker recorded earlier in this
+guide, one level up. There the file existed and was unhashed; here the file never arrived.
+
+So the fix was set membership, not ref distance. Re-vendoring at `v0.124.0` reported
+`2 file(s) changed content` — and both were the two new declarations. Nothing already vendored moved
+between `v0.122.0` and `v0.124.0`, and the staleness notice now reports all six byte-identical at
+`v0.125.0`. Upstream's own point, confirmed against it: **ref distance is not artifact distance.**
+
+### The declarations are inert here, and vendored anyway
+
+Upstream's stated trigger is `TS7016` when importing the config from TypeScript with `allowJs: false`.
+finance consumes it through Prettier's `prettier` key in `package.json`, resolved at runtime — no
+TypeScript import exists, so the failure cannot occur and the declarations buy nothing today.
+
+They are vendored regardless, because the argument for carrying them is not the type error. Carrying
+a subset made `--check` compare a different payload than upstream publishes, in a way that is silent
+in both directions: upstream cannot see which files a consumer chose, and the consumer's lock reports
+green over the subset it defined for itself.
+
+## A partial `--set` silently un-hashed five files
+
+Found by making the mistake. This fork's flag parser takes `--set a,b`; invoking it as
+`--set prettier --set citations` is not an error — the second occurrence overwrites the first. The
+result:
+
+```
+Vendored 1 file(s) from jrmoulckers/engineering@v0.124.0
+lock entries: 4 -> 1
+```
+
+Five files stayed on disk and left the lock. `--check` would then have passed, truthfully, over a
+tree it no longer covered. **Dropping a lock entry is indistinguishable from never having had one**,
+which is what made it silent — the same property that makes an unhashed file invisible.
+
+Now fatal unless `--prune` is passed deliberately:
+
+| invocation                             | before              | after                            |
+| -------------------------------------- | ------------------- | -------------------------------- |
+| `--set citations` with prettier locked | lock silently 6 → 1 | **exits 1**, lock untouched at 6 |
+| `--set citations --prune`              | —                   | exits 0, lock 1, opted in        |
+| `--set prettier,citations`             | lock 6              | lock 6, `--check` green          |
+
+Reported rather than repaired: carrying the omitted entries forward would put two refs in one lock,
+and a lock that cannot name a single ref cannot answer the question `--check` asks.
+
+## Porting the orphan check, and a hypothesis that did not survive
+
+Upstream shipped a fatal check for vendored trees nothing references, extending the framing recorded
+here: _a green `--check` means your tree matches the lock, not that your pin is current_ — and, per
+jrm-recipes, **not that anything still reads it.**
+
+Before porting it, the obvious objection: their walk scans `.json` files, and the lock records every
+vendored destination path by construction, so the lock would satisfy the check by existing. Measured
+against their source at `v0.124.0` instead of assumed:
+
+```js
+// The lock records itself as a reference otherwise, which is circular.
+return hits.filter((path) => path !== LOCK).sort();
+```
+
+**Refuted.** They exclude the lock by name and the script by content-or-path, closing both
+self-reference routes. The hypothesis was worth checking and worth recording as wrong, because the
+version of this note that shipped without checking would have been a confident false claim about
+someone else's code.
+
+Ported and measured in both directions, with the dest recovered as the common directory prefix of
+the lock keys (this fork's lock predates upstream's recorded `dest`):
+
+| input                               | result                                                                                            |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `config/engineering`                | **3** external references — `eslint.config.mjs`, `package.json`, `scripts/eng-citations-gate.mjs` |
+| self (`scripts/vendor-configs.mjs`) | excluded                                                                                          |
+| lock                                | excluded                                                                                          |
+| a dest nothing references           | **0** → gate fails                                                                                |
+
+The negative row is the one that matters: without a needle that returns zero, the check would be a
+predicate that can never fire, which is the class recorded two sections above.
+
+**Known limitation, in the safe direction.** The check counts a _mention_, not a _use_ — one of the
+three hits is `eslint.config.mjs`, where `config/engineering/**` appears as an ignore rule rather
+than a consumer. So it over-reports wiring and therefore under-reports orphanhood: it will miss some
+dead trees and can never falsely condemn a live one. That is the correct direction for something
+wired into a gate.
+
+### Three false readings, all self-inflicted by the probe
+
+Measuring the new check produced, in order: `self excluded? NO`, `lock excluded? yes`, and
+`unreferenced dest => 1 (vacuous)`. Two of those were wrong, and both for the same reason — **the
+probe was inside the tree it was measuring**:
+
+- it imported a _copy_ of the script, so `import.meta.url` named the copy and the real script no
+  longer matched `selfText` by content;
+- it contained the string it was searching for, so the "nothing references this" case found the
+  probe itself.
+
+Rewritten to append exports to the real file (restored afterwards) and to live under `node_modules/`,
+which the walk skips, with the negative needle assembled at runtime so no file contains it literally.
+Both readings inverted.
+
+This is the fourth measurement instrument in two sessions to report a property of itself as a
+property of the repository. The pattern is specific enough to state as a rule: **an instrument that
+lives inside its own search space measures itself first.** Upstream had already reached the same
+conclusion from the other side, which is why their check excludes its own script by content rather
+than by path — a renamed copy would otherwise vouch for the tree.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:

--- a/engineering-configs.lock.json
+++ b/engineering-configs.lock.json
@@ -1,16 +1,24 @@
 {
   "repository": "jrmoulckers/engineering",
-  "ref": "v0.122.0",
-  "fetchedAt": "2026-08-12T16:58:24.150Z",
+  "ref": "v0.124.0",
+  "fetchedAt": "2026-08-12T17:49:23.152Z",
   "refresh": "node scripts/vendor-configs.mjs <newer-ref>",
   "files": {
     "config/engineering/prettier/index.js": {
       "source": "packages/prettier-config/index.js",
       "sha256": "0cda065a2e3d88526f8e8b986145b14e823f8c987238f1435b850b82329d181b"
     },
+    "config/engineering/prettier/index.d.ts": {
+      "source": "packages/prettier-config/index.d.ts",
+      "sha256": "5ed5a00e2e493e9be4c1d233d157d127419bfb4f8813f8bf1e05209e7223de85"
+    },
     "config/engineering/prettier/svelte.js": {
       "source": "packages/prettier-config/svelte.js",
       "sha256": "6901f8eb670b4ce68ecac86fd7da37ec7f81227ad55e99df13106f54d521332f"
+    },
+    "config/engineering/prettier/svelte.d.ts": {
+      "source": "packages/prettier-config/svelte.d.ts",
+      "sha256": "66b85b7572f5c81c594583851ddde8d365bfe70bec11d3ac2ccf8a892172406f"
     },
     "config/engineering/prettier/package.json": {
       "source": "packages/prettier-config/package.json#type",

--- a/scripts/vendor-configs.mjs
+++ b/scripts/vendor-configs.mjs
@@ -29,9 +29,10 @@
  * else. Provenance lives in the lock file instead.
  */
 
-import { mkdir, writeFile, readFile } from 'node:fs/promises';
+import { mkdir, writeFile, readFile, access, readdir } from 'node:fs/promises';
 import { createHash } from 'node:crypto';
-import { join, dirname, basename } from 'node:path';
+import { join, dirname, basename, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const REPO = 'jrmoulckers/engineering';
 const LOCK = 'engineering-configs.lock.json';
@@ -52,7 +53,13 @@ const SETS = {
   },
   prettier: {
     from: 'packages/prettier-config',
-    files: ['index.js', 'svelte.js'],
+    // The declarations ship beside the modules they describe. finance imports
+    // this config through Prettier's `prettier` key in package.json rather than
+    // from TypeScript, so TS7016 cannot occur here and the declarations buy
+    // nothing today. They are vendored anyway because the set is upstream's to
+    // define: carrying a subset made `--check` compare a different payload than
+    // upstream publishes, and that divergence is silent in both directions.
+    files: ['index.js', 'index.d.ts', 'svelte.js', 'svelte.d.ts'],
     // These files are ESM, and upstream says so via `"type": "module"` in the
     // package it publishes. Vendoring copies the files and leaves that behind,
     // so in a consumer whose root package.json has no `type` field they are
@@ -93,6 +100,16 @@ function fail(message, hint) {
   throw new VendorError(message, hint);
 }
 
+/** True when a path is readable. Used to tell a dropped lock entry from a deleted file. */
+async function exists(path) {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function parseArgs(argv) {
   const positional = [];
   const flags = {};
@@ -105,10 +122,12 @@ function parseArgs(argv) {
       i += 1;
     } else if (arg === '--check') {
       flags.check = true;
+    } else if (arg === '--prune') {
+      flags.prune = true;
     } else if (arg.startsWith('--')) {
       fail(
         `unknown option ${arg}`,
-        'Usage: vendor-configs.mjs <ref> [--dest <dir>] [--set a,b] | vendor-configs.mjs --check',
+        'Usage: vendor-configs.mjs <ref> [--dest <dir>] [--set a,b] [--prune] | vendor-configs.mjs --check',
       );
     } else {
       positional.push(arg);
@@ -146,6 +165,74 @@ async function latestRef() {
  * build pressures the next person into bumping the ref without deciding to
  * accept the change, which is the property pinning exists to protect.
  */
+/** Longest shared directory prefix of a set of lock keys, without a trailing slash. */
+function commonDirPrefix(paths) {
+  if (paths.length === 0) return '';
+  const split = paths.map((path) => path.split('/').slice(0, -1));
+  const shared = [];
+  for (let i = 0; i < split[0].length; i += 1) {
+    const segment = split[0][i];
+    if (!split.every((parts) => parts[i] === segment)) break;
+    shared.push(segment);
+  }
+  return shared.join('/');
+}
+
+/**
+ * Files outside the vendored tree that mention it.
+ *
+ * A green `--check` means the tree matches the lock — not that the pin is
+ * current, and not that anything still reads it. Ported from upstream, which
+ * shipped it after jrm-recipes extended the framing. Both self-reference paths
+ * are excluded, because either one would let the check vouch for the tree it is
+ * auditing: this script carries the default dest as a literal, and the lock
+ * records every dest path by construction.
+ */
+async function wiringReferences(dest) {
+  const needle = String(dest).replace(/\\/g, '/').replace(/^\.\//, '').replace(/\/+$/, '');
+  if (needle === '' || needle === '.') return [];
+
+  const selfPath = resolve(fileURLToPath(import.meta.url));
+  const selfText = await readFile(selfPath, 'utf8').catch(() => null);
+
+  const SKIP = new Set([
+    'node_modules',
+    '.git',
+    'dist',
+    'build',
+    'coverage',
+    '.next',
+    '.turbo',
+    'out',
+  ]);
+  const EXT = /\.(json|jsonc|js|mjs|cjs|ts|mts|cts|ya?ml|toml)$/i;
+  const MAX_BYTES = 512 * 1024;
+  const hits = [];
+
+  async function walk(dir, depth) {
+    if (depth > 6) return;
+    const items = await readdir(dir, { withFileTypes: true }).catch(() => []);
+    for (const item of items) {
+      const path = dir === '.' ? item.name : `${dir}/${item.name}`;
+      if (item.isDirectory()) {
+        if (SKIP.has(item.name)) continue;
+        // The vendored tree references itself; only outside references count.
+        if (path === needle) continue;
+        await walk(path, depth + 1);
+      } else if (item.isFile() && EXT.test(item.name)) {
+        const text = await readFile(path, 'utf8').catch(() => null);
+        if (text === null) continue;
+        const isSelf = selfText === null ? resolve(path) === selfPath : text === selfText;
+        if (isSelf) continue;
+        if (text.length <= MAX_BYTES && text.includes(needle)) hits.push(path);
+      }
+    }
+  }
+
+  await walk('.', 0);
+  return hits.filter((path) => path !== LOCK).sort();
+}
+
 async function check() {
   let lock;
   try {
@@ -188,6 +275,20 @@ async function check() {
       `${unloadable.length} vendored ESM file(s) lack a "type": "module" marker:\n  ${unloadable.join('\n  ')}`,
       'Add a package.json containing {"type":"module"} beside each. Without it, ' +
         'Node below 22.7 cannot import the file, and no other gate detects this.',
+    );
+  }
+
+  // Upstream records `dest` in the lock; this fork's lock predates that, so the
+  // dest is recovered as the common directory prefix of every locked key. That
+  // is exact for a single-dest lock and degrades to a shorter prefix rather than
+  // a wrong one if a second dest is ever added.
+  const destPrefix = commonDirPrefix(entries.map(([dest]) => dest));
+  const wired = await wiringReferences(destPrefix);
+  if (wired.length === 0) {
+    fail(
+      `nothing outside ${destPrefix}/ references it.`,
+      'A green --check would keep saying the tree matches a lock nothing reads. ' +
+        'Restore the reference, or drop the set with --prune and delete the files.',
     );
   }
 
@@ -469,6 +570,28 @@ async function main() {
     previous = JSON.parse(await readFile(LOCK, 'utf8'));
   } catch {
     // No previous lock: this is a first vendor.
+  }
+
+  // A partial `--set` rewrites the whole lock, so any previously locked file
+  // outside the chosen sets drops out of it while staying on disk. `--check`
+  // then passes over a tree it no longer covers, which is the unhashed-file
+  // hazard the lock exists to remove — and it happens silently, because
+  // dropping an entry looks identical to never having had one.
+  //
+  // Reported rather than repaired: carrying the old entries forward would put
+  // two refs in one lock, and a lock that cannot name a single ref cannot
+  // answer the question `--check` asks.
+  const droppedFromLock = [];
+  for (const key of Object.keys(previous?.files ?? {})) {
+    if (lock.files[key]) continue;
+    if (await exists(key)) droppedFromLock.push(key);
+  }
+  if (droppedFromLock.length > 0 && !flags.prune) {
+    fail(
+      `vendoring only [${names.join(', ')}] would drop ${droppedFromLock.length} locked file(s) that are still on disk:\n` +
+        droppedFromLock.map((key) => `  - ${key}`).join('\n'),
+      'Re-run with every set the lock covers, or pass --prune to drop them deliberately (and delete the files).',
+    );
   }
 
   await writeFile(LOCK, `${JSON.stringify(lock, null, 2)}\n`, 'utf8');


### PR DESCRIPTION
## Summary

Upstream reported this repo pinned at `v0.15.7`, ~124 releases behind. Resolved: the lock was
already at **`v0.122.0`** — the correction was itself ~107 releases stale. But the other half was
right, for a reason neither side had named.

**This fork's prettier set was a subset of upstream's.**

```
upstream: ['index.js', 'index.d.ts', 'svelte.js', 'svelte.d.ts']
here:     ['index.js',               'svelte.js']
```

No ref refresh could have found that, and neither could `--check`: the lock is generated from the
same set it verifies, so **it cannot detect a file it was never told about** — the same shape as the
unhashed module marker, one level up. The fix is set membership, not ref distance. Re-vendoring at
`v0.124.0` reported `2 file(s) changed content`, and both were the new declarations; nothing already
vendored moved.

The declarations are **inert here** — finance consumes the config through Prettier's `prettier` key
at runtime, never from TypeScript, so `TS7016` cannot occur. Vendored anyway for set parity, since a
subset makes `--check` compare a different payload than upstream publishes.

## A partial `--set` silently un-hashed five files

Found by making the mistake. `--set prettier --set citations` is not an error — the parser takes
`a,b`, so the second occurrence overwrote the first and the lock went 4 → 1 while five files stayed
on disk. `--check` would then pass, truthfully, over a tree it no longer covered.

| invocation | before | after |
| --- | --- | --- |
| `--set citations` with prettier locked | lock silently 6 → 1 | **exits 1**, lock untouched |
| `--set citations --prune` | — | exits 0, opted in |
| `--set prettier,citations` | lock 6 | lock 6, `--check` green |

## Ported upstream's orphan check

A green `--check` means the tree matches the lock — not that the pin is current, and not that
anything still reads it.

| input | result |
| --- | --- |
| `config/engineering` | **3** references — `eslint.config.mjs`, `package.json`, `scripts/eng-citations-gate.mjs` |
| self / lock | both excluded |
| a dest nothing references | **0** → gate fails |

Counts a mention, not a use, so it over-reports wiring and under-reports orphanhood — the safe
direction for a gate.

## Issues

Refs #4029

## Testing

- [x] `npm run eng:vendor:check` — 6 files at `v0.124.0`
- [x] narrowing guard verified in all 3 directions above
- [x] orphan check verified in both directions (positive and a zero-hit needle)
- [x] `npm run eng:citations` — exit 0
- [x] `npm run workflow:security:test` 21/21, `npm run node:version:test` 12/12
- [x] `npx eslint --max-warnings 0` + `npx prettier --check` on changed files