### PR TITLE
fix(tools): walk every tag page instead of taking a maximum over the first

### DIFF
--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -6672,6 +6672,63 @@ recovery state is unhashed orphans that `--check` cannot see. The error text doe
 files", so it is documented rather than hidden — but a flag whose safe use requires a manual second
 step will eventually be used without it.
 
+## A maximum over a subset, and the coincidence that hid it
+
+The engineering repo advised resolving the newest ref by **sorting releases by date**. Measured
+against its own data, that advice is correct — and unfalsifiable there:
+
+```
+date-sort highest    v0.136.0
+numeric-sort highest v0.136.0
+```
+
+They agree because `jrmoulckers/engineering` maintains exactly one release line, so creation order
+and version order coincide. The advice fails the moment a repository backports: a maintenance wave
+publishes newest-major first and oldest-major last, so a date sort returns the _oldest_ maintained
+line as the frontier. finance resolves numerically for that reason and does not date-sort even as a
+tiebreak.
+
+The diagnosis attached to that advice was also inverted. It held that `v0.16.4` "sorts high under
+naive semver but is old". Numeric semver ranks it correctly — `16 < 136`. What ranks it wrongly is a
+**lexical string sort**, and a lexical sort over the live tag set does not return `v0.16.4` either:
+
+| ordering        | answer over 173 live semver tags    |
+| --------------- | ----------------------------------- |
+| numeric semver  | `v0.136.0`                          |
+| lexical string  | `v0.99.0`                           |
+| by publish date | `v0.136.0` (coincidence, see above) |
+
+`v0.16.4` ranks **118th of 173** lexically. So the named remedy is the broken one, the accused
+mechanism is the sound one, and the cited symptom belongs to neither.
+
+### The defect this turned up here
+
+Checking the claim against finance's own resolver found that it asked for `tags?per_page=100` and
+read the first page only. Upstream had **174 tags**. It had been computing a maximum over a subset.
+
+It returned the right answer anyway, which is the part worth keeping. Not because the subset was
+harmless, but because GitHub orders tags by _creation recency_ and this repository creates tags in
+ascending version order, so the newest 100 contained the maximum. Neither side guarantees that, and
+it inverts on precisely the backport case above: a wave creates low-version tags last, so page one
+would hold the oldest maintained lines.
+
+This is the tool's own thesis one layer down. A truncated page is a valid `200` with no marker in the
+body — "the whole list" and "the first hundred" are the same bytes to a caller. The resolver now
+follows `Link: rel="next"`, and a partial walk returns a **reason** rather than a smaller answer
+wearing an authoritative shape:
+
+```
+tag list exceeded 30 pages; refusing to report a maximum over a subset
+```
+
+Writing the tests surfaced a second one: when _both_ sources failed, only the release reason was
+printed. A truncated tag walk masked by an unrelated `HTTP 500` read as a plain outage. Both reasons
+are now joined.
+
+**The rule:** an off-by-one in a page size is invisible until the population crosses it, and the
+crossing is an upstream event no local gate observes. 20 tests, 8 of 8 mutants killed, calibrated on
+the unmutated tree first.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:

--- a/scripts/vendor-configs.mjs
+++ b/scripts/vendor-configs.mjs
@@ -167,6 +167,32 @@ export function highestSemver(tags) {
 }
 
 /**
+ * The `next` URL from a GitHub `Link` header, or null on the last page.
+ *
+ * Pagination on this API is opt-in and silent when ignored — a truncated page
+ * is a valid 200 with no marker in the body. Upstream passed 100 tags while
+ * this tool asked for one page of 100, so it was already computing a maximum
+ * over a subset. It returned the right answer anyway, but only because GitHub
+ * orders tags by creation recency and this repository happens to create them in
+ * ascending version order. That coincidence is not a property either side
+ * guarantees, and it inverts outright on a repository that backports: a
+ * maintenance wave creates low-version tags last, so page one would hold the
+ * *oldest* maintained lines.
+ */
+export function nextPageUrl(linkHeader) {
+  if (typeof linkHeader !== 'string') return null;
+  for (const part of linkHeader.split(',')) {
+    const match = /<([^>]+)>\s*;\s*rel="next"/.exec(part.trim());
+    if (match) return match[1];
+  }
+  return null;
+}
+
+/** Room for 3,000 tags. A cap that is reached is reported rather than treated
+ * as the end of the list, since those are the same bytes to a caller. */
+export const MAX_TAG_PAGES = 30;
+
+/**
  * Resolve the newest upstream ref, and say how the answer was reached.
  *
  * `releases/latest` does not compute a maximum — it reads a `make_latest` flag a
@@ -184,34 +210,72 @@ export function highestSemver(tags) {
 export async function latestRef() {
   const read = async (path, pick) => {
     try {
-      const response = await fetch(`https://api.github.com/repos/${REPO}/${path}`, {
+      const url = path.startsWith('https://')
+        ? path
+        : `https://api.github.com/repos/${REPO}/${path}`;
+      const response = await fetch(url, {
         headers: apiHeaders(),
       });
       if (!response.ok) {
         const limited = response.headers.get('x-ratelimit-remaining') === '0';
         return {
           value: null,
+          link: null,
           reason: limited
             ? `GitHub API rate limit exhausted (HTTP ${response.status}); set GITHUB_TOKEN to raise it`
             : `GitHub API returned HTTP ${response.status} for ${path}`,
         };
       }
-      return { value: pick(await response.json()), reason: null };
+      return {
+        value: pick(await response.json()),
+        link: response.headers.get('link'),
+        reason: null,
+      };
     } catch (error) {
-      return { value: null, reason: `could not reach the GitHub API (${error.message})` };
+      return {
+        value: null,
+        link: null,
+        reason: `could not reach the GitHub API (${error.message})`,
+      };
     }
+  };
+
+  /** Walks every page before taking a maximum. A partial read yields a reason,
+   * never a smaller answer that would read as authoritative. */
+  const readAllTags = async () => {
+    const names = [];
+    let path = 'tags?per_page=100';
+    for (let page = 0; page < MAX_TAG_PAGES; page += 1) {
+      const result = await read(path, (body) =>
+        Array.isArray(body) ? body.map((entry) => entry.name) : [],
+      );
+      if (result.reason) return { value: null, reason: result.reason };
+      names.push(...result.value);
+      const next = nextPageUrl(result.link);
+      if (!next) return { value: highestSemver(names), reason: null };
+      path = next;
+    }
+    return {
+      value: null,
+      reason: `tag list exceeded ${MAX_TAG_PAGES} pages; refusing to report a maximum over a subset`,
+    };
   };
 
   const release = await read('releases/latest', (body) =>
     typeof body.tag_name === 'string' ? body.tag_name : null,
   );
-  const tags = await read('tags?per_page=100', (body) =>
-    highestSemver(Array.isArray(body) ? body.map((entry) => entry.name) : []),
-  );
+  const tags = await readAllTags();
 
   const best = highestSemver([release.value, tags.value].filter(Boolean));
   if (best) return { ref: best, reason: null };
-  return { ref: null, reason: release.reason ?? tags.reason ?? 'no semver tag or release found' };
+  // Both failed for possibly different causes. Reporting only the first hides
+  // the other, which is the same silence at a smaller scale -- a truncated tag
+  // walk masked by an unrelated 500 reads as a plain outage.
+  const reasons = [...new Set([release.reason, tags.reason].filter(Boolean))];
+  return {
+    ref: null,
+    reason: reasons.length > 0 ? reasons.join('; ') : 'no semver tag or release found',
+  };
 }
 
 /**

--- a/scripts/vendor-configs.test.mjs
+++ b/scripts/vendor-configs.test.mjs
@@ -1,6 +1,12 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { apiHeaders, highestSemver, latestRef } from './vendor-configs.mjs';
+import {
+  apiHeaders,
+  highestSemver,
+  latestRef,
+  MAX_TAG_PAGES,
+  nextPageUrl,
+} from './vendor-configs.mjs';
 
 /** Stubs global fetch with a map of URL substring -> response descriptor. */
 function stubFetch(routes) {
@@ -152,4 +158,82 @@ test('both sources are queried, so a release-less tag cannot hide', async (t) =>
     stub.calls.some((c) => c.url.includes('/tags')),
     true,
   );
+});
+
+test('nextPageUrl finds the next link among several relations', () => {
+  const header =
+    '<https://api.github.com/repositories/1/tags?page=3>; rel="next", ' +
+    '<https://api.github.com/repositories/1/tags?page=9>; rel="last"';
+  assert.equal(nextPageUrl(header), 'https://api.github.com/repositories/1/tags?page=3');
+});
+
+test('nextPageUrl returns null on the last page and on a missing header', () => {
+  assert.equal(nextPageUrl('<https://api.github.com/x?page=1>; rel="prev"'), null);
+  assert.equal(nextPageUrl(null), null);
+  assert.equal(nextPageUrl(undefined), null);
+});
+
+test('the highest tag is found when it sits beyond the first page', async (t) => {
+  // The live failure this guards: upstream passed 100 tags while the tool asked
+  // for a single 100-entry page. It stayed correct only because GitHub returns
+  // tags newest-created first and this repo tags in ascending order. A repo that
+  // backports creates low versions last, putting the frontier on a later page.
+  const stub = stubFetch({
+    'tags?per_page=100': {
+      status: 200,
+      body: tagBody(['v0.9.0', 'v0.8.0']),
+      headers: { link: '<https://api.github.com/repos/x/y/tags?page=2>; rel="next"' },
+    },
+    'tags?page=2': { status: 200, body: tagBody(['v0.136.0', 'v0.135.0']) },
+    'releases/latest': { status: 200, body: releaseBody('v0.100.0') },
+  });
+  t.after(stub.restore);
+  assert.deepEqual(await latestRef(), { ref: 'v0.136.0', reason: null });
+  assert.ok(stub.calls.some((call) => call.url.includes('page=2')));
+});
+
+test('a later page failing does not yield a maximum over the pages that loaded', async (t) => {
+  // Returning v0.9.0 here would be a smaller answer wearing an authoritative
+  // shape -- the exact silence this tool exists to remove, one layer down.
+  const stub = stubFetch({
+    'tags?per_page=100': {
+      status: 200,
+      body: tagBody(['v0.9.0']),
+      headers: { link: '<https://api.github.com/repos/x/y/tags?page=2>; rel="next"' },
+    },
+    'tags?page=2': { status: 403, headers: { 'x-ratelimit-remaining': '0' } },
+    'releases/latest': { status: 500 },
+  });
+  t.after(stub.restore);
+  const result = await latestRef();
+  assert.equal(result.ref, null);
+  assert.match(result.reason, /rate limit exhausted/);
+  assert.match(result.reason, /HTTP 500/);
+});
+
+test('an endless next chain stops at the cap and names it', async (t) => {
+  const stub = stubFetch({
+    tags: {
+      status: 200,
+      body: tagBody(['v0.1.0']),
+      headers: { link: '<https://api.github.com/repos/x/y/tags?page=2>; rel="next"' },
+    },
+    'releases/latest': { status: 404 },
+  });
+  t.after(stub.restore);
+  const result = await latestRef();
+  assert.equal(result.ref, null);
+  assert.match(result.reason, /exceeded 30 pages/);
+  assert.match(result.reason, /HTTP 404/);
+  assert.equal(stub.calls.filter((call) => call.url.includes('tags')).length, MAX_TAG_PAGES);
+});
+
+test('a single-page tag list issues exactly one tag request', async (t) => {
+  const stub = stubFetch({
+    'tags?per_page=100': { status: 200, body: tagBody(['v0.2.0', 'v0.10.0']) },
+    'releases/latest': { status: 200, body: releaseBody('v0.2.0') },
+  });
+  t.after(stub.restore);
+  assert.deepEqual(await latestRef(), { ref: 'v0.10.0', reason: null });
+  assert.equal(stub.calls.filter((call) => call.url.includes('tags')).length, 1);
 });


### PR DESCRIPTION
## Summary

Upstream advised resolving the newest ref by **sorting releases by publish date**. Measured against
their own repository the advice is correct — and unfalsifiable there:

```
date-sort highest     v0.136.0
numeric-sort highest  v0.136.0
```

They agree because `jrmoulckers/engineering` maintains exactly one release line, so creation order
and version order coincide. It inverts the moment a repository backports: a maintenance wave
publishes newest-major first and oldest-major last, so a date sort returns the **oldest** maintained
line as the frontier, freshly computed and perfectly anti-correlated. finance resolves numerically
and does not date-sort even as a tiebreak.

The diagnosis attached to the advice was inverted too. It held that `v0.16.4` "sorts high under naive
semver but is old". Numeric semver ranks it correctly (`16 < 136`); what ranks it wrongly is a
**lexical string sort** — and lexical does not return `v0.16.4` either:

| ordering | answer over 173 live semver tags |
| --- | --- |
| numeric semver | `v0.136.0` |
| lexical string | **`v0.99.0`** |
| by publish date | `v0.136.0` (coincidence, above) |

`v0.16.4` ranks **118th of 173** lexically. The named remedy is the broken one, the accused mechanism
is the sound one, and the cited symptom belongs to neither.

## The defect that checking it exposed here

Our own resolver asked for `tags?per_page=100` and read **page one**. Upstream has **174 tags**. It
had been computing a maximum over a subset.

It returned the right answer anyway — and *why* is the part worth keeping. Not because the subset was
harmless, but because GitHub orders tags by **creation recency** and this repository creates tags in
ascending version order, so the newest 100 happened to contain the maximum. Neither side guarantees
that, and it inverts on precisely the backport case above: a wave creates low-version tags last, so
page one would hold the *oldest* maintained lines.

I'd have justified it, before measuring, as "the API returns tags sorted descending". It does not
sort by version at all.

This is the tool's own thesis one layer down, and the reason it survived the previous PR: a truncated
page is a valid `200` with **no marker in the body**, so "the whole list" and "the first hundred" are
the same bytes to a caller — the same shape as the rate-limited `null` that PR removed. An off-by-one
in a page size is invisible until the population crosses it, and the crossing is an upstream event no
local gate observes.

Now follows `Link: rel="next"`, and a partial walk returns a reason rather than a smaller answer
wearing an authoritative shape:

```
tag list exceeded 30 pages; refusing to report a maximum over a subset
```

## A second one the tests surfaced

Two of the new tests failed on first run, both for the same real cause: when **both** sources failed,
`release.reason ?? tags.reason` printed only the release reason. A truncated tag walk masked by an
unrelated `HTTP 500` read as a plain outage. Both reasons are now joined and de-duplicated.

## Verified live

```
latestRef() -> { "ref": "v0.137.0", "reason": null }
Notice: pinned at v0.134.0; newest release is v0.137.0,
        but all 6 vendored file(s) are byte-identical there.
No action needed - refreshing the ref would produce no diff.
```

Upstream moved three releases during this turn, which the staleness notice now reports correctly —
including that the content is unchanged, so it names the gap without manufacturing a bump.

## Issues

Refs #4029

## Testing

- [x] **20 tests, 8 of 8 new mutants killed**, scorer calibrated on the unmutated tree first
- [x] Mutants cover: inverted next-guard, cap off-by-one, dropped later pages, `rel="prev"`, ignored page failure, first-reason-only, link type guard, never-paginate
- [x] Page-2 maximum, endless-chain cap, single-page one-request, and later-page-failure paths all asserted
- [x] Resolved the live 174-ref tag set end to end
- [x] `eng:vendor:check`, `eng:citations` (v10, 27 extensions), `workflow:security:check`, `node:version:check`, `encoding:check` — green
- [x] `npx eslint --max-warnings 0` + `npx prettier --check` on every changed file