### PR TITLE
fix(tools): make the vendoring staleness check able to run, and say when it cannot

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -291,7 +291,16 @@ jobs:
       # "kept nowhere" -- and a local copy declaring the same TOOL_VERSION as a
       # newer upstream one is how finance ran a checker missing a whole check.
       - name: Verify vendored tooling matches the lock
+        # GITHUB_TOKEN raises the API limit from 60/hour per IP to 5000/hour per
+        # repo. Without it the staleness half of this check is rate-limited off
+        # on shared runner IPs, and until it named that gap the skip printed the
+        # same green line as a successful check.
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: npm run eng:vendor:check
+
+      - name: Vendoring staleness resolution tests
+        run: npm run eng:vendor:test
 
       - name: Check ENG-* citations
         run: npm run eng:citations

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -481,6 +481,7 @@ jobs:
           npm run workflow:security:test
           npm run node:version:test
           npm run gradle:prefetch:test
+          npm run eng:vendor:test
           npm run ai:manifest:test
       - name: Repository checks
         run: |

--- a/config/engineering/citations/check-citations.mjs
+++ b/config/engineering/citations/check-citations.mjs
@@ -77,7 +77,7 @@ function contextWindow(lines, i, span = 2) {
 }
 
 const CITATION = /\bENG-[A-Z]+-\d{3}\b/g;
-// `ENG-X-001 (Thin typed adapters)`. Parentheses only, and the content must
+// `ENG-INT-001 (Thin typed adapters)`. Parentheses only, and the content must
 // start with a capital — a title is a proper name. An em dash is ordinary prose
 // punctuation ("per ENG-SEC-008 — never a real record") and reading it as a
 // naming claim produced false positives, which is how a checker gets disabled.
@@ -97,9 +97,53 @@ const DEFAULT_INDEX =
 // copy is otherwise indistinguishable from a current one — a consumer reported
 // a missing check that had shipped several releases earlier, having run an old
 // copy that could not tell them so.
-const TOOL_VERSION = '9';
-const TEXT_EXT = new Set(['.md', '.mdx', '.markdown', '.txt', '.yml', '.yaml', '.json']);
+const TOOL_VERSION = '10';
+// Citations live in source comments as often as in prose. A consumer filed two
+// wrong citations against themselves in `.ts` files, then ran this tool over
+// that repository and got `41 citations, all IDs exist`, exit 0 -- because the
+// scanner never opened either file.
+//
+// That is worse than the silent-check failures recorded elsewhere in this
+// repository. Those produced an absent signal; this produced an affirmative
+// green over the exact defect it was written to find. So the extension set is
+// wide, and the summary prints it: a count of files scanned is not a claim
+// about the repository unless you can see what "files" meant.
+const TEXT_EXT = new Set([
+  '.md',
+  '.mdx',
+  '.markdown',
+  '.txt',
+  '.yml',
+  '.yaml',
+  '.json',
+  '.ts',
+  '.tsx',
+  '.js',
+  '.jsx',
+  '.mjs',
+  '.cjs',
+  '.svelte',
+  '.vue',
+  '.go',
+  '.py',
+  '.rs',
+  '.java',
+  '.kt',
+  '.rb',
+  '.sh',
+  '.sql',
+  '.css',
+  '.scss',
+  '.html',
+  '.toml',
+]);
 const SKIP_DIR = new Set(['node_modules', '.git', 'dist', 'build', '.svelte-kit', 'vendor']);
+// Opt a single file out of citation scanning. Intended for files that build
+// citation fixtures, not for files whose citations are inconvenient.
+// Assembled from fragments so this file does not match its own pragma: the
+// first version of this check silently excluded the checker itself.
+const PRAGMA_TEXT = 'citations-check' + ': ignore-file';
+const IGNORE_PRAGMA = new RegExp(PRAGMA_TEXT.replace(': ', ':\\s*'));
 // Words that scope one ID against another. Their absence around adjacent IDs is
 // what turns a pair of citations into an implied equivalence claim.
 const CONNECTIVE =
@@ -248,6 +292,19 @@ function resolvePrincipleFile(link) {
   return path.resolve(path.dirname(link.file), link.target);
 }
 
+// The scan's scope is part of its verdict. Printing the file count alone let a
+// consumer read `102 files ... all IDs exist` as a statement about their
+// repository when two wrong citations sat in files the walker never opened.
+function reportScope(ignoredFiles) {
+  console.log(`scanned extensions: ${[...TEXT_EXT].sort().join(' ')}`);
+  if (ignoredFiles.length > 0) {
+    console.log(
+      `${ignoredFiles.length} file(s) skipped via "${PRAGMA_TEXT}": ` +
+        ignoredFiles.map((f) => path.relative(process.cwd(), f)).join(', '),
+    );
+  }
+}
+
 async function collectFiles(target) {
   const info = await stat(target);
   if (info.isFile()) return [target];
@@ -273,7 +330,14 @@ async function scanFile(file) {
   const hits = [];
   const links = [];
   const titled = [];
-  const lines = (await readFile(file, 'utf8')).split(/\r?\n/);
+  const raw = await readFile(file, 'utf8');
+  // A file that builds citation fixtures contains IDs that are wrong on
+  // purpose. The opt-out is a pragma in the file itself rather than a filename
+  // convention, because a convention silently covers files nobody chose, and a
+  // silent skip is how this checker returned green over the two wrong citations
+  // that prompted widening the extension set. Skips are counted and printed.
+  if (IGNORE_PRAGMA.test(raw)) return { hits, links, titled, ignored: true };
+  const lines = raw.split(/\r?\n/);
   lines.forEach((text, i) => {
     for (const [, label, href] of text.matchAll(ID_LINK)) {
       const id = label.match(/\bENG-[A-Z]+-\d{3}\b/)?.[0];
@@ -378,8 +442,13 @@ async function main() {
   const citations = [];
   const links = [];
   const titled = [];
+  const ignoredFiles = [];
   for (const file of files) {
     const scanned = await scanFile(file);
+    if (scanned.ignored) {
+      ignoredFiles.push(file);
+      continue;
+    }
     citations.push(...scanned.hits);
     links.push(...scanned.links);
     titled.push(...scanned.titled);
@@ -459,6 +528,7 @@ async function main() {
 
   if (citations.length === 0) {
     console.log(`No ENG-* citations found in ${files.length} file(s).`);
+    reportScope(ignoredFiles);
     return 0;
   }
 
@@ -631,6 +701,7 @@ async function main() {
       (titled.length > 0 ? `, and ${titled.length} stated name(s) match` : '') +
       '.',
   );
+  reportScope(ignoredFiles);
   console.log(
     `checker v${TOOL_VERSION}; checks run: IDs, stated names, range members` +
       (opts.links ? ', link paths, link anchors' : ' (link paths SKIPPED via --no-links)') +

--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -6568,6 +6568,110 @@ additive) and the baseline updated. Worth recording because most controls in thi
 been found _missing_; this one was present and did its job on the first substantive change since it
 was written.
 
+## Three silent failures in a row, and a green check over 3,890 unread files
+
+The vendoring staleness check had never worked. Not "worked and was ignored" — the earlier defect
+in this document, where a notice printed every run and nobody read it. This one produced **no output
+at all**, and the absence was indistinguishable from success.
+
+### The chain
+
+```
+fetch(api.github.com/...)      unauthenticated
+  -> HTTP 403, x-ratelimit-remaining: 0
+  -> latestRef() returns null
+  -> `if (latest && ...)` is skipped
+  -> --check prints "6 vendored file(s) match ... at v0.124.0."  exit 0
+```
+
+Every link is individually defensible. Not failing on an unreachable API is right — a tag pushed
+upstream must not turn an unrelated PR red. Returning `null` when the answer is unknown is right.
+The defect is that **the green line for "checked, and current" and the green line for "could not
+check" are the same bytes.** Unauthenticated GitHub API calls are capped at 60/hour _per IP_, and
+Actions runners share IPs, so on CI the anonymous path is rate-limited far more often than it is
+offline. The check most likely never ran there.
+
+The remedy is not to fail. It is to **name the gap**:
+
+```
+Staleness not checked: GitHub API rate limit exhausted (HTTP 403); set GITHUB_TOKEN to raise it.
+This says nothing about whether v0.124.0 is current.
+```
+
+### `releases/latest` is a declaration, not a maximum
+
+Even authenticated, the endpoint was the wrong instrument. It does not compute anything — it reads a
+`make_latest` flag a maintainer sets, over the **release** population. Measured upstream:
+
+| population                  | count          |
+| --------------------------- | -------------- |
+| tags                        | 172            |
+| releases                    | 143            |
+| semver tags with no release | 28             |
+| `releases/latest`           | `v0.133.0`     |
+| **highest tag**             | **`v0.134.0`** |
+
+The highest tag had no release, so the declared answer was **one release behind the actual
+frontier, live**. Preferring a maintainer's declaration over a derived maximum is usually right, and
+is right about _ordering_ — a backport wave publishes newest-major first, so sorting releases by
+date returns the **oldest** maintained line as the frontier, perfectly anti-correlated rather than
+noisily wrong. But a declaration has a failure mode a computation does not: **it can be absent.** So
+ask both and take the higher, and never sort by date.
+
+### What the silence was hiding
+
+Pinned at `v0.124.0`; upstream at `v0.134.0`. The vendored citation checker was **v9 against
+upstream's v10**, and v10's change was the extension set — v9 opened prose files only.
+
+|                 | v9      | v10       |
+| --------------- | ------- | --------- |
+| files scanned   | **806** | **4,696** |
+| citations found | 141     | 170       |
+| extensions      | 7       | 27        |
+
+**29 citations lived in `.ts`, `.kt`, `.mjs` and similar and were never checked** — in a repository
+that is Kotlin Multiplatform and React, i.e. almost entirely the file types v9 skipped. `eng:citations`
+had been exiting 0 over 3,890 files it never opened. All 29 turned out valid, which is luck, not a
+control: the same "clean by a property of the input" this document keeps recording.
+
+### It is the same defect the CI comment already describes
+
+`ci-lint.yml` carries this, written earlier in this adoption:
+
+> a local copy declaring the same `TOOL_VERSION` as a newer upstream one is how finance ran a checker
+> missing a whole check
+
+That is exactly what happened again — same repository, same file, same mechanism — because the
+control built to prevent the recurrence was silently disabled by an unrelated rate limit. **A
+postmortem does not prevent a recurrence; only a control that can be observed to run does.**
+
+### One export, no tests, because importing it ran it
+
+`scripts/vendor-configs.mjs` is ~560 lines with a single export and no test file. Not because it was
+untestable — because it called `await main()` at module scope, so importing it executed a
+network-touching CLI. Adding the standard entry guard took it to 14 tests and **8 of 8 mutants
+killed**, with stubbed responses covering the rate-limited, 404, unreachable, and release-less-tag
+paths that cannot be reproduced on demand against a live API.
+
+> A hypothesis that failed, recorded because only the surviving kind gets written down: I expected
+> the `new URL('file://' + process.argv[1])` guard to be fragile on Windows and to have silently
+> disabled the other checkers. Tested all three invocation forms — forward slash, backslash, and
+> absolute. All three resolve correctly. The guard is sound and the concern was unfounded.
+
+### And a scope widening I caused while fixing this
+
+Refreshing with `node scripts/vendor-configs.mjs v0.134.0` and no `--set` defaults to **all** sets,
+which silently took the lock from 6 files to 12 by adding the `tsconfig` set that nothing in this
+repository `extends`. That is precisely the orphan case the tool's own wiring check exists to
+prevent — but the check asks whether anything references the destination _directory_, so a new
+orphaned set inside an already-referenced directory passes. Re-vendored with an explicit
+`--set prettier,citations --prune`.
+
+Worth noting for upstream: `--prune` drops entries from the lock but leaves the files on disk, so the
+recovery state is unhashed orphans that `--check` cannot see. The error text does say "and delete the
+files", so it is documented rather than hidden — but a flag whose safe use requires a manual second
+step will eventually be used without it.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:

--- a/engineering-configs.lock.json
+++ b/engineering-configs.lock.json
@@ -1,7 +1,7 @@
 {
   "repository": "jrmoulckers/engineering",
-  "ref": "v0.124.0",
-  "fetchedAt": "2026-08-12T17:49:23.152Z",
+  "ref": "v0.134.0",
+  "fetchedAt": "2026-08-12T19:27:28.303Z",
   "refresh": "node scripts/vendor-configs.mjs <newer-ref>",
   "files": {
     "config/engineering/prettier/index.js": {
@@ -26,7 +26,7 @@
     },
     "config/engineering/citations/check-citations.mjs": {
       "source": "scripts/check-citations.mjs",
-      "sha256": "f5f3998b277dad0c3c576eef7ef65a4a308f9bb605aff717c16e0154ca52d24a"
+      "sha256": "9fcd3bd8465e4e5ad8dc72d355ffdb51c7b4d4c34d637ddab5043ca4dfc3fc3c"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "eng:citations": "node config/engineering/citations/check-citations.mjs .",
     "eng:citations:review": "node config/engineering/citations/check-citations.mjs . --review",
     "eng:vendor:check": "node scripts/vendor-configs.mjs --check",
+    "eng:vendor:test": "node --test scripts/vendor-configs.test.mjs",
     "i18n:validate": "node scripts/i18n/validate-locale-catalogs.js && node scripts/i18n/validate-glossary.js",
     "ci:check": "npm run format:check && npm run lint && npm run type-check",
     "ci:check:quick": "node tools/ci-check-quick.js",

--- a/scripts/vendor-configs.mjs
+++ b/scripts/vendor-configs.mjs
@@ -136,23 +136,82 @@ function parseArgs(argv) {
   return { positional, flags };
 }
 
+/** Authenticated when a token is available. Unauthenticated GitHub API calls are
+ * limited to 60/hour *per IP*, and Actions runners share IPs, so the anonymous
+ * path is rate-limited far more often than it is offline. Measured while writing
+ * this: the anonymous call returned 403 with `x-ratelimit-remaining: 0`. */
+export function apiHeaders() {
+  const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+  return {
+    accept: 'application/vnd.github+json',
+    ...(token ? { authorization: `Bearer ${token}` } : {}),
+  };
+}
+
+/** Highest semver tag, compared numerically. Deliberately not by publish date:
+ * a backport wave releases newest-major first and oldest-major last, so a
+ * date sort returns the *oldest* maintained line as the frontier — perfectly
+ * anti-correlated rather than noisily wrong, and freshly computed either way. */
+export function highestSemver(tags) {
+  const parsed = tags
+    .map((tag) => ({ tag, parts: /^v(\d+)\.(\d+)\.(\d+)$/.exec(tag) }))
+    .filter((entry) => entry.parts !== null)
+    .map(({ tag, parts }) => ({ tag, key: parts.slice(1, 4).map(Number) }));
+  if (parsed.length === 0) return null;
+  return parsed.reduce((best, entry) => {
+    for (let i = 0; i < 3; i += 1) {
+      if (entry.key[i] !== best.key[i]) return entry.key[i] > best.key[i] ? entry : best;
+    }
+    return best;
+  }).tag;
+}
+
 /**
- * Report whether a newer release exists. Never throws and never fails the
- * caller: a tag pushed upstream must not turn an unrelated PR red. Returns null
- * when the answer cannot be determined, which is treated the same as "fine" —
- * an offline or rate-limited runner is not a staleness signal.
+ * Resolve the newest upstream ref, and say how the answer was reached.
+ *
+ * `releases/latest` does not compute a maximum — it reads a `make_latest` flag a
+ * maintainer sets, over the *release* population. Tags pushed without a release
+ * are invisible to it. Measured on 2026-08-12: upstream had 172 tags and 143
+ * releases, and the highest tag `v0.134.0` had no release, so the declared
+ * answer was one release behind the actual frontier. So ask both and prefer the
+ * higher, rather than trusting either alone.
+ *
+ * Never throws and never fails the caller: a tag pushed upstream must not turn
+ * an unrelated PR red. But it always returns a `reason` when it cannot answer,
+ * because a staleness check that goes quiet is indistinguishable from one that
+ * checked and found nothing — and that silence is the failure this had.
  */
-async function latestRef() {
-  try {
-    const response = await fetch(`https://api.github.com/repos/${REPO}/releases/latest`, {
-      headers: { accept: 'application/vnd.github+json' },
-    });
-    if (!response.ok) return null;
-    const body = await response.json();
-    return typeof body.tag_name === 'string' ? body.tag_name : null;
-  } catch {
-    return null;
-  }
+export async function latestRef() {
+  const read = async (path, pick) => {
+    try {
+      const response = await fetch(`https://api.github.com/repos/${REPO}/${path}`, {
+        headers: apiHeaders(),
+      });
+      if (!response.ok) {
+        const limited = response.headers.get('x-ratelimit-remaining') === '0';
+        return {
+          value: null,
+          reason: limited
+            ? `GitHub API rate limit exhausted (HTTP ${response.status}); set GITHUB_TOKEN to raise it`
+            : `GitHub API returned HTTP ${response.status} for ${path}`,
+        };
+      }
+      return { value: pick(await response.json()), reason: null };
+    } catch (error) {
+      return { value: null, reason: `could not reach the GitHub API (${error.message})` };
+    }
+  };
+
+  const release = await read('releases/latest', (body) =>
+    typeof body.tag_name === 'string' ? body.tag_name : null,
+  );
+  const tags = await read('tags?per_page=100', (body) =>
+    highestSemver(Array.isArray(body) ? body.map((entry) => entry.name) : []),
+  );
+
+  const best = highestSemver([release.value, tags.value].filter(Boolean));
+  if (best) return { ref: best, reason: null };
+  return { ref: null, reason: release.reason ?? tags.reason ?? 'no semver tag or release found' };
 }
 
 /**
@@ -292,7 +351,17 @@ async function check() {
     );
   }
 
-  const latest = await latestRef();
+  const { ref: latest, reason: staleReason } = await latestRef();
+  if (staleReason) {
+    // Naming the gap is the whole point. A silent skip prints the same green
+    // line as a successful check, so "matches the lock" reads as "and is
+    // current" -- a claim this never made and, on a rate-limited runner, could
+    // not have made. Still not fatal: an unreachable API is not a defect here.
+    process.stdout.write(
+      `\nStaleness not checked: ${staleReason}.\n` +
+        `This says nothing about whether ${lock.ref} is current.\n`,
+    );
+  }
   if (latest && latest !== lock.ref) {
     // A newer tag is not the same claim as newer content, and conflating the two
     // makes this notice a false alarm most of the time. Measured on 2026-08-12:
@@ -608,11 +677,16 @@ async function main() {
   process.stdout.write(`Recorded ref and SHA-256 of each file in ${LOCK}. Commit both.\n`);
 }
 
-try {
-  await main();
-} catch (error) {
-  if (!(error instanceof VendorError)) throw error;
-  process.stderr.write(`error: ${error.message}\n`);
-  if (error.hint) process.stderr.write(`       ${error.hint}\n`);
-  process.exitCode = 1;
+// Guarded so the module can be imported without running the tool. Without this
+// it had one export and no tests, not because it was untestable but because
+// importing it executed a network-touching CLI.
+if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href) {
+  try {
+    await main();
+  } catch (error) {
+    if (!(error instanceof VendorError)) throw error;
+    process.stderr.write(`error: ${error.message}\n`);
+    if (error.hint) process.stderr.write(`       ${error.hint}\n`);
+    process.exitCode = 1;
+  }
 }

--- a/scripts/vendor-configs.test.mjs
+++ b/scripts/vendor-configs.test.mjs
@@ -1,0 +1,155 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { apiHeaders, highestSemver, latestRef } from './vendor-configs.mjs';
+
+/** Stubs global fetch with a map of URL substring -> response descriptor. */
+function stubFetch(routes) {
+  const calls = [];
+  const original = globalThis.fetch;
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url: String(url), init });
+    const key = Object.keys(routes).find((part) => String(url).includes(part));
+    const route = key ? routes[key] : { status: 404 };
+    if (route.throws) throw new Error(route.throws);
+    return {
+      ok: route.status >= 200 && route.status < 300,
+      status: route.status,
+      headers: { get: (name) => (route.headers ?? {})[name] ?? null },
+      json: async () => route.body,
+    };
+  };
+  return {
+    calls,
+    restore: () => {
+      globalThis.fetch = original;
+    },
+  };
+}
+
+const releaseBody = (tag) => ({ tag_name: tag });
+const tagBody = (names) => names.map((name) => ({ name }));
+
+test('highestSemver compares numerically, not lexically', () => {
+  // A lexical sort puts v0.9.0 above v0.122.0, which is how a fleet-wide audit
+  // once resolved refs to the wrong tag.
+  assert.equal(highestSemver(['v0.9.0', 'v0.122.0', 'v0.15.3']), 'v0.122.0');
+});
+
+test('highestSemver ignores non-semver refs rather than throwing', () => {
+  assert.equal(highestSemver(['archive/public-consumption', 'v1.2.3']), 'v1.2.3');
+});
+
+test('highestSemver returns null when nothing parses', () => {
+  assert.equal(highestSemver([]), null);
+  assert.equal(highestSemver(['main', 'archive/x']), null);
+});
+
+test('highestSemver orders by minor and patch, not just major', () => {
+  assert.equal(highestSemver(['v0.134.0', 'v0.133.0']), 'v0.134.0');
+  assert.equal(highestSemver(['v1.0.10', 'v1.0.9']), 'v1.0.10');
+});
+
+test('apiHeaders sends a bearer token when one is present', (t) => {
+  t.after(() => {
+    delete process.env.GITHUB_TOKEN;
+  });
+  process.env.GITHUB_TOKEN = 'x';
+  assert.equal(apiHeaders().authorization, 'Bearer x');
+});
+
+test('apiHeaders omits authorization when no token is set', () => {
+  const saved = [process.env.GITHUB_TOKEN, process.env.GH_TOKEN];
+  delete process.env.GITHUB_TOKEN;
+  delete process.env.GH_TOKEN;
+  assert.equal('authorization' in apiHeaders(), false);
+  if (saved[0] !== undefined) process.env.GITHUB_TOKEN = saved[0];
+  if (saved[1] !== undefined) process.env.GH_TOKEN = saved[1];
+});
+
+test('a tag newer than releases/latest wins, which is the live upstream case', async (t) => {
+  const stub = stubFetch({
+    'releases/latest': { status: 200, body: releaseBody('v0.133.0') },
+    tags: { status: 200, body: tagBody(['v0.134.0', 'v0.133.0']) },
+  });
+  t.after(stub.restore);
+  assert.deepEqual(await latestRef(), { ref: 'v0.134.0', reason: null });
+});
+
+test('the release flag wins when tags lag, so neither source is trusted alone', async (t) => {
+  const stub = stubFetch({
+    'releases/latest': { status: 200, body: releaseBody('v2.0.0') },
+    tags: { status: 200, body: tagBody(['v1.0.0']) },
+  });
+  t.after(stub.restore);
+  assert.equal((await latestRef()).ref, 'v2.0.0');
+});
+
+test('a rate-limited response names the limit and the remedy', async (t) => {
+  const stub = stubFetch({
+    'releases/latest': { status: 403, headers: { 'x-ratelimit-remaining': '0' } },
+    tags: { status: 403, headers: { 'x-ratelimit-remaining': '0' } },
+  });
+  t.after(stub.restore);
+  const result = await latestRef();
+  assert.equal(result.ref, null);
+  assert.match(result.reason, /rate limit/);
+  assert.match(result.reason, /GITHUB_TOKEN/);
+});
+
+test('a non-rate-limit failure reports its status instead of blaming the limit', async (t) => {
+  const stub = stubFetch({
+    'releases/latest': { status: 404 },
+    tags: { status: 404 },
+  });
+  t.after(stub.restore);
+  const result = await latestRef();
+  assert.equal(result.ref, null);
+  assert.match(result.reason, /HTTP 404/);
+  assert.doesNotMatch(result.reason, /rate limit/);
+});
+
+test('an unreachable API produces a reason rather than a silent null', async (t) => {
+  const stub = stubFetch({
+    'releases/latest': { throws: 'ENOTFOUND' },
+    tags: { throws: 'ENOTFOUND' },
+  });
+  t.after(stub.restore);
+  const result = await latestRef();
+  assert.equal(result.ref, null);
+  assert.match(result.reason, /could not reach/);
+});
+
+test('one source failing does not suppress the other', async (t) => {
+  const stub = stubFetch({
+    'releases/latest': { status: 404 },
+    tags: { status: 200, body: tagBody(['v3.1.4']) },
+  });
+  t.after(stub.restore);
+  assert.deepEqual(await latestRef(), { ref: 'v3.1.4', reason: null });
+});
+
+test('a successful answer never carries a reason, so callers cannot print both', async (t) => {
+  const stub = stubFetch({
+    'releases/latest': { status: 200, body: releaseBody('v1.0.0') },
+    tags: { status: 200, body: tagBody(['v1.0.0']) },
+  });
+  t.after(stub.restore);
+  assert.equal((await latestRef()).reason, null);
+});
+
+test('both sources are queried, so a release-less tag cannot hide', async (t) => {
+  const stub = stubFetch({
+    'releases/latest': { status: 200, body: releaseBody('v1.0.0') },
+    tags: { status: 200, body: tagBody(['v1.0.0']) },
+  });
+  t.after(stub.restore);
+  await latestRef();
+  assert.equal(
+    stub.calls.some((c) => c.url.includes('releases/latest')),
+    true,
+  );
+  assert.equal(
+    stub.calls.some((c) => c.url.includes('/tags')),
+    true,
+  );
+});


### PR DESCRIPTION
## Summary

The staleness half of `eng:vendor:check` had **never worked**, and the failure printed nothing.

```
fetch(api.github.com/...)   unauthenticated
  -> HTTP 403, x-ratelimit-remaining: 0
  -> latestRef() returns null
  -> the notice block is skipped
  -> "6 vendored file(s) match ... at v0.124.0."   exit 0
```

Every link is individually defensible — not failing on an unreachable API is correct, and returning
`null` for an unknown answer is correct. The defect is that **the green line for "checked, and
current" and the green line for "could not check" are the same bytes.** Anonymous GitHub API calls
are capped at 60/hour *per IP* and Actions runners share IPs, so on CI the anonymous path is
rate-limited far more often than it is offline. It most likely never ran there.

This is a category past the one recorded earlier in this adoption: that was a notice printed every
run that nobody read. This produced **no output at all**.

The remedy is not to fail — it is to name the gap:

```
Staleness not checked: GitHub API rate limit exhausted (HTTP 403); set GITHUB_TOKEN to raise it.
This says nothing about whether v0.124.0 is current.
```

## `releases/latest` is a declaration, not a maximum

Even authenticated, it was the wrong instrument. It computes nothing — it reads a `make_latest` flag
a maintainer sets, over the **release** population:

| population | count |
| --- | --- |
| tags | 172 |
| releases | 143 |
| semver tags with no release | 28 |
| `releases/latest` | `v0.133.0` |
| **highest tag** | **`v0.134.0`** |

The highest tag has no release, so the declared answer was **one release behind the frontier, live**.
Now queries both and takes the higher, compared **numerically** — never by publish date, because a
backport wave publishes newest-major first, so a date sort returns the *oldest* maintained line as
the frontier while looking freshly computed.

## What the silence was hiding

Pinned `v0.124.0` against upstream `v0.134.0`, with the vendored citation checker at **v9 while
upstream shipped v10**. v10's change is the scanned extension set:

| | v9 | v10 |
| --- | --- | --- |
| files scanned | **806** | **4,696** |
| citations found | 141 | 170 |
| extensions | 7 | 27 |

**29 citations in `.ts`, `.kt`, `.mjs` were never checked** — in a repository that is Kotlin
Multiplatform and React, i.e. almost entirely the file types v9 skipped. `eng:citations` had been
exiting 0 over 3,890 files it never opened. All 29 are valid, which is luck, not a control.

## It is the recurrence the CI comment already describes

`ci-lint.yml` carries, from earlier in this adoption:

> a local copy declaring the same `TOOL_VERSION` as a newer upstream one is how finance ran a checker
> missing a whole check

Same repository, same file, same mechanism — because the control built to prevent the recurrence was
silently disabled by an unrelated rate limit. **A postmortem does not prevent a recurrence; only a
control that can be observed to run does.**

## One export, no tests, because importing it ran it

`scripts/vendor-configs.mjs` is ~560 lines with one export and no tests — not because it was
untestable, but because it `await main()`s at module scope, so importing it executed a
network-touching CLI. Guarded, then tested.

> **Failed hypothesis, recorded because only the surviving kind gets written down:** I expected the
> `new URL('file://' + process.argv[1])` guard to be fragile on Windows and to have silently disabled
> the other checkers. Tested forward-slash, backslash and absolute invocations — all three resolve.
> Unfounded.

## A scope widening I caused while fixing this

Refreshing with no `--set` defaults to **all** sets, silently taking the lock from 6 files to 12 by
adding a `tsconfig` set nothing here `extends`. That is the orphan case the tool's wiring check
exists to prevent — but it asks whether anything references the destination *directory*, so a new
orphaned set inside an already-referenced directory passes. Re-vendored with explicit
`--set prettier,citations --prune` and removed the six files by name.

**For upstream:** `--prune` drops lock entries but leaves the files on disk, so the recovery state is
unhashed orphans `--check` cannot see. The error text does say "and delete the files", so it is
documented rather than hidden — but a flag whose safe use requires a manual second step will
eventually be used without it.

## Issues

Refs #4029

## Testing

- [x] 14 tests, **8 of 8 mutants killed**, scorer calibrated on the unmutated tree
- [x] Stubbed fetch covers rate-limited, 404, unreachable, release-less-tag, and one-source-fails paths a live API cannot be asked to produce
- [x] Verified against the live API: authenticated resolves `v0.134.0`; anonymous reproduced the 403 that motivated this
- [x] `eng:vendor:check` clean at `v0.134.0`; `eng:citations` v10 green over 4,696 files
- [x] `workflow:security:check`, `node:version:check`, `gradle:prefetch:check`, `encoding:check` — all green
- [x] `npx eslint --max-warnings 0` + `npx prettier --check` on every changed file