### PR TITLE
ci(workflows): exercise the declared engines.node range instead of asserting it

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -450,3 +450,39 @@ jobs:
         if: always()
         working-directory: services/api
         run: docker compose down -v
+  # ---------------------------------------------------------------------------
+  # engines.node range exercise
+  # ---------------------------------------------------------------------------
+  # package.json declares `engines.node: ">=22.0.0"`, which claims every major
+  # from 22 upward, while all 36 workflow pins run 22. That left the upper half of
+  # the claim asserted and never executed -- the same defect the browser matrices
+  # above exist to prevent for a different support surface.
+  #
+  # The version is a literal, not a matrix expression, so the pin checker can read
+  # it and confirm the marked value really is inside the declared range.
+  #
+  # Nightly rather than per-PR: this exercises a claim, it does not gate a change.
+  engines-range:
+    name: engines.node range (Node 24)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '24' # exercises-engines-range
+          cache: npm
+      - name: Install
+        run: npm ci
+      - name: Repository tooling suites
+        run: |
+          npm run workflow:security:test
+          npm run node:version:test
+          npm run ai:manifest:test
+      - name: Repository checks
+        run: |
+          npm run workflow:security:check
+          npm run encoding:check
+          npm run eng:citations

--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -6398,6 +6398,90 @@ Five other workflows (`ci-android`, `ci-shared`, `ci-security`, `release-platfor
 Line-tip lag is a better proxy, not a measurement of the real thing: it counts _a release you do not
 have_, not _a fix you need_. It over-reports, which is the safe direction for a gate.
 
+## An asserted range is a claim nothing runs
+
+A sibling session found that its repo declares `engines.node: ">=20"` while every CI job pins 20 —
+the floor exercised, the rest asserted — and that the same repo had already written the postmortem
+for that exact defect fifteen lines above, about a different dependency. finance has the same shape,
+and worse: the notice was already being printed.
+
+```
+engines.node   ">=22.0.0"        claims 22, 24, 26, ...
+.nvmrc          22
+workflow pins   36 literals, every one 22
+```
+
+`npm run node:version:check` has emitted _"engines.node is `>=22.0.0`, which admits majors above 22"_
+on every run since it was added. It was a notice, so it scrolled past — a control that reports into a
+stream nobody consumes is indistinguishable from one that reports nothing.
+
+### finance's version is sharper than theirs
+
+The idiom for exercising a declared support surface is not merely present here, it is routine:
+
+| declared surface         | values exercised              |
+| ------------------------ | ----------------------------- |
+| browsers (`nightly.yml`) | **6**                         |
+| browsers (`ci-web.yml`)  | 4                             |
+| Android API levels       | 1                             |
+| **Node majors**          | **1, of an open-ended range** |
+
+Six browsers get a matrix. The runtime range in the repository's own manifest got one point.
+
+### Two correct controls, colliding again
+
+The obvious fix — run a job on Node 24 — is _forbidden_ by the checker added in #4225, which is
+fatal on any literal disagreeing with `.nvmrc`. That is the same deadlock shape recorded earlier in
+this document, this time caused by a control this repository added itself, and it argues that the
+pattern is not a coincidence of two unlucky rules. **A control that pins a value forbids the job that
+tests a different one, unless it is taught the difference between drift and an experiment.**
+
+Resolved with an explicit marker rather than an exemption list:
+
+```yaml
+node-version: '24' # exercises-engines-range
+```
+
+The marker is constrained from both sides so it cannot become a way to silence drift:
+
+| marked literal                                       | verdict                                                 |
+| ---------------------------------------------------- | ------------------------------------------------------- |
+| inside `engines.node`, different major from `.nvmrc` | exempt — this is the intended use                       |
+| same major as `.nvmrc`                               | **fatal** — exercises nothing, so the marker only hides |
+| outside `engines.node` (e.g. 20)                     | **fatal** — the manifest never claimed it               |
+| unreadable (`${{ matrix.node }}`)                    | **fatal** — cannot be judged, so must not be exempt     |
+
+You can only exempt a version the manifest already claims to support, which is why the escape hatch
+cannot widen the thing it escapes.
+
+The unexercised range itself is now **fatal**, not a notice, and it passes the discriminator that
+governs the rest of these gates: _can something outside this tree, with no change here, turn it red?_
+It cannot — a new Node release does not flip it; only editing `engines`, `.nvmrc`, or the workflows
+does. So both remedies stay open and both are correct: exercise the range, or narrow the claim to
+what CI runs.
+
+The job lives in `nightly.yml` with a literal rather than a one-value matrix, so the checker can read
+the version and confirm it. It exercises a claim; it does not gate a change.
+
+### The fabricated SHA
+
+Writing that job, I pinned `actions/setup-node@48b55a01f5c6b6d0a1f0b8b4d6f7c1e6c4a5b1e6`. The real
+pin is `48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e`. I had measured the real one earlier, remembered
+its opening characters, and typed the rest.
+
+**Eight identical leading characters, then invention** — the sibling reported the identical error one
+message earlier with ten. Reading a message about a failure mode, then committing it inside the hour,
+while writing the fix for a different instance of "asserted rather than checked."
+
+What makes it worth recording is where it would have stopped. `check-workflow-security.mjs` validates
+that a ref is 40 hex characters; it cannot validate that the object exists, because it does not touch
+the network. A fabricated SHA of the right shape **passes every local gate** and fails only when a
+runner tries to resolve the action. The pin check answers "is this pinned", which reads like "is this
+right".
+
+The fix is not vigilance: read the value out of the file. Both SHAs in that job were extracted from
+`ci-lint.yml` by pattern, never retyped.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:

--- a/tools/check-node-version-consistency.mjs
+++ b/tools/check-node-version-consistency.mjs
@@ -43,7 +43,12 @@ export function findNodeVersionPins(text) {
   for (const [index, line] of lines.entries()) {
     const literal = line.match(/^\s*(?:-\s*)?node-version:\s*['"]?([^\s'"#]+)/);
     if (literal) {
-      pins.push({ kind: 'literal', value: literal[1], line: index + 1 });
+      pins.push({
+        kind: 'literal',
+        value: literal[1],
+        line: index + 1,
+        exercisesRange: line.includes(`# ${RANGE_MARKER}`),
+      });
       continue;
     }
     const fromFile = line.match(/^\s*(?:-\s*)?node-version-file:\s*['"]?([^\s'"#]+)/);
@@ -54,10 +59,85 @@ export function findNodeVersionPins(text) {
   return pins;
 }
 
+/**
+ * Marker that opts a literal out of the `.nvmrc` equality rule.
+ *
+ * A repository that declares `engines.node: ">=22.0.0"` claims 22, 24 and every
+ * later major. Pinning every job to `.nvmrc` exercises the floor and leaves the
+ * rest asserted, which is how a support claim rots without any file changing.
+ * Marked literals deliberately run a different major to exercise that claim.
+ */
+export const RANGE_MARKER = 'exercises-engines-range';
+
 /** Extracts the major from a `setup-node` version literal such as `22.11.0`. */
 export function pinMajor(value) {
   const match = String(value ?? '').match(/^v?(\d+)/);
   return match ? match[1] : null;
+}
+
+/**
+ * True when `major` falls inside an `engines.node` range.
+ *
+ * Understands the lower/upper bound forms this repository uses. An unparseable
+ * range returns `null` -- undecided, never a violation, so a form the check
+ * cannot read stays silent instead of failing a tree it cannot judge.
+ */
+export function majorSatisfiesEngines(major, range) {
+  if (!major || !range) return null;
+  const lower = String(range).match(/>=?\s*v?(\d+)/);
+  if (!lower) return null;
+  const upper = String(range).match(/<=?\s*v?(\d+)/);
+  const value = Number(major);
+  if (value < Number(lower[1])) return false;
+  if (upper && value > Number(upper[1])) return false;
+  return true;
+}
+
+/**
+ * Reports marked literals that do not do the job the marker claims.
+ *
+ * The marker is the only way past the `.nvmrc` rule, so it is constrained from
+ * both sides: a marked literal must sit inside the declared range (otherwise it
+ * exercises a version the manifest never claimed) and must differ from `.nvmrc`
+ * (otherwise it exercises nothing and the marker only hides drift). Both are
+ * caused by a local edit, so both are fatal.
+ */
+export function findRangeExerciseViolations(file, text, expectedMajor, range) {
+  const violations = [];
+  for (const pin of findNodeVersionPins(text)) {
+    if (pin.kind !== 'literal' || !pin.exercisesRange) continue;
+    const major = pinMajor(pin.value);
+    if (major === null) {
+      violations.push(
+        `${file}:${pin.line} is marked ${RANGE_MARKER} but its version cannot be read`,
+      );
+      continue;
+    }
+    if (major === expectedMajor) {
+      violations.push(
+        `${file}:${pin.line} is marked ${RANGE_MARKER} but pins ${pin.value}, the same major as .nvmrc; it exercises nothing`,
+      );
+    }
+    if (majorSatisfiesEngines(major, range) === false) {
+      violations.push(
+        `${file}:${pin.line} is marked ${RANGE_MARKER} but Node ${pin.value} is outside engines.node "${range}"`,
+      );
+    }
+  }
+  return violations;
+}
+
+/** Majors above `.nvmrc` that some marked literal actually runs. */
+export function exercisedMajorsAbove(files, expectedMajor) {
+  const majors = new Set();
+  for (const { text } of files) {
+    for (const pin of findNodeVersionPins(text)) {
+      if (pin.kind !== 'literal' || !pin.exercisesRange) continue;
+      const major = pinMajor(pin.value);
+      if (major !== null && Number(major) > Number(expectedMajor)) majors.add(major);
+    }
+  }
+  return [...majors].sort((a, b) => Number(a) - Number(b));
 }
 
 /**
@@ -66,13 +146,15 @@ export function pinMajor(value) {
  * A `node-version-file` pin is single-sourced and never reported. A literal
  * whose major cannot be read (`lts/*`, an expression) is left undecided rather
  * than reported, so an unparsed form stays silent instead of failing a tree the
- * check cannot judge.
+ * check cannot judge. A literal marked `exercises-engines-range` is judged by
+ * `findRangeExerciseViolations` instead.
  */
 export function findNodeVersionMismatches(file, text, expectedMajor) {
   if (!expectedMajor) return [];
   const violations = [];
   for (const pin of findNodeVersionPins(text)) {
     if (pin.kind !== 'literal') continue;
+    if (pin.exercisesRange) continue;
     const major = pinMajor(pin.value);
     if (major === null) continue;
     if (major !== expectedMajor) {
@@ -107,26 +189,34 @@ function main() {
   }
 
   const files = readdirSync(workflowDirectory).filter((name) => /\.ya?ml$/.test(name));
+  const engines = JSON.parse(readFileSync(join(repositoryRoot, 'package.json'), 'utf8')).engines;
   const violations = [];
+  const loaded = [];
   let literalCount = 0;
   let fileCount = 0;
+  let markedCount = 0;
 
   for (const file of files) {
     const text = readFileSync(join(workflowDirectory, file), 'utf8');
+    loaded.push({ file, text });
     for (const pin of findNodeVersionPins(text)) {
-      if (pin.kind === 'literal') literalCount += 1;
-      else fileCount += 1;
+      if (pin.kind !== 'literal') fileCount += 1;
+      else if (pin.exercisesRange) markedCount += 1;
+      else literalCount += 1;
     }
     violations.push(...findNodeVersionMismatches(file, text, expectedMajor));
+    violations.push(...findRangeExerciseViolations(file, text, expectedMajor, engines?.node));
+  }
+
+  const exercised = exercisedMajorsAbove(loaded, expectedMajor);
+  if (enginesAdmitsAbove(engines?.node, expectedMajor) && exercised.length === 0) {
+    violations.push(
+      `package.json engines.node is "${engines.node}", which claims majors above ${expectedMajor}, but no workflow runs one. ` +
+        `Either narrow the range to what CI exercises, or mark a job's node-version with "# ${RANGE_MARKER}".`,
+    );
   }
 
   const notices = [];
-  const engines = JSON.parse(readFileSync(join(repositoryRoot, 'package.json'), 'utf8')).engines;
-  if (enginesAdmitsAbove(engines?.node, expectedMajor)) {
-    notices.push(
-      `package.json engines.node is "${engines.node}", which admits majors above ${expectedMajor}; it cannot express the runtime CI uses.`,
-    );
-  }
   const runningMajor = process.versions.node.split('.')[0];
   if (runningMajor !== expectedMajor) {
     notices.push(
@@ -135,7 +225,7 @@ function main() {
   }
 
   if (violations.length > 0) {
-    console.error('Node runtime pins disagree with .nvmrc:\n');
+    console.error('Node runtime pin check failed:\n');
     for (const violation of violations) console.error(`  - ${violation}`);
     process.exitCode = 1;
     return;
@@ -144,6 +234,11 @@ function main() {
   console.log(
     `Node runtime pins agree with .nvmrc (${expectedMajor}): ${literalCount} literal, ${fileCount} via node-version-file, across ${files.length} workflow file(s).`,
   );
+  if (markedCount > 0) {
+    console.log(
+      `engines.node "${engines.node}" is exercised above ${expectedMajor} at Node ${exercised.join(', ')} by ${markedCount} marked pin(s).`,
+    );
+  }
   for (const notice of notices) console.log(`Notice: ${notice}`);
 }
 

--- a/tools/check-node-version-consistency.test.mjs
+++ b/tools/check-node-version-consistency.test.mjs
@@ -5,10 +5,14 @@ import test from 'node:test';
 import { fileURLToPath } from 'node:url';
 
 import {
+  RANGE_MARKER,
   enginesAdmitsAbove,
+  exercisedMajorsAbove,
+  findRangeExerciseViolations,
   findNodeVersionMismatches,
   findNodeVersionPins,
   parseNvmrc,
+  majorSatisfiesEngines,
   pinMajor,
 } from './check-node-version-consistency.mjs';
 
@@ -105,4 +109,80 @@ test('the real workflow tree agrees with .nvmrc, and a mutated copy does not', (
     .find((text) => findNodeVersionPins(text).some((pin) => pin.kind === 'literal'))
     .replace(/node-version:\s*['"]?\d+/, 'node-version: 18');
   assert.ok(findNodeVersionMismatches('mutated.yml', mutated, expected).length > 0);
+});
+
+const marked = (version) =>
+  `      - uses: actions/setup-node@abc\n        with:\n          node-version: '${version}' # ${RANGE_MARKER}\n`;
+
+test('a marked literal is exempt from the .nvmrc equality rule', () => {
+  assert.deepEqual(findNodeVersionMismatches('nightly.yml', marked('24'), '22'), []);
+});
+
+test('an unmarked literal of the same value is still a mismatch', () => {
+  const text = marked('24').replace(` # ${RANGE_MARKER}`, '');
+  assert.equal(findNodeVersionMismatches('nightly.yml', text, '22').length, 1);
+});
+
+test('findNodeVersionPins records the marker only when present', () => {
+  assert.equal(findNodeVersionPins(marked('24'))[0].exercisesRange, true);
+  const bare = marked('24').replace(` # ${RANGE_MARKER}`, '');
+  assert.equal(findNodeVersionPins(bare)[0].exercisesRange, false);
+});
+
+test('majorSatisfiesEngines honours both bounds and stays undecided when unreadable', () => {
+  assert.equal(majorSatisfiesEngines('24', '>=22.0.0'), true);
+  assert.equal(majorSatisfiesEngines('20', '>=22.0.0'), false);
+  assert.equal(majorSatisfiesEngines('26', '>=22.0.0 <25'), false);
+  assert.equal(majorSatisfiesEngines('24', '>=22.0.0 <25'), true);
+  assert.equal(majorSatisfiesEngines('24', 'lts/*'), null);
+  assert.equal(majorSatisfiesEngines(null, '>=22.0.0'), null);
+});
+
+test('a marker on the .nvmrc major is fatal because it exercises nothing', () => {
+  const found = findRangeExerciseViolations('nightly.yml', marked('22'), '22', '>=22.0.0');
+  assert.equal(found.length, 1);
+  assert.match(found[0], /exercises nothing/);
+});
+
+test('a marker outside the declared range is fatal', () => {
+  const found = findRangeExerciseViolations('nightly.yml', marked('20'), '22', '>=22.0.0');
+  assert.equal(found.length, 1);
+  assert.match(found[0], /outside engines\.node/);
+});
+
+test('a marker on an unreadable version is fatal rather than silently exempt', () => {
+  const found = findRangeExerciseViolations(
+    'nightly.yml',
+    marked('${{ matrix.node }}'),
+    '22',
+    '>=22.0.0',
+  );
+  assert.equal(found.length, 1);
+  assert.match(found[0], /cannot be read/);
+});
+
+test('a valid marker produces no violation', () => {
+  assert.deepEqual(findRangeExerciseViolations('nightly.yml', marked('24'), '22', '>=22.0.0'), []);
+});
+
+test('exercisedMajorsAbove reports marked majors above the declared one only', () => {
+  const files = [
+    { file: 'a.yml', text: marked('24') },
+    { file: 'b.yml', text: marked('24').replace(` # ${RANGE_MARKER}`, '') },
+  ];
+  assert.deepEqual(exercisedMajorsAbove(files, '22'), ['24']);
+  assert.deepEqual(exercisedMajorsAbove([{ file: 'c.yml', text: marked('22') }], '22'), []);
+});
+
+test('the repository declares a range and exercises it', () => {
+  const engines = JSON.parse(readFileSync(join(repositoryRoot, 'package.json'), 'utf8')).engines;
+  const expected = parseNvmrc(readFileSync(join(repositoryRoot, '.nvmrc'), 'utf8'));
+  if (!enginesAdmitsAbove(engines.node, expected)) return;
+  const files = readdirSync(workflowDirectory)
+    .filter((name) => /\.ya?ml$/.test(name))
+    .map((file) => ({ file, text: readFileSync(join(workflowDirectory, file), 'utf8') }));
+  assert.ok(
+    exercisedMajorsAbove(files, expected).length > 0,
+    'engines.node claims majors above .nvmrc but no workflow runs one',
+  );
 });


### PR DESCRIPTION
## Summary

`package.json` declares `engines.node: ">=22.0.0"` — a claim about 22, 24 and every later major —
while all 36 workflow pins run 22. The floor was exercised; the rest was asserted.

The checker added in #4225 had been printing this as a **notice on every single run**. It scrolled
past. A control that reports into a stream nobody consumes is indistinguishable from one that
reports nothing, which is why it took an outside session naming the defect in *its* repo for anyone
to act on it here.

finance's version is sharper than the repo that reported it: the idiom is routine here.

| declared surface | values exercised |
| --- | --- |
| browsers (`nightly.yml`) | **6** |
| browsers (`ci-web.yml`) | 4 |
| **Node majors** | **1, of an open-ended range** |

## Two of this repo's own controls deadlocked

The fix — run a job on Node 24 — is *forbidden* by #4225's checker, which is fatal on any literal
disagreeing with `.nvmrc`. Same deadlock shape recorded here before, now between two gates this
repository added itself, which suggests it is structural rather than bad luck: **a control that pins
a value forbids the job that tests a different one, unless it is taught the difference between drift
and an experiment.**

Resolved with an explicit marker, constrained from both sides so it cannot become a silencer:

```yaml
node-version: '24' # exercises-engines-range
```

| marked literal | verdict |
| --- | --- |
| inside `engines.node`, different major from `.nvmrc` | exempt — intended use |
| same major as `.nvmrc` | **fatal** — exercises nothing, marker only hides |
| outside `engines.node` (e.g. 20) | **fatal** — manifest never claimed it |
| unreadable (`${{ matrix.node }}`) | **fatal** — cannot be judged, must not be exempt |

You can only exempt a version the manifest already claims, so the escape hatch cannot widen the
thing it escapes.

The unexercised range is now **fatal**, not a notice. It passes the discriminator used for the other
gates here — *can something outside this tree turn it red with no change here?* It cannot; a new Node
release doesn't flip it. Both remedies stay open and both are correct: exercise the range, or narrow
the claim.

## The fabricated SHA

Writing this job I pinned `actions/setup-node@48b55a01f5c6b6d0a1f0b8b4d6f7c1e6c4a5b1e6`. The real
pin is `48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e` — **8 identical leading characters, then
invention**, from memory of a value I had measured an hour earlier.

Where it would have stopped matters more than the slip: `check-workflow-security.mjs` validates that
a ref is 40 hex characters and cannot validate that the object exists, because it never touches the
network. A fabricated SHA of the right shape **passes every local gate** and fails only when a runner
tries to resolve it. The pin check answers "is this pinned", which reads like "is this right".

Both SHAs in the final job were extracted from `ci-lint.yml` by pattern, never retyped.

Also caught by an existing control: `workflow:security:check` rejected the new job for omitting
job-level `permissions` (ENG-SEC-004) — while grandfathering the 8 pre-existing jobs in the same
file that do the same thing. Working as a ratchet should. Added `contents: read`.

## Issues

Refs #4029

## Testing

- [x] Checker calibrated on the real defect **first** — exits 1 on the unfixed tree with the exact finding, then 0 after
- [x] 10 new tests (22 total), covering all four marker verdicts and both `majorSatisfiesEngines` bounds
- [x] **6 of 6 mutants killed**, each confirmed applied, scorer calibrated on the unmutated tree before scoring
- [x] `workflow:security:check` + 21/21 tests, `encoding:check`, `eng:citations` — all exit 0
- [x] `npx eslint --max-warnings 0` + `npx prettier --check` on all changed files
- [x] `nightly.yml` parses; job resolves to `node-version: 24`, `permissions: {contents: read}`