### PR TITLE
fix(tools): check engines.node against the dependency tree it describes

### DIFF
--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -6729,6 +6729,87 @@ are now joined.
 crossing is an upstream event no local gate observes. 20 tests, 8 of 8 mutants killed, calibrated on
 the unmutated tree first.
 
+## The hole in the middle of an open-ended range
+
+An upstream session argued that a declared `engines.node` cannot be repaired by the declaring
+repository, because npm treats the field as advisory: `EBADENGINE` is a warning, the install
+proceeds, and `engine-strict` belongs to the _consumer_. Their conclusion — **a severity you do not
+own cannot be promoted** — is correct for a publisher. It does not hold here, because finance is the
+consumer of its own manifest.
+
+Their narrowing suggestion does not survive either. `^20` is not "the same claim, honestly bounded":
+
+| range  | 20.0.0 | 22.0.0    | 24.3.0    |
+| ------ | ------ | --------- | --------- |
+| `>=20` | true   | true      | true      |
+| `^20`  | true   | **false** | **false** |
+
+`^20` is `>=20.0.0 <21.0.0`. It excludes two majors rather than narrowing a claim about them.
+
+### What measuring the field actually found
+
+finance declared `engines.node: ">=22.0.0"`. Checking that against the `engines` its own 451
+dependency declarations state:
+
+| probed      | dependencies rejecting it |
+| ----------- | ------------------------- |
+| 22.0.0      | **49**                    |
+| 22.11.0     | 48                        |
+| 22.12.0     | 14                        |
+| **22.23.0** | **0**                     |
+| **23.9.0**  | **20**                    |
+| 24.0.0      | 0                         |
+
+Two separate falsehoods, in opposite directions from the one being discussed:
+
+1. **The floor was below the real floor.** `>=22.22.1` and `^22.13.0` bounds put the true minimum at
+   **22.23.0**, not 22.0.0.
+2. **The range has a hole.** Twenty packages declare `^20.19.0 || ^22.13.0 || >=24.0.0`, skipping
+   Node 23 entirely — it is an odd, non-LTS line. An open-ended `>=22.0.0` claims 23 works. It does
+   not, and nothing above it is monotonic: 23 fails while 24 is clean.
+
+The thread until now had treated a range as an interval with a tested floor and an asserted top. This
+one is **discontinuous**, and neither "exercise the top" nor "narrow to what you tested" describes the
+defect. Corrected to `>=22.23.0 <23 || >=24`.
+
+None of it was visible because every workflow pins `node-version: 22`, which resolves to the latest
+22.x. The floor is never installed at its own boundary.
+
+### The check broke the checker
+
+Applying the corrected range immediately failed `node:version:check` with _"Node 24 is outside
+`>=22.23.0 <23 || >=24`"_. Both range predicates in that tool were hand-rolled: they read the first
+`>=` and the first `<` out of the string, so on a `||` range they took the bound from one alternative
+and the ceiling from another. `enginesAdmitsAbove` had the mirror bug — it asked "is there no upper
+bound", answered "no majors above", and would have **silently retired** the requirement that a job
+exercise them.
+
+This is the rule coined earlier in this adoption, recurring in the tool that coined it: _a control
+validated only against the shape that motivated it inherits that shape's blind spots._ The comment
+above the function said it "understands the forms this repository uses" — accurate, and precisely the
+defect. Range logic is now delegated to `semver`, added as an explicit devDependency rather than
+reached for transitively.
+
+### What was deliberately not done
+
+`engine-strict=true` in `.npmrc` would make finance's own declaration binding on finance, which is
+the promotion the upstream session said was unavailable. It was measured and declined:
+
+```
+latest Node 22 = v22.23.2      declared floor = 22.23.0      margin = 2 patch releases
+```
+
+Enabling it makes every install depend on the runner resolving `22` to a patch level above a floor it
+clears by two releases — an upstream event no local gate observes, which is the exact failure class
+this PR removed elsewhere. The severity was promoted instead in the place finance actually owns: from
+a warning npm prints and discards to a **fatal repository check** that compares the declaration
+against the dependency tree on every run.
+
+**The rule:** an advisory field is not checkable against itself, but it is checkable against the tree
+it describes. 31 tests, 9 of 10 mutants killed; the survivor is reported below as equivalent —
+`semver.satisfies` returns `false` rather than throwing on an invalid range, so the `validRange`
+guard has no observable effect and is retained for intent.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,11 +25,12 @@
         "husky": "^9.1.7",
         "lint-staged": "^17.0.8",
         "prettier": "^3.9.1",
+        "semver": "^7.7.4",
         "turbo": "^2.10.0",
         "typescript-eslint": "^8.62.0"
       },
       "engines": {
-        "node": ">=22.0.0"
+        "node": ">=22.23.0 <23 || >=24"
       }
     },
     "apps/web": {
@@ -6892,25 +6893,6 @@
       },
       "funding": {
         "url": "https://ko-fi.com/dangreen"
-      }
-    },
-    "node_modules/git-raw-commits/node_modules/conventional-commits-parser": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
-      "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@simple-libs/stream-utils": "^1.2.0",
-        "meow": "^13.0.0"
-      },
-      "bin": {
-        "conventional-commits-parser": "dist/cli/index.js"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/git-raw-commits/node_modules/meow": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6895,6 +6895,25 @@
         "url": "https://ko-fi.com/dangreen"
       }
     },
+    "node_modules/git-raw-commits/node_modules/conventional-commits-parser": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
+      "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@simple-libs/stream-utils": "^1.2.0",
+        "meow": "^13.0.0"
+      },
+      "bin": {
+        "conventional-commits-parser": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/git-raw-commits/node_modules/meow": {
       "version": "13.2.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "url": "https://github.com/jrmoulckers/finance.git"
   },
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.23.0 <23 || >=24"
   },
   "packageManager": "npm@10.9.4",
   "overrides": {
@@ -124,6 +124,7 @@
     "husky": "^9.1.7",
     "lint-staged": "^17.0.8",
     "prettier": "^3.9.1",
+    "semver": "^7.7.4",
     "turbo": "^2.10.0",
     "typescript-eslint": "^8.62.0"
   },

--- a/tools/check-node-version-consistency.mjs
+++ b/tools/check-node-version-consistency.mjs
@@ -16,9 +16,10 @@
  * do not fail the check.
  */
 
-import { readFileSync, readdirSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import semver from 'semver';
 
 const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const workflowDirectory = join(repositoryRoot, '.github', 'workflows');
@@ -78,19 +79,22 @@ export function pinMajor(value) {
 /**
  * True when `major` falls inside an `engines.node` range.
  *
- * Understands the lower/upper bound forms this repository uses. An unparseable
- * range returns `null` -- undecided, never a violation, so a form the check
- * cannot read stays silent instead of failing a tree it cannot judge.
+ * This previously read the first `>=` and the first `<` out of the string, which
+ * was correct for every form the repository then used and silently wrong for the
+ * first one it didn't: given `>=22.23.0 <23 || >=24` it took the bound from the
+ * first alternative and the ceiling from the second, and rejected Node 24. A
+ * control validated only against the shape that motivated it inherits that
+ * shape's blind spots, so range logic is delegated to `semver` rather than
+ * approximated here.
+ *
+ * An unparseable range returns `null` -- undecided, never a violation, so a form
+ * the check cannot read stays silent instead of failing a tree it cannot judge.
  */
 export function majorSatisfiesEngines(major, range) {
   if (!major || !range) return null;
-  const lower = String(range).match(/>=?\s*v?(\d+)/);
-  if (!lower) return null;
-  const upper = String(range).match(/<=?\s*v?(\d+)/);
-  const value = Number(major);
-  if (value < Number(lower[1])) return false;
-  if (upper && value > Number(upper[1])) return false;
-  return true;
+  const text = String(range);
+  if (!semver.validRange(text)) return null;
+  return semver.intersects(`${Number(major)}.x`, text);
 }
 
 /**
@@ -175,11 +179,95 @@ export function findNodeVersionMismatches(file, text, expectedMajor) {
  */
 export function enginesAdmitsAbove(range, expectedMajor) {
   if (!range || !expectedMajor) return false;
-  const lowerBoundOnly = /^\s*>=?\s*v?\d+/.test(range);
-  const hasUpperBound = /<\s*v?\d+/.test(range);
-  return lowerBoundOnly && !hasUpperBound;
+  const text = String(range);
+  if (!semver.validRange(text)) return false;
+  // Not "has no upper bound": `>=22.23.0 <23 || >=24` has one and still admits
+  // 24. Reading the ceiling off the first alternative would answer "no majors
+  // above", silently retiring the requirement that some job exercise them.
+  const base = Number(expectedMajor);
+  for (let major = base + 1; major <= base + 20; major += 1) {
+    if (semver.intersects(`${major}.x`, text)) return true;
+  }
+  return false;
 }
 
+/**
+ * Node versions worth probing for a range claim.
+ *
+ * A declared range is only ever wrong at a boundary some package states, so the
+ * probe set is every literal version appearing in a dependency's own range, plus
+ * each major boundary. Sampling a fixed grid instead would step over exactly the
+ * `>=22.22.1` style bound that makes the claim false.
+ */
+export function probeVersions(dependencyRanges, lowMajor = 18, highMajor = 30) {
+  const versions = new Set();
+  for (let major = lowMajor; major <= highMajor; major += 1) versions.add(`${major}.0.0`);
+  for (const range of dependencyRanges) {
+    for (const match of String(range).matchAll(/(\d+)\.(\d+)\.(\d+)/g)) {
+      versions.add(`${match[1]}.${match[2]}.${match[3]}`);
+    }
+  }
+  return [...versions].filter((version) => semver.valid(version));
+}
+
+/**
+ * Versions the declared range admits but an installed dependency rejects.
+ *
+ * `engines` is advisory in npm's default configuration -- `EBADENGINE` is a
+ * warning and the install proceeds -- so a false range produces no failure
+ * anywhere until a consumer sets `engine-strict`. That makes this the one place
+ * the claim can be checked against something other than itself.
+ */
+export function findAdmittedIncompatibilities(declared, dependencies) {
+  if (!declared || !semver.validRange(declared)) return [];
+  const usable = dependencies.filter((dep) => dep.range && semver.validRange(dep.range));
+  const admitted = [];
+  for (const version of probeVersions(usable.map((dep) => dep.range))) {
+    if (!semver.satisfies(version, declared)) continue;
+    const failing = usable.filter((dep) => !semver.satisfies(version, dep.range));
+    if (failing.length > 0) {
+      admitted.push({
+        version,
+        count: failing.length,
+        ranges: [...new Set(failing.map((dep) => dep.range))].sort().slice(0, 3),
+      });
+    }
+  }
+  return admitted.sort((a, b) => semver.compare(a.version, b.version));
+}
+
+/** Every installed dependency that states an `engines.node`, walked from disk. */
+export function collectDependencyEngines(root, depth = 0) {
+  const found = [];
+  if (depth > 4 || !existsSync(root)) return found;
+  let entries;
+  try {
+    entries = readdirSync(root, { withFileTypes: true });
+  } catch {
+    return found;
+  }
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const full = join(root, entry.name);
+    if (entry.name === 'node_modules') {
+      found.push(...collectDependencyEngines(full, depth + 1));
+      continue;
+    }
+    if (entry.name.startsWith('@')) {
+      found.push(...collectDependencyEngines(full, depth));
+      continue;
+    }
+    try {
+      const manifest = JSON.parse(readFileSync(join(full, 'package.json'), 'utf8'));
+      const range = manifest?.engines?.node;
+      if (typeof range === 'string') found.push({ name: manifest.name ?? entry.name, range });
+    } catch {
+      /* not a package, or unreadable -- neither is this check's business */
+    }
+    found.push(...collectDependencyEngines(join(full, 'node_modules'), depth + 1));
+  }
+  return found;
+}
 function main() {
   const expectedMajor = parseNvmrc(readFileSync(join(repositoryRoot, '.nvmrc'), 'utf8'));
   if (!expectedMajor) {
@@ -217,6 +305,27 @@ function main() {
   }
 
   const notices = [];
+  const modules = join(repositoryRoot, 'node_modules');
+  if (!existsSync(modules)) {
+    // Never silently skip: an absent tree and a clean one are the same exit code.
+    notices.push('node_modules is absent, so engines.node was not checked against dependencies.');
+  } else {
+    const dependencies = collectDependencyEngines(modules);
+    const admitted = findAdmittedIncompatibilities(engines?.node, dependencies);
+    if (admitted.length > 0) {
+      const worst = admitted[0];
+      violations.push(
+        `package.json engines.node is "${engines.node}", which admits Node ${worst.version}, ` +
+          `but ${worst.count} installed dependenc(ies) declare themselves incompatible there ` +
+          `(e.g. ${worst.ranges.join(', ')}). ${admitted.length} admitted version(s) fail this way. ` +
+          `Narrow engines.node to what the dependency tree actually supports.`,
+      );
+    } else {
+      notices.push(
+        `engines.node "${engines?.node}" admits no version rejected by any of ${dependencies.length} dependency declaration(s).`,
+      );
+    }
+  }
   const runningMajor = process.versions.node.split('.')[0];
   if (runningMajor !== expectedMajor) {
     notices.push(

--- a/tools/check-node-version-consistency.test.mjs
+++ b/tools/check-node-version-consistency.test.mjs
@@ -5,15 +5,17 @@ import test from 'node:test';
 import { fileURLToPath } from 'node:url';
 
 import {
-  RANGE_MARKER,
   enginesAdmitsAbove,
   exercisedMajorsAbove,
-  findRangeExerciseViolations,
+  findAdmittedIncompatibilities,
   findNodeVersionMismatches,
   findNodeVersionPins,
-  parseNvmrc,
+  findRangeExerciseViolations,
   majorSatisfiesEngines,
+  parseNvmrc,
   pinMajor,
+  probeVersions,
+  RANGE_MARKER,
 } from './check-node-version-consistency.mjs';
 
 const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
@@ -185,4 +187,85 @@ test('the repository declares a range and exercises it', () => {
     exercisedMajorsAbove(files, expected).length > 0,
     'engines.node claims majors above .nvmrc but no workflow runs one',
   );
+});
+
+test('majorSatisfiesEngines reads every alternative, not the first bound it sees', () => {
+  // The regression: reading the first `>=` and the first `<` out of
+  // `>=22.23.0 <23 || >=24` took the ceiling from the wrong alternative and
+  // rejected Node 24, which is the major the range exists to admit.
+  const range = '>=22.23.0 <23 || >=24';
+  assert.equal(majorSatisfiesEngines('24', range), true);
+  assert.equal(majorSatisfiesEngines('22', range), true);
+  assert.equal(majorSatisfiesEngines('23', range), false);
+  assert.equal(majorSatisfiesEngines('20', range), false);
+});
+
+test('majorSatisfiesEngines stays undecided on a range it cannot parse', () => {
+  assert.equal(majorSatisfiesEngines('22', 'lts/*'), null);
+  assert.equal(majorSatisfiesEngines('22', ''), null);
+  assert.equal(majorSatisfiesEngines(null, '>=22'), null);
+});
+
+test('enginesAdmitsAbove is not "has no upper bound"', () => {
+  assert.equal(enginesAdmitsAbove('>=22.23.0 <23 || >=24', '22'), true);
+  assert.equal(enginesAdmitsAbove('>=22.0.0 <23', '22'), false);
+  assert.equal(enginesAdmitsAbove('>=22.0.0', '22'), true);
+  assert.equal(enginesAdmitsAbove('lts/*', '22'), false);
+});
+
+test('probeVersions samples the bounds dependencies actually state', () => {
+  const versions = probeVersions(['>=22.22.1', '^20.19.0 || ^22.13.0 || >=24']);
+  // A fixed grid of major boundaries steps straight over 22.22.1, which is the
+  // bound that makes the claim false.
+  assert.ok(versions.includes('22.22.1'));
+  assert.ok(versions.includes('20.19.0'));
+  assert.ok(versions.includes('24.0.0'));
+});
+
+test('findAdmittedIncompatibilities names a version the range admits and a dependency rejects', () => {
+  const admitted = findAdmittedIncompatibilities('>=22.0.0', [
+    { name: 'a', range: '>=22.22.1' },
+    { name: 'b', range: '>=22.0.0' },
+  ]);
+  assert.ok(admitted.length > 0);
+  assert.equal(admitted[0].version, '22.0.0');
+  assert.equal(admitted[0].count, 1);
+  assert.deepEqual(admitted[0].ranges, ['>=22.22.1']);
+});
+
+test('findAdmittedIncompatibilities reports the lowest failing version first', () => {
+  const admitted = findAdmittedIncompatibilities('>=20.0.0', [{ name: 'a', range: '>=24.0.0' }]);
+  assert.equal(admitted[0].version, '20.0.0');
+  assert.ok(admitted.every((entry, i) => i === 0 || entry.version >= admitted[0].version));
+});
+
+test('findAdmittedIncompatibilities is silent when the range is honest', () => {
+  assert.deepEqual(
+    findAdmittedIncompatibilities('>=22.23.0 <23 || >=24', [
+      { name: 'a', range: '>=22.22.1' },
+      { name: 'b', range: '^20.19.0 || ^22.13.0 || >=24' },
+    ]),
+    [],
+  );
+});
+
+test('findAdmittedIncompatibilities ignores unreadable inputs rather than throwing', () => {
+  assert.deepEqual(findAdmittedIncompatibilities('lts/*', [{ name: 'a', range: '>=24' }]), []);
+  assert.deepEqual(findAdmittedIncompatibilities(undefined, [{ name: 'a', range: '>=24' }]), []);
+  // A dependency whose range is unparseable cannot accuse the declaration.
+  assert.deepEqual(
+    findAdmittedIncompatibilities('>=22.0.0', [{ name: 'a', range: 'garbage' }]),
+    [],
+  );
+});
+test('findAdmittedIncompatibilities sorts by version, not by probe order', () => {
+  // Probing walks the major grid first and appends dependency-stated bounds
+  // after it, so an unsorted result reports 22.22.1 last -- below every version
+  // printed before it. The caller shows admitted[0] as "the lowest that fails".
+  const admitted = findAdmittedIncompatibilities('>=22.0.0', [
+    { name: 'a', range: '>=22.22.1' },
+    { name: 'b', range: '>=30.0.0' },
+  ]);
+  assert.equal(admitted[0].version, '22.0.0');
+  assert.equal(admitted[1].version, '22.22.1');
 });


### PR DESCRIPTION
## Summary

An upstream session argued that a declared `engines.node` cannot be repaired by the declaring
repository: npm treats the field as advisory, `EBADENGINE` is a warning, the install proceeds, and
`engine-strict` belongs to the **consumer**. Their conclusion — *a severity you do not own cannot be
promoted* — is correct for a publisher, and does not hold here, because finance is the consumer of
its own manifest.

Their narrowing suggestion doesn't survive either. `^20` is `>=20.0.0 <21.0.0`:

| range | 20.0.0 | 22.0.0 | 24.3.0 |
| --- | --- | --- | --- |
| `>=20` | true | true | true |
| `^20` | true | **false** | **false** |

It excludes two majors rather than honestly bounding a claim about them.

## What measuring the field found

finance declared `engines.node: ">=22.0.0"`. Against the `engines` its own **451** installed
dependency declarations state:

| probed | dependencies rejecting it |
| --- | --- |
| 22.0.0 | **49** |
| 22.11.0 | 48 |
| 22.12.0 | 14 |
| **22.23.0** | **0** |
| **23.9.0** | **20** |
| 24.0.0 | 0 |

Two falsehoods, and neither is the "untested upper half" this thread had been about:

1. **The floor was below the real floor.** `>=22.22.1` and `^22.13.0` bounds put the true minimum at
   **22.23.0**.
2. **The range has a hole.** 20 packages declare `^20.19.0 || ^22.13.0 || >=24.0.0`, skipping Node 23
   — an odd, non-LTS line. `>=22.0.0` claims 23 works; it fails, while 24 is clean. **Nothing above
   the floor is monotonic.**

The thread had treated a range as an interval with a tested floor and an asserted top. This one is
**discontinuous**, so neither "exercise the top" nor "narrow to what you tested" describes it.
Corrected to `>=22.23.0 <23 || >=24`.

It was invisible because every workflow pins `node-version: 22`, which resolves to the latest 22.x —
**the declared floor is never installed at its own boundary.**

## Applying the correction broke the checker

`node:version:check` immediately failed with *"Node 24 is outside `>=22.23.0 <23 || >=24`"*. Both
range predicates were hand-rolled: they read the first `>=` and the first `<` out of the string, so on
a `||` range they took the bound from one alternative and the ceiling from another.

`enginesAdmitsAbove` had the mirror bug — it asked "is there no upper bound", would have answered "no
majors above" for a range that admits them, and **silently retired** the requirement that some job
exercise them. A weakening, not a failure.

This is the rule coined earlier in this adoption recurring in the tool that coined it: *a control
validated only against the shape that motivated it inherits that shape's blind spots.* The docstring
said it "understands the forms this repository uses" — accurate, and exactly the defect.

## Dependency added

**`semver` (devDependency, `^7.7.4`).** It was already resolvable transitively and the first draft
used it that way — relying on a package the manifest doesn't declare is the same unstated-assumption
class this PR fixes, so it is now explicit. Evaluating `||`-composed caret ranges is precisely what it
exists for, and hand-rolling it is what produced both bugs above.

## What was deliberately not done

`engine-strict=true` would make finance's declaration binding on finance — the promotion the upstream
session said was unavailable. Measured and declined:

```
latest Node 22 = v22.23.2     declared floor = 22.23.0     margin = 2 patch releases
```

It would make every install depend on the runner resolving `22` to a patch level it clears by two
releases — an upstream event no local gate observes, which is the failure class removed in #4236 and
#4237. The severity is promoted where finance owns it instead: from a warning npm prints and discards
to a **fatal repository check** comparing the declaration against the tree on every run.

**The rule:** an advisory field is not checkable against itself, but it is checkable against the tree
it describes.

## Issues

Refs #4029

## Testing

- [x] Checker **calibrated on the uncorrected tree first** — exit 1 naming `22.0.0` and 49 rejecting dependencies — then the fix applied
- [x] **31 tests; 9 of 10 mutants killed.** The survivor is reported **equivalent**, not rounded up: `semver.satisfies` returns `false` rather than throwing on an invalid range, so the `validRange` guard has no observable effect (retained for intent)
- [x] Mutants cover both rewritten predicates, probe-set construction, sort order, and the incompatibility filter
- [x] `node:version:check`, `eng:vendor:check`, `eng:citations`, `workflow:security:check`, `encoding:check`, `gradle:prefetch:check` — green
- [x] `npx eslint --max-warnings 0` + `npx prettier --check` on every changed file