### PR TITLE
fix(tools): read drift enforcement from the workflow, not from prose (#4233)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,7 +133,7 @@ AI agents that skip issue creation, commit directly to `main`, or fail to create
 
 - **Kotlin linting** is handled by **detekt** in CI (not ESLint/Prettier)
 - **`.prettierignore`** covers non-JS source files (Kotlin, Swift, etc.) — `npm run format` only touches JS/TS/JSON/MD/YAML
-- **AI agents** are defined in `.github/agents/` as `*.agent.md` files — that directory is the **source of truth** for the roster. The **AI Manifest Check** workflow (`npm run ai:manifest:check`, backed by `tools/ai-manifest.js`) validates the exact roster, generated provenance, local-agent boundary, and managed sync inventory. There are **23 agents**: 22 Studio-generated canonical definitions plus the Finance-authored `finance-domain`.
+- **AI agents** are defined in `.github/agents/` as `*.agent.md` files — that directory is the **source of truth** for the roster. The **AI Manifest Check** workflow runs two arms with different authority: `npm run ai:manifest:test` is **blocking**, while the drift arm (`npm run ai:manifest:check`, backed by `tools/check-ai-manifest.js`) is **warn-only** — it reports the roster, generated provenance, local-agent boundary, and managed sync inventory, but cannot fail the build. A green check therefore means the digest rules hold, **not** that drift is absent; read the step output for that. There are **23 agents**: 22 Studio-generated canonical definitions plus the Finance-authored `finance-domain`.
 
 ## AI Agent Configuration
 

--- a/tools/check-ai-manifest.js
+++ b/tools/check-ai-manifest.js
@@ -560,6 +560,65 @@ function citationFindings(text, citations = CANON_CITATIONS) {
   return findings;
 }
 
+// A green "AI Manifest Check" in the PR list does NOT mean drift is absent. The drift step runs
+// with STRICT: '0', so it prints findings and exits 0; only the digest rule tests block. The
+// workflow says so plainly in its own comments -- but the reader deciding whether to merge sees
+// the check name, not the workflow file, and AGENTS.md described the workflow as validating the
+// roster without saying that arm cannot fail. The disclosure existed one click from the decision.
+//
+// So the enforcement mode is READ FROM THE WORKFLOW and compared against the prose, rather than
+// the prose being trusted. Flipping STRICT without rewriting the sentence now fails here, and so
+// does rewriting the sentence without flipping STRICT.
+const ENFORCEMENT_WORKFLOW = '.github/workflows/ai-manifest-check.yml';
+const ENFORCEMENT_STEP = 'Check for drift';
+
+/**
+ * Determine whether the drift step blocks, by reading the workflow rather than believing prose.
+ *
+ * @param {string} workflowText Contents of the manifest-check workflow.
+ * @returns {{mode: 'blocking'|'warn-only'}|{error: string}} Mode, or why it could not be read.
+ */
+function driftEnforcement(workflowText) {
+  const at = workflowText.indexOf(ENFORCEMENT_STEP);
+  // Fails closed. A renamed step must not read as "warn-only" by default: that silent-skip
+  // default is how a parser stops observing and still returns a confident answer.
+  if (at < 0) return { error: `cannot locate the "${ENFORCEMENT_STEP}" step` };
+  const block = workflowText.slice(at, at + 500);
+  const strict = /STRICT:\s*'?(\d)'?/.exec(block);
+  if (!strict && !block.includes('--strict')) {
+    return { error: 'drift step declares neither STRICT nor --strict' };
+  }
+  const blocking = block.includes('--strict') || (strict && strict[1] === '1');
+  return { mode: blocking ? 'blocking' : 'warn-only' };
+}
+
+/**
+ * Report disagreement between the workflow's real enforcement and how the docs describe it.
+ *
+ * @param {string} workflowText Contents of the manifest-check workflow.
+ * @param {string} docText Contents of the runtime documentation making the claim.
+ * @returns {string[]} Findings; empty when the prose matches the workflow.
+ */
+function enforcementFindings(workflowText, docText) {
+  const read = driftEnforcement(workflowText);
+  if (read.error) return [`cannot read drift enforcement: ${read.error}`];
+  if (!docText.includes('AI Manifest Check')) {
+    return ['runtime docs no longer describe the AI Manifest Check workflow'];
+  }
+  const findings = [];
+  const saysWarn = docText.includes('warn-only');
+  if (read.mode === 'warn-only' && !saysWarn) {
+    findings.push(
+      'the drift step runs with STRICT off, but the docs do not say the check is warn-only — ' +
+        'a green check would read as "no drift" when it cannot fail on drift',
+    );
+  }
+  if (read.mode === 'blocking' && saysWarn) {
+    findings.push('the drift step now blocks, but the docs still describe it as warn-only');
+  }
+  return findings;
+}
+
 // The engine hashes LF-normalized text (`hashText` in `lock.mjs`). Naming it here rather
 // than spelling `.replace(/\r\n/g, '\n')` at each call site keeps one word for one rule:
 // three inline spellings is what made this normalization impossible to cite accurately,
@@ -1049,6 +1108,34 @@ function verifyManagedContent(lock) {
   return findings;
 }
 
+/**
+ * Read CI's drift enforcement mode for display, degrading to the reason it could not be read.
+ *
+ * @returns {string} A human-readable mode or error string; never throws.
+ */
+function readEnforcementMode() {
+  const workflowPath = path.join(ROOT, ENFORCEMENT_WORKFLOW);
+  if (!fs.existsSync(workflowPath)) return 'unreadable (workflow not found)';
+  const read = driftEnforcement(fs.readFileSync(workflowPath, 'utf8'));
+  return read.error ? `unreadable (${read.error})` : read.mode;
+}
+
+/**
+ * Compare the workflow's real drift enforcement with how AGENTS.md describes it.
+ *
+ * @returns {string[]} Findings; empty when prose and workflow agree.
+ */
+function validateEnforcementDoc() {
+  const workflowPath = path.join(ROOT, ENFORCEMENT_WORKFLOW);
+  const docPath = path.join(ROOT, 'AGENTS.md');
+  if (!fs.existsSync(workflowPath)) return [`missing workflow: ${ENFORCEMENT_WORKFLOW}`];
+  if (!fs.existsSync(docPath)) return ['missing AGENTS.md'];
+  return enforcementFindings(
+    fs.readFileSync(workflowPath, 'utf8'),
+    fs.readFileSync(docPath, 'utf8'),
+  );
+}
+
 function main() {
   const manifest = buildManifest();
   const counts = manifest.counts;
@@ -1058,7 +1145,13 @@ function main() {
     `Filesystem reality: ${counts.agents} agents, ${counts.skills} skills, ` +
       `${counts.instructions} instructions, ${counts.mcpServers} MCP servers\n`,
   );
-  process.stdout.write(`Mode: ${STRICT ? 'STRICT (blocking)' : 'informational (warn-only)'}\n\n`);
+  process.stdout.write(`Mode: ${STRICT ? 'STRICT (blocking)' : 'informational (warn-only)'}\n`);
+  // `Mode` above is *this invocation's* strictness. The line below is CI's, read from the workflow
+  // rather than described, and printed unconditionally: the reader deciding to merge sees the check
+  // name and this report, never the workflow's own comments (#4233).
+  process.stdout.write(
+    `CI drift enforcement (${ENFORCEMENT_WORKFLOW}): ${readEnforcementMode()}\n\n`,
+  );
 
   const scan = scanDocs(counts);
   const countFindings = scan.claims;
@@ -1068,6 +1161,7 @@ function main() {
     ...validateAgentRoster(manifest.agents),
     ...validateActivationDoc(),
     ...validateSyncLock(),
+    ...validateEnforcementDoc(),
   ];
   for (const doc of scan.missing) process.stdout.write(`- ${doc}: not found\n`);
   // Printed unconditionally, in both the passing and the failing branch. The old report emitted
@@ -1192,6 +1286,9 @@ module.exports = {
   verifySourceReproduction,
   KNOWN_UNREPRODUCED,
   CANON_CITATIONS,
+  ENFORCEMENT_WORKFLOW,
+  driftEnforcement,
+  enforcementFindings,
   HELP_TEXT,
   EXPECTED_AGENTS,
   MANAGED_COUNTS,

--- a/tools/check-ai-manifest.test.mjs
+++ b/tools/check-ai-manifest.test.mjs
@@ -29,6 +29,9 @@ const {
   verifySourceReproduction,
   KNOWN_UNREPRODUCED,
   CANON_CITATIONS,
+  ENFORCEMENT_WORKFLOW,
+  driftEnforcement,
+  enforcementFindings,
   METRICS,
   HELP_TEXT,
   EXPECTED_AGENTS,
@@ -626,6 +629,43 @@ test('the corpus yields the claims it yielded before, not merely more than zero'
   assert.equal(total, 4, 'the declared corpus carries four count claims');
 });
 
+// --- #4233: what a green check actually asserts ---------------------------------------------//
+// The drift step runs with STRICT: '0'. It prints findings and exits 0, so "AI Manifest Check ✅"
+// in the PR list is compatible with drift being present. The workflow discloses this in its own
+// comments; the reader deciding to merge sees the check name. Disclosure one click from the
+// decision is the same shape as a real disagreement printed above an exit 0 (#4210).
+
+test('the docs describe the enforcement the workflow actually applies', () => {
+  const workflow = fs.readFileSync(path.join(ROOT, ENFORCEMENT_WORKFLOW), 'utf8');
+  const doc = fs.readFileSync(path.join(ROOT, 'AGENTS.md'), 'utf8');
+  assert.deepEqual(enforcementFindings(workflow, doc), []);
+  // PREMISE: the mode was really read, not defaulted. Asserting [] above is satisfied by an
+  // unreadable workflow only if driftEnforcement fails open -- it does not, and this pins that.
+  assert.equal(driftEnforcement(workflow).mode, 'warn-only', 'drift is warn-only today');
+});
+
+test('a renamed or unreadable drift step is a finding, not a clean read', () => {
+  assert.ok(driftEnforcement('jobs:\n  steps:\n    - name: Something else\n').error);
+  assert.equal(
+    driftEnforcement('- name: Check for drift\n  run: node tool.js\n').error !== undefined,
+    true,
+  );
+  const findings = enforcementFindings('- name: Renamed\n', 'AI Manifest Check is warn-only');
+  assert.equal(findings.length, 1, 'an unreadable workflow must report, not pass');
+  assert.match(findings[0], /cannot read drift enforcement/);
+});
+
+test('prose and workflow must move together in both directions', () => {
+  const warnOnly = "- name: Check for drift\n  env:\n    STRICT: '0'\n  run: node tool.js\n";
+  const blocking = "- name: Check for drift\n  env:\n    STRICT: '1'\n  run: node tool.js\n";
+  const saysWarn = 'The AI Manifest Check drift arm is warn-only.';
+  const saysNothing = 'The AI Manifest Check workflow validates the roster.';
+  assert.deepEqual(enforcementFindings(warnOnly, saysWarn), [], 'agreement is clean');
+  assert.deepEqual(enforcementFindings(blocking, saysNothing), [], 'agreement is clean');
+  assert.match(enforcementFindings(warnOnly, saysNothing)[0], /do not say the check is warn-only/);
+  assert.match(enforcementFindings(blocking, saysWarn)[0], /now blocks/);
+});
+
 test('--help reaches this tool, rather than exiting inside a require', () => {
   // HELP_TEXT was unreachable: ai-manifest.js called process.exit(0) at module scope whenever
   // --help appeared in argv, so requiring it killed the process at line 7 and the drift checker
@@ -886,4 +926,18 @@ test('the walk names its exclusions rather than dropping them silently', () => {
       `WALK_SKIP excludes a directory the lock delivers into: ${skipped}`,
     );
   }
+});
+
+test('the report states CI enforcement, not just this invocation mode (#4233)', () => {
+  // The whole finding is that the deciding reader never opens the workflow. Asserting the constant
+  // would repeat #4230's vacuous test, so this asserts by execution.
+  const out = execFileSync(process.execPath, [TOOL], { encoding: 'utf8' });
+  assert.match(
+    out,
+    /CI drift enforcement \(\.github\/workflows\/ai-manifest-check\.yml\): warn-only/,
+  );
+  assert.ok(
+    out.indexOf('CI drift enforcement') < out.indexOf('Canonical runtime activation:'),
+    'enforcement disclosure must precede the verdict it qualifies',
+  );
 });


### PR DESCRIPTION
## Summary

The AI Manifest Check's drift arm runs with `STRICT: '0'` and cannot fail the check. The workflow
is explicit about that in its own step name and comments — but the reader deciding to merge sees
the check name in the PR list, and at most the tool's report. Neither said so.

That is the sign-flipped twin of #4210 (a real disagreement printed above an `exit 0`): the
information was present, correct, and one click from the decision.

`AGENTS.md:136` compounded it by implying blocking validation and attributing it to
**`tools/ai-manifest.js`** — the generator, not the validator. The same file confusion that
produced #4230, in the sentence naming the tool.

## Changes

- `driftEnforcement(workflowText)` parses the step, returning `{mode}` or `{error}`, and **fails
  closed** — a renamed or unreadable step is a finding, not a clean read.
- `enforcementFindings(workflowText, docText)` compares workflow and prose **in both directions**,
  so promoting the workflow to blocking goes red until the prose follows, and vice versa.
- The report prints CI's enforcement mode **unconditionally**, ahead of the verdict it qualifies —
  per #4212, an absent section is not a report.
- `AGENTS.md` now states that `ai:manifest:test` is blocking, the drift arm is warn-only, and a
  green check means the digest rules hold rather than that drift is absent.

**The workflow is not modified.**

## Issues

Closes #4233

## Testing

- [ ] `node --test tools/check-ai-manifest.test.mjs` — **53 pass, 0 fail** (was 49)
- [ ] `node tools/check-ai-manifest.js --strict` — exit 0, 4 count claims, enforcement line renders
- [ ] `npx prettier --check` and `npx eslint --max-warnings 0` on all touched files — clean

5 mutants, 5 killed by distinct failing test name, sources restored byte-identical:

```
A missing-step fails OPEN         -> a renamed or unreadable drift step is a finding, not a clean read
B warn-only mismatch unreported   -> prose and workflow must move together in both directions
C blocking mismatch unreported    -> prose and workflow must move together in both directions
D revert the AGENTS.md sentence   -> the docs describe the enforcement the workflow actually applies
E drop the disclosure line        -> the report states CI enforcement, not just this invocation mode
```

Test E asserts by **execution**, not against the constant — asserting the constant would repeat the
vacuous test #4230 was fixing.