### PR TITLE
ci(workflows): make the Gradle prefetch a control instead of a sweep

### DIFF
--- a/.github/workflows/ci-android.yml
+++ b/.github/workflows/ci-android.yml
@@ -109,6 +109,20 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-konan-
 
+      # The wrapper fetches the distribution with no retry and a 10s network
+      # timeout, so a transient reset from services.gradle.org fails the build
+      # step before a single line is compiled. Fetching here keeps the retry
+      # scoped to the download: a build failure still fails on the first attempt.
+      - name: Prefetch Gradle distribution
+        shell: bash
+        run: |
+          for attempt in 1 2 3; do
+            if ./gradlew --version; then exit 0; fi
+            echo "Gradle distribution fetch failed (attempt ${attempt}/3)"
+            sleep $(( attempt * 15 ))
+          done
+          echo "::error::Gradle distribution unavailable after 3 attempts"
+          exit 1
       - name: Run detekt
         id: detekt
         run: |
@@ -205,6 +219,20 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-konan-
 
+      # The wrapper fetches the distribution with no retry and a 10s network
+      # timeout, so a transient reset from services.gradle.org fails the build
+      # step before a single line is compiled. Fetching here keeps the retry
+      # scoped to the download: a build failure still fails on the first attempt.
+      - name: Prefetch Gradle distribution
+        shell: bash
+        run: |
+          for attempt in 1 2 3; do
+            if ./gradlew --version; then exit 0; fi
+            echo "Gradle distribution fetch failed (attempt ${attempt}/3)"
+            sleep $(( attempt * 15 ))
+          done
+          echo "::error::Gradle distribution unavailable after 3 attempts"
+          exit 1
       - name: Compile debug Kotlin
         id: compile
         run: |
@@ -332,6 +360,20 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
+      # The wrapper fetches the distribution with no retry and a 10s network
+      # timeout, so a transient reset from services.gradle.org fails the build
+      # step before a single line is compiled. Fetching here keeps the retry
+      # scoped to the download: a build failure still fails on the first attempt.
+      - name: Prefetch Gradle distribution
+        shell: bash
+        run: |
+          for attempt in 1 2 3; do
+            if ./gradlew --version; then exit 0; fi
+            echo "Gradle distribution fetch failed (attempt ${attempt}/3)"
+            sleep $(( attempt * 15 ))
+          done
+          echo "::error::Gradle distribution unavailable after 3 attempts"
+          exit 1
       - name: Run instrumented tests
         uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2.38.0
         with:

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -125,6 +125,9 @@ jobs:
       - name: Workflow Node pins agree with .nvmrc
         run: npm run node:version:check
 
+      - name: Gradle jobs prefetch the distribution
+        run: npm run gradle:prefetch:check
+
   pr-title:
     name: Semantic PR Title
     needs: changes

--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -64,6 +64,20 @@ jobs:
               - '**/build.gradle*'
               - 'gradle/**'
               - 'settings.gradle*'
+      # The wrapper fetches the distribution with no retry and a 10s network
+      # timeout, so a transient reset from services.gradle.org fails the build
+      # step before a single line is compiled. Fetching here keeps the retry
+      # scoped to the download: a build failure still fails on the first attempt.
+      - name: Prefetch Gradle distribution
+        shell: bash
+        run: |
+          for attempt in 1 2 3; do
+            if ./gradlew --version; then exit 0; fi
+            echo "Gradle distribution fetch failed (attempt ${attempt}/3)"
+            sleep $(( attempt * 15 ))
+          done
+          echo "::error::Gradle distribution unavailable after 3 attempts"
+          exit 1
       - if: github.event_name != 'pull_request' || steps.changes.outputs.kotlin == 'true'
         uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
@@ -346,6 +360,20 @@ jobs:
             exit 1
           fi
 
+      # The wrapper fetches the distribution with no retry and a 10s network
+      # timeout, so a transient reset from services.gradle.org fails the build
+      # step before a single line is compiled. Fetching here keeps the retry
+      # scoped to the download: a build failure still fails on the first attempt.
+      - name: Prefetch Gradle distribution
+        shell: bash
+        run: |
+          for attempt in 1 2 3; do
+            if ./gradlew --version; then exit 0; fi
+            echo "Gradle distribution fetch failed (attempt ${attempt}/3)"
+            sleep $(( attempt * 15 ))
+          done
+          echo "::error::Gradle distribution unavailable after 3 attempts"
+          exit 1
       - name: Verify Gradle dependency checksums
         run: |
           ./gradlew dependencies --configuration runtimeClasspath --no-daemon 2>&1 | tee gradle-deps.txt || true
@@ -516,6 +544,7 @@ jobs:
         run: |
           npm run workflow:security:test
           npm run workflow:security:check
+          npm run gradle:prefetch:check
 
       # Always-on lint + format gate (ci-lint.yml is path-filtered and may be
       # skipped, so we re-run the essentials here to guarantee coverage).

--- a/.github/workflows/ci-shared.yml
+++ b/.github/workflows/ci-shared.yml
@@ -83,6 +83,20 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-konan-
 
+      # The wrapper fetches the distribution with no retry and a 10s network
+      # timeout, so a transient reset from services.gradle.org fails the build
+      # step before a single line is compiled. Fetching here keeps the retry
+      # scoped to the download: a build failure still fails on the first attempt.
+      - name: Prefetch Gradle distribution
+        shell: bash
+        run: |
+          for attempt in 1 2 3; do
+            if ./gradlew --version; then exit 0; fi
+            echo "Gradle distribution fetch failed (attempt ${attempt}/3)"
+            sleep $(( attempt * 15 ))
+          done
+          echo "::error::Gradle distribution unavailable after 3 attempts"
+          exit 1
       - name: Build shared packages
         id: build
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -480,6 +480,7 @@ jobs:
         run: |
           npm run workflow:security:test
           npm run node:version:test
+          npm run gradle:prefetch:test
           npm run ai:manifest:test
       - name: Repository checks
         run: |

--- a/.github/workflows/release-platform.yml
+++ b/.github/workflows/release-platform.yml
@@ -320,6 +320,21 @@ jobs:
         shell: bash
         run: mkdir -p release-artifacts
 
+      # The wrapper fetches the distribution with no retry and a 10s network
+      # timeout, so a transient reset from services.gradle.org fails the build
+      # step before a single line is compiled. Fetching here keeps the retry
+      # scoped to the download: a build failure still fails on the first attempt.
+      - name: Prefetch Gradle distribution
+        if: matrix.platform == 'android' || matrix.platform == 'windows'
+        shell: bash
+        run: |
+          for attempt in 1 2 3; do
+            if ./gradlew --version; then exit 0; fi
+            echo "Gradle distribution fetch failed (attempt ${attempt}/3)"
+            sleep $(( attempt * 15 ))
+          done
+          echo "::error::Gradle distribution unavailable after 3 attempts"
+          exit 1
       - name: Build Android artifacts
         if: matrix.platform == 'android'
         shell: bash

--- a/.github/workflows/reusable-release-smoke-test.yml
+++ b/.github/workflows/reusable-release-smoke-test.yml
@@ -107,6 +107,20 @@ jobs:
         with:
           cache-read-only: true
 
+      # The wrapper fetches the distribution with no retry and a 10s network
+      # timeout, so a transient reset from services.gradle.org fails the build
+      # step before a single line is compiled. Fetching here keeps the retry
+      # scoped to the download: a build failure still fails on the first attempt.
+      - name: Prefetch Gradle distribution
+        shell: bash
+        run: |
+          for attempt in 1 2 3; do
+            if ./gradlew --version; then exit 0; fi
+            echo "Gradle distribution fetch failed (attempt ${attempt}/3)"
+            sleep $(( attempt * 15 ))
+          done
+          echo "::error::Gradle distribution unavailable after 3 attempts"
+          exit 1
       - name: Run unit tests
         run: |
           ./gradlew :apps:android:testReleaseUnitTest \
@@ -282,6 +296,20 @@ jobs:
         with:
           cache-read-only: true
 
+      # The wrapper fetches the distribution with no retry and a 10s network
+      # timeout, so a transient reset from services.gradle.org fails the build
+      # step before a single line is compiled. Fetching here keeps the retry
+      # scoped to the download: a build failure still fails on the first attempt.
+      - name: Prefetch Gradle distribution
+        shell: bash
+        run: |
+          for attempt in 1 2 3; do
+            if ./gradlew --version; then exit 0; fi
+            echo "Gradle distribution fetch failed (attempt ${attempt}/3)"
+            sleep $(( attempt * 15 ))
+          done
+          echo "::error::Gradle distribution unavailable after 3 attempts"
+          exit 1
       - name: Build application
         run: ./gradlew :apps:windows:build --parallel --build-cache --stacktrace
 

--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -6482,6 +6482,92 @@ right".
 The fix is not vigilance: read the value out of the file. Both SHAs in that job were extracted from
 `ci-lint.yml` by pattern, never retyped.
 
+## A sweep is not a control, and hand enumeration is not a census
+
+The Gradle distribution fetch has no retry and a 10-second network timeout, so a transient reset
+from `services.gradle.org` fails a job before anything compiles. One site was fixed earlier; this
+generalises it. The interesting part is not the retry — it is that every step of _finding_ the
+sites by hand was wrong, in the same direction, three times.
+
+### Three undercounts, all from encoding a formatting assumption
+
+The manual pass grepped `^\s*\.?/?gradlew` across the workflow directory and reported **8 jobs in
+5 files**. A checker that parses jobs into steps and asks whether any step invokes the wrapper
+reported **9 unguarded of 10 total**:
+
+| missed job                                            | why the grep missed it                                                                |
+| ----------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| `ci-security.yml` / `codeql-java-kotlin`              | `run: ./gradlew clean compileKotlinJvm` — inline, so the wrapper is not at line start |
+| `release-platform.yml` / `build-platform` second call | the hand scan stopped at the first hit per job                                        |
+
+The pattern was not wrong about `gradlew`. It was wrong about **`run: |` versus `run:`** — an
+assumption about YAML style that was never stated, never tested, and silently excluded 11% of the
+population. This is the same defect as an `^`-anchored pattern against a joined blob, and it is the
+third time in this adoption that a hand-built enumeration has been corrected by a parser.
+
+The rule that generalises: **an enumeration is only as good as the least-stated assumption in its
+pattern, and patterns do not report their own assumptions.** The remedy is not a better regex; it
+is to make the check the artefact and let the sweep fall out of it. Which is why this landed as
+`tools/check-gradle-prefetch.mjs` and not as nine edits.
+
+### A sweep silently regresses; a check does not
+
+Nine hand-applied steps are correct on the day they merge and unenforced thereafter — the tenth
+Gradle job added next month gets none, and nothing says so. Adding the checker first, then letting
+it name its own targets, converts a one-time correction into an invariant. It was calibrated on the
+real defect before the fix existed: exit 1 naming all nine, then exit 0.
+
+### The checker's own hole, found by the fix it generated
+
+`release-platform.yml` / `build-platform` is a matrix job with **two** wrapper steps, each guarded
+on a different leg:
+
+```yaml
+- name: Build Android artifacts
+  if: matrix.platform == 'android'
+- name: Build Windows artifacts
+  if: matrix.platform == 'windows'
+```
+
+The generated prefetch inherited the _first_ step's condition, so the Windows leg fetched unwarmed —
+**and the checker passed**, because "a prefetch before the first wrapper call" is satisfied. Per-job
+ordering is the wrong granularity when steps are conditional: the job is guarded, and one of its
+legs is not.
+
+Fixed both sides. The condition became the disjunction `setup-java` in the same job already uses,
+and the checker gained `findUncoveredConditions`, which requires each later wrapper step's condition
+to appear verbatim in the prefetch's. It does not evaluate matrix expressions — it under-decides,
+flagging only what it can read, in keeping with _a checker must under-decide, never over-report_.
+
+> **A control validated only against the shape that motivated it inherits that shape's blind spots.**
+> The nine simple jobs all passed. The one structurally different job passed too, and should not
+> have.
+
+### A test that failed because the checker was wrong
+
+`stepCondition` read `/^\s+if:/`, matching `if:` as a _following_ key but not as a step's _leading_
+one (`- if: ...`). Both are valid YAML. A guarded step written the second way reported "no
+condition" — which, in `findUncoveredConditions`, turns a **covered** leg into a **false
+violation**. The failing test was fixed in the checker, not in the fixture.
+
+### Mutation results, and an equivalent mutant reported as equivalent
+
+7 mutants, **6 killed**, scorer calibrated on the unmutated tree first. The survivor —
+`.slice(prefetchIndex + 1)` → `.slice(prefetchIndex)` — is **equivalent, not a coverage gap**:
+including the prefetch step in its own scan compares `guard.includes(guard)`, which is always true,
+so the step filters itself out. Forcing this to 7/7 would require a test that cannot exist. Reported
+as equivalent rather than rounded up, because a mutation score inflated by one unkillable mutant is
+the same failure as a coverage number that counts unreachable lines.
+
+### The drift baseline fired, correctly
+
+`workflow:security:check` rejected the edit to `reusable-release-smoke-test.yml` — a reviewed local
+fork whose content is hash-pinned, with action-pin rotations normalised out so only substantive
+changes trip it. That is the control working: the diff was reviewed (28 added lines, purely
+additive) and the baseline updated. Worth recording because most controls in this adoption have
+been found _missing_; this one was present and did its job on the first substantive change since it
+was written.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "encoding:check": "node tools/check-text-encoding.mjs",
     "workflow:security:check": "node tools/check-workflow-security.mjs",
     "workflow:security:test": "node --test tools/check-workflow-security.test.mjs",
+    "gradle:prefetch:check": "node tools/check-gradle-prefetch.mjs",
+    "gradle:prefetch:test": "node --test tools/check-gradle-prefetch.test.mjs",
     "agent:worktree": "node tools/agent-scripts/setup-worktree.js",
     "agent:check": "node tools/agent-scripts/pre-push-check.js",
     "agent:pr": "node tools/agent-scripts/create-pr.js",

--- a/tools/check-gradle-prefetch.mjs
+++ b/tools/check-gradle-prefetch.mjs
@@ -1,0 +1,187 @@
+#!/usr/bin/env node
+/**
+ * Verifies that every workflow job invoking the Gradle wrapper first warms the
+ * distribution through a retrying prefetch step.
+ *
+ * The wrapper fetches its distribution with `networkTimeout=10000` and retries
+ * zero times, so a transient reset from services.gradle.org fails the job before
+ * anything is compiled. A prefetch step scoped to the download makes that class
+ * of failure recoverable without making genuine build failures recoverable too.
+ *
+ * Cites ENG-BUILD-004 (reproducible builds) and ENG-TEST-006 (a flaky signal is
+ * a broken signal).
+ */
+import { readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const WORKFLOW_DIR = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '.github',
+  'workflows',
+);
+
+export const PREFETCH_STEP_NAME = 'Prefetch Gradle distribution';
+
+function normalize(text) {
+  return text.replace(/\r\n/g, '\n');
+}
+
+/**
+ * Splits a workflow into jobs, returning `{ name, line, body }` for each.
+ * Text-based on purpose: the sibling workflow checkers parse the same way, and
+ * a YAML loader would resolve anchors this check must see literally.
+ */
+export function splitJobs(workflow) {
+  const lines = normalize(workflow).split('\n');
+  const jobsStart = lines.findIndex((line) => /^jobs:\s*$/.test(line));
+  if (jobsStart === -1) return [];
+  const jobs = [];
+  let current = null;
+  for (let index = jobsStart + 1; index < lines.length; index += 1) {
+    const line = lines[index];
+    const header = line.match(/^ {2}([A-Za-z0-9_-]+):\s*$/);
+    if (header) {
+      if (current) jobs.push(current);
+      current = { name: header[1], line: index + 1, body: [] };
+      continue;
+    }
+    if (/^\S/.test(line) && line.trim() !== '') {
+      break;
+    }
+    if (current) current.body.push(line);
+  }
+  if (current) jobs.push(current);
+  return jobs.map((job) => ({ ...job, body: job.body.join('\n') }));
+}
+
+/**
+ * Returns the step blocks of a job in order. A step starts at a `- name:`,
+ * `- uses:` or `- run:` entry at the job's step indentation.
+ */
+export function splitSteps(jobBody) {
+  const lines = normalize(jobBody).split('\n');
+  const steps = [];
+  let current = null;
+  let indent = null;
+  for (const line of lines) {
+    const start = line.match(/^(\s*)- (?:name|uses|run|id|if):/);
+    if (start && (indent === null || start[1].length === indent)) {
+      indent = start[1].length;
+      if (current) steps.push(current.join('\n'));
+      current = [line];
+      continue;
+    }
+    if (current) current.push(line);
+  }
+  if (current) steps.push(current.join('\n'));
+  return steps;
+}
+
+const GRADLEW = /(^|[\s"'`&|(])\.?\/?gradlew(\.bat)?[\s"'`)]/;
+
+export function invokesGradle(step) {
+  return GRADLEW.test(`${step}\n`);
+}
+
+export function isPrefetchStep(step) {
+  return new RegExp(`- name:\\s*${PREFETCH_STEP_NAME}\\s*$`, 'm').test(step);
+}
+
+export function stepCondition(step) {
+  // `if:` may be the step's leading key (`- if: ...`) or a following one, and a
+  // check that reads only the second form silently reports "no condition" for a
+  // guarded step -- turning a covered leg into a false violation.
+  const line = step.split('\n').find((entry) => /^\s*(?:-\s*)?if:/.test(entry));
+  return line ? line.replace(/^\s*(?:-\s*)?if:\s*/, '').trim() : null;
+}
+
+/**
+ * A conditional prefetch only covers the legs its own condition admits. Rather
+ * than evaluate matrix expressions, require the guarded step's condition to
+ * appear verbatim in the prefetch condition -- under-deciding on anything else,
+ * so this can flag a real gap without inventing one.
+ */
+export function findUncoveredConditions(steps, prefetchIndex) {
+  const guard = stepCondition(steps[prefetchIndex]);
+  if (guard === null) return [];
+  return steps
+    .slice(prefetchIndex + 1)
+    .filter(invokesGradle)
+    .map(stepCondition)
+    .filter((condition) => condition === null || !guard.includes(condition));
+}
+
+/**
+ * A job is compliant when no step invokes the wrapper, or when the prefetch
+ * step appears before the first step that does. Ordering is the whole point: a
+ * prefetch after the first real invocation warms nothing.
+ */
+export function findUnguardedGradleJobs(file, workflow) {
+  const violations = [];
+  for (const job of splitJobs(workflow)) {
+    const steps = splitSteps(job.body);
+    const firstGradle = steps.findIndex((step) => invokesGradle(step));
+    if (firstGradle === -1) continue;
+    const prefetch = steps.findIndex((step) => isPrefetchStep(step));
+    if (prefetch === -1) {
+      violations.push(
+        `${file}: job "${job.name}" invokes the Gradle wrapper with no "${PREFETCH_STEP_NAME}" step; ` +
+          'a transient distribution fetch failure fails the job (ENG-TEST-006)',
+      );
+      continue;
+    }
+    for (const uncovered of findUncoveredConditions(steps, prefetch)) {
+      violations.push(
+        `${file}: job "${job.name}" prefetches under "${stepCondition(steps[prefetch])}" but a later ` +
+          `wrapper step runs under "${uncovered ?? 'no condition'}"; that leg fetches unwarmed (ENG-TEST-006)`,
+      );
+    }
+    if (prefetch > firstGradle) {
+      violations.push(
+        `${file}: job "${job.name}" runs "${PREFETCH_STEP_NAME}" after step ${firstGradle + 1}, ` +
+          'which already invoked the wrapper; a prefetch that runs second warms nothing (ENG-TEST-006)',
+      );
+    }
+  }
+  return violations;
+}
+
+export function scanGradlePrefetch(workflows) {
+  return Object.entries(workflows).flatMap(([file, text]) => findUnguardedGradleJobs(file, text));
+}
+
+function loadWorkflows() {
+  const workflows = {};
+  for (const entry of readdirSync(WORKFLOW_DIR)) {
+    if (!/\.ya?ml$/.test(entry)) continue;
+    workflows[entry] = readFileSync(path.join(WORKFLOW_DIR, entry), 'utf8');
+  }
+  return workflows;
+}
+
+function main() {
+  const workflows = loadWorkflows();
+  const gradleJobs = Object.entries(workflows).reduce(
+    (total, [, text]) =>
+      total + splitJobs(text).filter((job) => splitSteps(job.body).some(invokesGradle)).length,
+    0,
+  );
+  const violations = scanGradlePrefetch(workflows);
+  if (violations.length > 0) {
+    console.error('Gradle prefetch check failed:');
+    for (const violation of violations) console.error(`  - ${violation}`);
+    console.error(
+      `\n${violations.length} of ${gradleJobs} Gradle job(s) across ${Object.keys(workflows).length} workflow(s).`,
+    );
+    process.exit(1);
+  }
+  console.log(
+    `${gradleJobs} Gradle job(s) across ${Object.keys(workflows).length} workflow(s) prefetch the distribution before use.`,
+  );
+}
+
+if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href) {
+  main();
+}

--- a/tools/check-gradle-prefetch.test.mjs
+++ b/tools/check-gradle-prefetch.test.mjs
@@ -1,0 +1,159 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  PREFETCH_STEP_NAME,
+  findUncoveredConditions,
+  findUnguardedGradleJobs,
+  invokesGradle,
+  isPrefetchStep,
+  scanGradlePrefetch,
+  splitJobs,
+  splitSteps,
+  stepCondition,
+} from './check-gradle-prefetch.mjs';
+
+const prefetch = (condition) =>
+  [
+    `      - name: ${PREFETCH_STEP_NAME}`,
+    ...(condition ? [`        if: ${condition}`] : []),
+    '        run: ./gradlew --version',
+  ].join('\n');
+
+const workflow = (steps) => ['jobs:', '  build:', '    steps:', ...steps].join('\n');
+
+test('splitJobs finds every job and stops at the next top-level key', () => {
+  const jobs = splitJobs(
+    ['jobs:', '  a:', '    steps: []', '  b:', '    steps: []', 'on:'].join('\n'),
+  );
+  assert.deepEqual(
+    jobs.map((job) => job.name),
+    ['a', 'b'],
+  );
+});
+
+test('splitJobs returns nothing when there is no jobs block', () => {
+  assert.deepEqual(splitJobs('name: x\non: push\n'), []);
+});
+
+test('splitSteps keeps multi-line run blocks with their step', () => {
+  const steps = splitSteps(
+    [
+      '    steps:',
+      '      - name: one',
+      '        run: |',
+      '          echo a',
+      '      - name: two',
+    ].join('\n'),
+  );
+  assert.equal(steps.length, 2);
+  assert.match(steps[0], /echo a/);
+});
+
+test('invokesGradle matches an inline run, which a line-anchored grep misses', () => {
+  assert.equal(invokesGradle('      - run: ./gradlew clean --no-daemon'), true);
+});
+
+test('invokesGradle matches a block run and the Windows wrapper', () => {
+  assert.equal(invokesGradle('        run: |\n          ./gradlew build'), true);
+  assert.equal(invokesGradle('        run: gradlew.bat build'), true);
+});
+
+test('invokesGradle does not match a substring of another word', () => {
+  assert.equal(invokesGradle('        run: echo mygradlewrapper'), false);
+  assert.equal(invokesGradle('        run: npm test'), false);
+});
+
+test('isPrefetchStep matches only the exact step name', () => {
+  assert.equal(isPrefetchStep(`      - name: ${PREFETCH_STEP_NAME}`), true);
+  assert.equal(isPrefetchStep('      - name: Prefetch Gradle distribution cache'), false);
+});
+
+test('a job with no wrapper call is not a violation', () => {
+  assert.deepEqual(findUnguardedGradleJobs('w.yml', workflow(['      - run: npm ci'])), []);
+});
+
+test('a wrapper call with no prefetch is a violation', () => {
+  const found = findUnguardedGradleJobs('w.yml', workflow(['      - run: ./gradlew build']));
+  assert.equal(found.length, 1);
+  assert.match(found[0], /no "Prefetch Gradle distribution" step/);
+});
+
+test('a prefetch before the wrapper call passes', () => {
+  assert.deepEqual(
+    findUnguardedGradleJobs('w.yml', workflow([prefetch(), '      - run: ./gradlew build'])),
+    [],
+  );
+});
+
+test('a prefetch after the wrapper call is a violation, because order is the point', () => {
+  const found = findUnguardedGradleJobs(
+    'w.yml',
+    workflow(['      - run: ./gradlew build', prefetch()]),
+  );
+  assert.equal(found.length, 1);
+  assert.match(found[0], /runs second warms nothing/);
+});
+
+test('stepCondition reads an if and returns null without one', () => {
+  assert.equal(stepCondition(prefetch("matrix.os == 'a'")), "matrix.os == 'a'");
+  assert.equal(stepCondition(prefetch()), null);
+});
+
+test('an unconditional prefetch covers every later leg', () => {
+  const steps = splitSteps(
+    workflow([prefetch(), "      - if: matrix.os == 'a'\n        run: ./gradlew build"]),
+  );
+  assert.deepEqual(findUncoveredConditions(steps, steps.findIndex(isPrefetchStep)), []);
+});
+
+test('a conditional prefetch does not cover a differently guarded leg', () => {
+  const body = workflow([
+    prefetch("matrix.os == 'a'"),
+    "      - if: matrix.os == 'b'\n        run: ./gradlew build",
+  ]);
+  const found = findUnguardedGradleJobs('w.yml', body);
+  assert.equal(found.length, 1);
+  assert.match(found[0], /that leg fetches unwarmed/);
+});
+
+test('a conditional prefetch does not cover an unconditional leg', () => {
+  const found = findUnguardedGradleJobs(
+    'w.yml',
+    workflow([prefetch("matrix.os == 'a'"), '      - run: ./gradlew build']),
+  );
+  assert.equal(found.length, 1);
+  assert.match(found[0], /runs under "no condition"/);
+});
+
+test('a disjunction covering both legs passes, which is the release-platform shape', () => {
+  assert.deepEqual(
+    findUnguardedGradleJobs(
+      'w.yml',
+      workflow([
+        prefetch("matrix.platform == 'android' || matrix.platform == 'windows'"),
+        "      - if: matrix.platform == 'android'\n        run: ./gradlew a",
+        "      - if: matrix.platform == 'windows'\n        run: ./gradlew w",
+      ]),
+    ),
+    [],
+  );
+});
+
+test('scanGradlePrefetch reports across files and names each one', () => {
+  const found = scanGradlePrefetch({
+    'a.yml': workflow(['      - run: ./gradlew build']),
+    'b.yml': workflow([prefetch(), '      - run: ./gradlew build']),
+  });
+  assert.equal(found.length, 1);
+  assert.match(found[0], /^a\.yml:/);
+});
+
+test('the emulator action carrying a wrapper call in its inputs still counts', () => {
+  const found = findUnguardedGradleJobs(
+    'w.yml',
+    workflow([
+      '      - uses: reactivecircus/android-emulator-runner@0000000000000000000000000000000000000000\n        with:\n          script: ./gradlew connectedCheck',
+    ]),
+  );
+  assert.equal(found.length, 1);
+});

--- a/tools/check-workflow-security.mjs
+++ b/tools/check-workflow-security.mjs
@@ -38,7 +38,7 @@ const privilegedWorkflows = new Set([
 const localReusableBaselines = {
   'reusable-detect-changes.yml': '73a26b45af9ff6254e6982b63b336dc4a9a2bdd785d7ffbdaae4094d2ae90697',
   'reusable-release-smoke-test.yml':
-    '170107646a35e855dbfc9b95aaa395da41ccab84cad70f1bdc559448e8c603df',
+    'cb8de56b54292447ab67941b56e1f08c3c2fa0cfa3b8b533eddacc6fce5c9f02',
 };
 
 const requiredEnvironmentJobs = {


### PR DESCRIPTION
## Summary

Generalises the single-site Gradle retry from #4229 to the remaining jobs. The wrapper fetches its
distribution with `networkTimeout=10000` and retries **zero** times, so a transient reset from
`services.gradle.org` fails a job before anything compiles.

The retry is the boring half. The interesting half is that **every step of finding the sites by hand
was wrong, in the same direction.**

## Hand enumeration undercounted by 11%

A grep for `^\s*\.?/?gradlew` reported **8 jobs in 5 files**. A checker that parses jobs into steps
reported **9 unguarded of 10 total**:

| missed | why |
| --- | --- |
| `ci-security.yml` / `codeql-java-kotlin` | `run: ./gradlew clean compileKotlinJvm` — inline, not at line start |
| `release-platform.yml` / `build-platform`, 2nd call | the scan stopped at the first hit per job |

The pattern wasn't wrong about `gradlew`. It was wrong about **`run: |` versus `run:`** — a YAML-style
assumption never stated and never tested. Third time in this adoption a hand-built enumeration has
been corrected by a parser.

So this lands as `tools/check-gradle-prefetch.mjs` with the nine edits *generated from it*, not as
nine edits. Nine hand-applied steps are correct on merge day and unenforced after: the tenth Gradle
job added next month gets none and nothing says so. Calibrated on the unfixed tree first — exit 1
naming all nine, then exit 0.

## The checker's own hole, found in the fix it generated

`release-platform.yml` / `build-platform` is a matrix job with **two** wrapper steps on different legs:

```yaml
- name: Build Android artifacts
  if: matrix.platform == 'android'
- name: Build Windows artifacts
  if: matrix.platform == 'windows'
```

The generated prefetch inherited the *first* condition, so the Windows leg fetched unwarmed — **and
the checker passed**, since "prefetch before the first wrapper call" was satisfied. Per-job ordering
is the wrong granularity when steps are conditional: the job is guarded, one of its legs is not.

Fixed both sides. The condition became the disjunction `setup-java` in that same job already uses;
`findUncoveredConditions` now requires each later step's condition to appear verbatim in the
prefetch's. It does not evaluate matrix expressions — it under-decides, flagging only what it can
read.

> A control validated only against the shape that motivated it inherits that shape's blind spots.
> The nine simple jobs passed. The one structurally different job passed too, and should not have.

## A failing test that was the checker's fault

`stepCondition` read `/^\s+if:/` — matching `if:` as a *following* key but not a step's *leading* one
(`- if:`). Both are valid YAML, and a step written the second way reported "no condition", turning a
**covered** leg into a **false violation**. Fixed in the checker, not the fixture.

## The drift baseline fired, correctly

`workflow:security:check` rejected the edit to `reusable-release-smoke-test.yml` — a hash-pinned
reviewed local fork, with action-pin rotations normalised out so only substantive changes trip it.
The diff was reviewed (28 lines, purely additive) and the baseline updated. Worth noting because most
controls in this adoption have been found *missing*; this one was present and did its job on the
first substantive change since it was written.

## Issues

Refs #4029

## Testing

- [x] Checker calibrated on the **unfixed** tree first: exit 1 naming 9 of 10, then exit 0
- [x] Condition-coverage rule separately calibrated on the real Windows-leg gap before being trusted
- [x] 18 tests; **6 of 7 mutants killed**, scorer calibrated on the unmutated tree
- [x] The survivor (`slice(i+1)` → `slice(i)`) is **equivalent, not a gap** — the prefetch filters itself out via `guard.includes(guard)`. Reported as equivalent rather than rounded up
- [x] All 31 workflows parse as YAML (0 failures)
- [x] `workflow:security:check` + 21/21, `node:version:check` + 22/22, `encoding:check`, `eng:citations` — all green
- [x] `npx eslint --max-warnings 0` + `npx prettier --check` on every changed file