### PR TITLE
fix(tools): make --help reachable and its counts derived (#4230)

### DIFF
--- a/tools/ai-manifest.js
+++ b/tools/ai-manifest.js
@@ -35,7 +35,12 @@ const path = require('path');
 const ROOT = path.resolve(__dirname, '..');
 const args = process.argv.slice(2);
 
-if (args.includes('--help') || args.includes('-h')) {
+// `require.main === module` is load-bearing, not decoration. This block calls process.exit at
+// module scope, so without the guard `require('./ai-manifest.js')` terminates the REQUIRING
+// process whenever `--help` is anywhere in argv -- which is why `check-ai-manifest.js --help`
+// printed this generator's help and never its own. The same idiom already guards run() below;
+// it was applied to the main block and not to the earlier exit.
+if (require.main === module && (args.includes('--help') || args.includes('-h'))) {
   process.stdout.write(`
 AI Manifest Generator — Finance monorepo
 

--- a/tools/check-ai-manifest.js
+++ b/tools/check-ai-manifest.js
@@ -82,8 +82,11 @@ const MANAGED_COUNTS = {
   total: 81,
 };
 
-if (args.includes('--help') || args.includes('-h')) {
-  process.stdout.write(`
+// The tool's own advertisement of what it checks. Both counts are interpolated rather than
+// transcribed, because a hand-written number here decays exactly when the surface it describes
+// changes -- and this file is not in DOC_FILES, so the count arm it advertises never read it.
+// Correctness by construction; the test then pins that the construction is still a derivation.
+const HELP_TEXT = `
 AI Manifest Drift Check — Finance monorepo
 
 Usage:
@@ -91,34 +94,53 @@ Usage:
   node tools/check-ai-manifest.js --strict   # blocking (exit 1 on drift)
   STRICT=1 node tools/check-ai-manifest.js   # blocking (exit 1 on drift)
 
-Validates filesystem counts, the exact 23-agent activated roster, generated
+Validates filesystem counts, the exact ${EXPECTED_AGENTS.length}-agent activated roster, generated
 provenance, the sole local finance-domain agent, retired-role absence, canonical
-runtime documentation, and the 81-entry Studio sync inventory.
-`);
+runtime documentation, and the ${MANAGED_COUNTS.total}-entry Studio sync inventory.
+`;
+
+if (args.includes('--help') || args.includes('-h')) {
+  process.stdout.write(HELP_TEXT);
   process.exit(0);
 }
 
 const DOC_FILES = ['docs/ai/README.md', 'docs/INDEX.md', 'AGENTS.md'];
+// `<n>-agent roster` is a count claim and reads as one, but `\s` does not match the hyphen, so
+// the compound-adjective form matched no METRIC and was certified unread -- the same evasion
+// #4212 documented for `twenty-three agents`, in the form a copy editor produces by accident
+// rather than on purpose. The separator admits either spelling.
+//
+// It is `\s+|-`, NOT `[-\s]`. The bare class drops the `+` that the original `\s+` carried and
+// silently stops matching a claim separated by more than one space -- which is what a re-wrapped
+// logical line produces. That spelling passed all 47 tests and removed a real claim from the
+// report; the corpus claim count is asserted below precisely because the suite did not notice.
+const COUNT_GAP = '(?:\\s+|-)';
 const METRICS = [
   {
     key: 'agents',
     label: 'agents',
-    regex: /(\d+)\s+(?:AI\s+|active\s+|custom\s+|copilot\s+|total\s+|defined\s+)*agents?\b/gi,
+    regex: new RegExp(
+      `(\\d+)${COUNT_GAP}(?:AI${COUNT_GAP}|active${COUNT_GAP}|custom${COUNT_GAP}|copilot${COUNT_GAP}|total${COUNT_GAP}|defined${COUNT_GAP})*agents?\\b`,
+      'gi',
+    ),
   },
   {
     key: 'skills',
     label: 'skills',
-    regex: /(\d+)\s+(?:reusable\s+|domain\s+|agent\s+|total\s+)*skills?\b/gi,
+    regex: new RegExp(
+      `(\\d+)${COUNT_GAP}(?:reusable${COUNT_GAP}|domain${COUNT_GAP}|agent${COUNT_GAP}|total${COUNT_GAP})*skills?\\b`,
+      'gi',
+    ),
   },
   {
     key: 'instructions',
     label: 'instructions',
-    regex: /(\d+)\s+(?:instruction\s+files?|instructions?)\b/gi,
+    regex: new RegExp(`(\\d+)${COUNT_GAP}(?:instruction${COUNT_GAP}files?|instructions?)\\b`, 'gi'),
   },
   {
     key: 'mcpServers',
     label: 'MCP servers',
-    regex: /(\d+)\s+MCP\s+servers?\b/gi,
+    regex: new RegExp(`(\\d+)${COUNT_GAP}MCP${COUNT_GAP}servers?\\b`, 'gi'),
   },
 ];
 
@@ -1170,6 +1192,9 @@ module.exports = {
   verifySourceReproduction,
   KNOWN_UNREPRODUCED,
   CANON_CITATIONS,
+  HELP_TEXT,
+  EXPECTED_AGENTS,
+  MANAGED_COUNTS,
   citationFindings,
   BARE_COORDINATE,
   exemptionMatches,

--- a/tools/check-ai-manifest.test.mjs
+++ b/tools/check-ai-manifest.test.mjs
@@ -12,6 +12,7 @@ import path from 'node:path';
 import crypto from 'node:crypto';
 import { fileURLToPath } from 'node:url';
 import { createRequire } from 'node:module';
+import { execFileSync } from 'node:child_process';
 
 const require = createRequire(import.meta.url);
 const {
@@ -28,6 +29,10 @@ const {
   verifySourceReproduction,
   KNOWN_UNREPRODUCED,
   CANON_CITATIONS,
+  METRICS,
+  HELP_TEXT,
+  EXPECTED_AGENTS,
+  MANAGED_COUNTS,
   citationFindings,
   exemptionMatches,
   sourceDisclosureLines,
@@ -37,6 +42,7 @@ const {
   countCoverageFindings,
 } = require('./check-ai-manifest.js');
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const TOOL = path.join(ROOT, 'tools', 'check-ai-manifest.js');
 
 const sha = (text) => crypto.createHash('sha256').update(text).digest('hex');
 const wrap = (body) => `<!-- studio:base:start -->\n${body}<!-- studio:base:end -->\n`;
@@ -560,6 +566,75 @@ test('every registered citation names a symbol this file actually mentions', () 
       `CANON_CITATIONS names ${row.symbol}, but no comment in this file cites it`,
     );
   }
+});
+
+// --- #4230: the tool's own advertisement was outside every arm it advertises ---------------
+
+// Mirrors scanDoc's normalization so these assertions test the METRIC rules rather than a
+// second, divergent copy of the matching logic.
+function metricHits(text) {
+  const normalized = text.replace(/[*`_]+/g, ' ');
+  const hits = [];
+  for (const metric of METRICS) {
+    metric.regex.lastIndex = 0;
+    let match;
+    while ((match = metric.regex.exec(normalized)) !== null) {
+      hits.push(`${metric.label}=${match[1]}`);
+    }
+  }
+  return hits;
+}
+//
+// `--help` claimed a "23-agent roster" and an "81-entry inventory" as hard-coded literals, in a
+// file absent from DOC_FILES, written in a compound-adjective form that matches no METRIC. Three
+// independent reasons the count arm could never read the sentence that advertises the count arm.
+
+test('the help text derives its counts instead of transcribing them', () => {
+  const claims = [...HELP_TEXT.matchAll(/(\d+)-(agent|entry)/g)];
+  assert.equal(claims.length, 2, 'PREMISE: both advertised counts are present to be checked');
+  const byNoun = Object.fromEntries(claims.map((c) => [c[2], Number(c[1])]));
+  assert.equal(byNoun.agent, EXPECTED_AGENTS.length, 'help agent count must track the roster');
+  assert.equal(byNoun.entry, MANAGED_COUNTS.total, 'help entry count must track the lock total');
+});
+
+test('a compound-adjective count claim is a claim, not an invisible one', () => {
+  // The evasion #4212 named for `twenty-three agents`, in the form a copy editor produces by
+  // accident. Both spellings must reach the same metric or the arm certifies text it never read.
+  const hyphen = metricHits('the exact 23-agent activated roster');
+  const spaced = metricHits('the exact 23 agents activated roster');
+  assert.deepEqual(hyphen, ['agents=23'], 'hyphenated form must be detected');
+  assert.deepEqual(spaced, ['agents=23'], 'spaced form must still be detected');
+});
+
+test('closing the hyphen gap widened matching only where a digit precedes the noun', () => {
+  // A separator class is blunt, so the cost is measured rather than assumed. `multi-agent` has
+  // no digit and stays prose; `2019-agent-era` newly matches and is the accepted false positive
+  // -- a spurious finding a human clears, which is the safe polarity for this arm. `v2 agents`
+  // matched under the old `\s+` rule too, so it is not evidence about this change either way.
+  assert.deepEqual(metricHits('multi-agent orchestration across the fleet'), []);
+  assert.deepEqual(metricHits('agents-of-change tooling'), []);
+  assert.deepEqual(metricHits('see the 2019-agent-era notes'), ['agents=2019']);
+});
+
+test('the corpus yields the claims it yielded before, not merely more than zero', () => {
+  // The existing observation guard asserts claimCount > 0. Changing COUNT_GAP from `\s+` to
+  // `[-\s]` dropped AGENTS.md's skills claim -- 4 became 3 -- and every one of 47 tests passed,
+  // because a guard armed against the empty corpus is blind at n=3. Pinning the cardinality is
+  // what makes a silently narrowed regex fail here instead of in the report nobody re-reads.
+  const counts = { agents: 23, skills: 20, instructions: 5, mcpServers: 0, prompts: 8 };
+  const total = DOC_FILES.reduce((sum, doc) => sum + scanDoc(doc, counts).findings.length, 0);
+  assert.equal(total, 4, 'the declared corpus carries four count claims');
+});
+
+test('--help reaches this tool, rather than exiting inside a require', () => {
+  // HELP_TEXT was unreachable: ai-manifest.js called process.exit(0) at module scope whenever
+  // --help appeared in argv, so requiring it killed the process at line 7 and the drift checker
+  // printed the GENERATOR's help. No count arm could read the sentence because no one could see
+  // it. Asserted by execution, since the defect was in reachability, not content.
+  const out = execFileSync(process.execPath, [TOOL, '--help'], { encoding: 'utf8' });
+  assert.match(out, /AI Manifest Drift Check/, 'must print this tool, not the generator');
+  assert.doesNotMatch(out, /AI Manifest Generator/, 'a required module must not answer --help');
+  assert.equal(out, HELP_TEXT, 'the printed help is the constant the derivation test pins');
 });
 
 test('an entry stating no source hash is named rather than silently skipped', () => {


### PR DESCRIPTION
## Summary

`node tools/check-ai-manifest.js --help` printed **a different tool's help**:

```
AI Manifest Generator — Finance monorepo
Usage:
  node tools/ai-manifest.js [options]
```

`check-ai-manifest.js:7` requires `./ai-manifest.js`, which calls `process.exit(0)` **at module scope** on `--help`, unguarded. Requiring it terminates the requiring process. Proved by execution:

```
probe.js --help  ->  "BEFORE require" | generator help | <exit 0>   AFTER never runs
probe.js         ->  "BEFORE require" | "AFTER require -- reached"
```

**This tool's own help had never been printed.**

## The guard already existed 200 lines below

`ai-manifest.js` uses `if (require.main === module)` for its main block. The idiom that prevents this defect was applied to the later exit and not the earlier one — a file demonstrating the correct pattern contained the bug the pattern prevents.

## The unreachable text was also wrong

It transcribed `23-agent` and `81-entry` as literals. **Four independent reasons the count arm could not read the sentence advertising the count arm:**

1. unreachable (above);
2. not derived from `EXPECTED_AGENTS.length` / `MANAGED_COUNTS.total`;
3. `tools/check-ai-manifest.js` is not in `DOC_FILES`;
4. `23-agent` matches **no METRIC** — the regex required `\s+`, and a hyphen is not whitespace.

(4) is the same evasion #4212 documents for `twenty-three agents`, in the form a copy editor produces by accident. That comment sits ~130 lines below a live instance of itself.

```
hyphenated count claims in scanned DOC_FILES : 0
hyphenated count claims in the tool itself   : 2
"23-agent activated roster" -> NO METRIC MATCHES
"23 agents"                 -> agents=23        (control)
```

## Changes

- `ai-manifest.js`: guard the help exit with `require.main === module`.
- `HELP_TEXT` extracted and exported; both counts interpolated.
- `COUNT_GAP = '(?:\s+|-)'` across all four METRICS.
- Exported `HELP_TEXT`, `METRICS`, `EXPECTED_AGENTS`, `MANAGED_COUNTS`.

**Deliberately not** adding this file to `DOC_FILES` — scanning its own source would turn every comment discussing a count into an asserted claim. Construction for its own text, detection for the corpus.

## A regression my own suite did not catch

My first spelling was `COUNT_GAP = '[-\s]'` — a character class, which **drops the `+`** that `\s+` carried. `AGENTS.md:156` (`20 skills`) silently vanished: **4 claims became 3, and all 47 tests passed.**

Caught by diffing `--strict` output, not by the suite. The existing observation guard asserts `claimCount > 0`, and **a guard armed against the empty corpus is blind at n=3**. Now pinned by cardinality, and that mutant is in the table below.

## Self-disclosure

- I wrote the help-derivation test **before** discovering the text was unreachable. It passed against a constant nothing printed — the vacuity class this work keeps finding, authored by me, caught only because I ran the binary instead of reading the constant. The replacement asserts by execution.
- Two probe errors, opposite polarities: `scanDoc(relPath, counts)` reads from **disk**, and I called it as `(name, text, counts)`. With an existing path it scanned the whole file with a string as `counts` and produced a **false finding** at line 218; with a fake path it returned `{missing:true}` and reported **`NONE`** for probes that should match — a false negative reading as clean, which would have retired this finding. Both caught by a control (`23 agents` must match) disagreeing.

## Issues

Closes #4230

## Testing

- [x] `node --test` — **49 pass, 0 fail** (was 44)
- [x] Six mutants, each at a verified unique source index, each killed by failing test **name**:
  - revert `require.main` guard → `--help reaches this tool, rather than exiting inside a require`
  - revert `COUNT_GAP` to `\s+` → 2 tests
  - **replay the `[-\s]` regression** → `the corpus yields the claims it yielded before, not merely more than zero`
  - help agent count transcribed → derivation test
  - help entry count transcribed → derivation test
  - help claim deleted → derivation test (premise guard)
  - source restored byte-identical after every run
- [x] `npx eslint … --max-warnings 0` — exit 0 (3 files)
- [x] `npx prettier --check` — clean
- [x] `node tools/check-ai-manifest.js --strict` — exit 0, **4** claims, output otherwise unchanged
- [x] `node tools/ai-manifest.js --help` and `--json` — unaffected, exit 0