### PR TITLE
feat(lint): enable ESLint 10-compatible React Hooks rules

### DIFF
--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -6887,6 +6887,115 @@ Node runtime pins agree with .nvmrc (22): 37 pin(s) = 36 literal + 1 marked exer
 A denominator names how many; the metric names of what; and a partition has to
 sum, or one of its parts is invisible.
 
+## A lint that could not fail: 601 `.tsx` files, zero React rules
+
+Upstream sent a `--print-config` probe with the principle that _a passing lint is evidence
+about the rules that ran, not the rules that should have_. Run against finance it found
+something larger than the case it was written for.
+
+### The premise correction first
+
+The message opened "your deliberate `>=0.8.0 <0.9.0` pin is now costing you more than it
+saves." finance has **zero `@jrmoulckers/*` declarations** — none in `package.json`, none in
+any workspace manifest, none in `package-lock.json`, no range to widen. The pin belongs to a
+different consumer. The advice about the `[0.9.0, 0.12.0)` window is correct and was verified
+against the published manifests; it is simply addressed to the wrong repository.
+
+### What the probe found
+
+| measurement                   | value |
+| ----------------------------- | ----- |
+| `.tsx` files in the repo      | 601   |
+| rules loaded on a `.tsx` file | 93    |
+| `react/*` rules               | 0     |
+| `react-hooks/*` rules         | 0     |
+| `jsx-a11y/*` rules            | 0     |
+
+Rule counts by tier — apps/web 93, services 92, tools/root 87 — are strict subsets of each
+other, so the tiering is deliberate and has no accidental holes. The React coverage is not a
+hole in the tiering; the plugins were never installed.
+
+### The binding constraint is a peer range, not a token
+
+The standing description of this blocker in earlier sections of this document — "171
+`jsx-a11y/no-redundant-roles` errors, gated on a `read:packages` grant" — is **stale**. It was
+measured before finance moved to ESLint 10. Re-measured today against `eslint@10.8.1`:
+
+| plugin                      | latest | peer `eslint`    | installs?         |
+| --------------------------- | ------ | ---------------- | ----------------- |
+| `eslint-plugin-react`       | 7.37.5 | `… \|\| ^9.7`    | **no** — ERESOLVE |
+| `eslint-plugin-jsx-a11y`    | 6.10.2 | `… \|\| ^9`      | **no** — ERESOLVE |
+| `eslint-plugin-react-hooks` | 7.1.1  | `… \|\| ^10.0.0` | yes               |
+
+Those error counts are unreachable: the rules cannot be loaded at all. The blocker changed
+identity while the description of it did not — which is upstream's own stale-denominator
+lesson applied to this document.
+
+### What landed
+
+`eslint-plugin-react-hooks@7.1.1` is the one plugin that supports ESLint 10. Its
+`recommended-latest` config declares **17 rules** (an earlier note in this document said 29;
+that was the plugin's total rule export, not the recommended set). Measured across 2,326
+linted files:
+
+| partition                | count                         |
+| ------------------------ | ----------------------------- |
+| rules at zero violations | 10 — **enabled**              |
+| rules with violations    | 7 — not enabled, counts below |
+
+    set-state-in-effect            98
+    exhaustive-deps                34
+    preserve-manual-memoization    21
+    refs                           15
+    rules-of-hooks                  3
+    immutability                    2
+    purity                          2
+
+The 10 clean rules are enabled as `error`/`warn` at their upstream severities and `apps/web`
+lints at `--max-warnings 0` with exit 0. The 7 are listed in `eslint.config.mjs` itself with
+their counts, because a narrowing that is not stated in the artifact becomes a ratchet nobody
+can audit.
+
+### Two findings from the rules that were not enabled
+
+**A false positive from name shape.** `apps/web/e2e/fixtures.ts:298` is flagged by
+`rules-of-hooks` for calling `use`. It is Playwright's fixture callback, not React's `use`
+hook — the rule matches an identifier, and an identifier is a shape, not a referent. This is
+the same class as a 40-hex string that parses as a SHA and resolves to nothing. The plugin is
+therefore scoped to `apps/web/src/**`, not `apps/web/**`, and the scope carries a comment
+saying why.
+
+**Two real conditional hooks.** `apps/web/src/pages/HouseholdPage.tsx:3596` and `:3608` call
+`useGoals()` and `useTransactions()` inside `try { } catch { }`. A hook that can throw partway
+through render breaks React's hook ordering for every subsequent hook in the component. These
+are genuine latent defects, found by a rule that has never run in this repository, in a file
+of 3,600+ lines. Fixing them is a design change to the underlying hooks and is filed as
+follow-up rather than bundled into an adoption change.
+
+So of the 3 `rules-of-hooks` hits, 1 is a false positive and 2 are real bugs — a 67% true
+positive rate on a rule that was worth turning on for exactly that reason.
+
+### A correction to last turn's lock diagnosis
+
+Last turn attributed the pruning of the nested
+`git-raw-commits/node_modules/conventional-commits-parser@6.4.0` entry to
+`npm install --package-lock-only`. That was wrong. A plain `npm install --save-dev` pruned it
+identically this turn. The variable is not the flag, it is the **npm version**: local is npm
+11.16.0 on Node 24, CI resolves `node-version: 22`. The repository already prints this
+mismatch as a notice on every run.
+
+The remedy is unchanged and is now confirmed as the general one: let npm generate the lock,
+then restore the pruned block verbatim from `origin/main` and require the diff against `main`
+to show **zero removed entries** before pushing. This turn: 51 lines added, 0 removed,
+`npm ci` exit 0.
+
+### For the engineering repo
+
+If `@jrmoulckers/eslint-config` declares `eslint-plugin-react` or `eslint-plugin-jsx-a11y` as
+peers, **the preset cannot install in any ESLint 10 consumer**. This is not specific to
+finance and is not something a consumer can work around locally — the upstream plugins cap
+below `^10`. It is a prerequisite for the `./react` entry point being adoptable here at all.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,6 +2,7 @@
 
 import js from '@eslint/js';
 import globals from 'globals';
+import reactHooks from 'eslint-plugin-react-hooks';
 import tseslint from 'typescript-eslint';
 
 const moneyTemplateRule = {
@@ -161,6 +162,32 @@ export default [
     files: ['apps/web/**/*.{ts,tsx}'],
     rules: {
       'finance/no-hardcoded-date-locale': 'error',
+    },
+  },
+  // React Hooks rules (ENG-WEB-004). Scoped to apps/web/src: apps/web/e2e is
+  // Playwright, whose `use()` fixture callback is name-matched by
+  // react-hooks/rules-of-hooks even though it is not React's `use` hook.
+  //
+  // Only the rules that are already at zero violations are enabled. The
+  // remaining 7 of the plugin's 17 recommended-latest rules are NOT enabled;
+  // measured counts across 2,326 linted files are recorded in
+  // docs/guides/engineering-practice-adoption.md and tracked as follow-up work:
+  //   set-state-in-effect 98, exhaustive-deps 34, preserve-manual-memoization 21,
+  //   refs 15, rules-of-hooks 3, immutability 2, purity 2.
+  {
+    files: ['apps/web/src/**/*.{ts,tsx}'],
+    plugins: { 'react-hooks': reactHooks },
+    rules: {
+      'react-hooks/config': 'error',
+      'react-hooks/error-boundaries': 'error',
+      'react-hooks/gating': 'error',
+      'react-hooks/globals': 'error',
+      'react-hooks/incompatible-library': 'warn',
+      'react-hooks/set-state-in-render': 'error',
+      'react-hooks/static-components': 'error',
+      'react-hooks/unsupported-syntax': 'warn',
+      'react-hooks/use-memo': 'error',
+      'react-hooks/void-use-memo': 'error',
     },
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6896,25 +6896,6 @@
         "url": "https://ko-fi.com/dangreen"
       }
     },
-    "node_modules/git-raw-commits/node_modules/conventional-commits-parser": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
-      "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@simple-libs/stream-utils": "^1.2.0",
-        "meow": "^13.0.0"
-      },
-      "bin": {
-        "conventional-commits-parser": "dist/cli/index.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/git-raw-commits/node_modules/meow": {
       "version": "13.2.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@commitlint/config-conventional": "^21.0.2",
         "@eslint/js": "^10.0.1",
         "eslint": "^10.6.0",
+        "eslint-plugin-react-hooks": "^7.1.1",
         "globals": "^17.11.0",
         "husky": "^9.1.7",
         "js-yaml": "^4.3.1",
@@ -6376,6 +6377,26 @@
         }
       }
     },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "9.1.2",
       "dev": true,
@@ -7079,6 +7100,23 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hermes-estree": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hermes-parser": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.25.1"
       }
     },
     "node_modules/html-encoding-sniffer": {
@@ -10619,6 +10657,19 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "packages/design-tokens": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6896,6 +6896,25 @@
         "url": "https://ko-fi.com/dangreen"
       }
     },
+    "node_modules/git-raw-commits/node_modules/conventional-commits-parser": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
+      "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@simple-libs/stream-utils": "^1.2.0",
+        "meow": "^13.0.0"
+      },
+      "bin": {
+        "conventional-commits-parser": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/git-raw-commits/node_modules/meow": {
       "version": "13.2.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "@commitlint/config-conventional": "^21.0.2",
     "@eslint/js": "^10.0.1",
     "eslint": "^10.6.0",
+    "eslint-plugin-react-hooks": "^7.1.1",
     "globals": "^17.11.0",
     "husky": "^9.1.7",
     "js-yaml": "^4.3.1",


### PR DESCRIPTION
## Summary

finance has **601 `.tsx` files** and was loading **0 `react/*`, 0 `react-hooks/*`, 0 `jsx-a11y/*`** rules. Found by running upstream's `--print-config` probe, on the principle that *a passing lint is evidence about the rules that ran, not the rules that should have.*

## The blocker is a peer range, not the packages token

The standing description of this blocker in the adoption doc — "171 `jsx-a11y/no-redundant-roles` errors, gated on `read:packages`" — was **stale**, measured before finance moved to ESLint 10. Re-measured against `eslint@10.8.1`:

| plugin | latest | peer `eslint` | installs? |
| --- | --- | --- | --- |
| `eslint-plugin-react` | 7.37.5 | `… \|\| ^9.7` | **no** — ERESOLVE |
| `eslint-plugin-jsx-a11y` | 6.10.2 | `… \|\| ^9` | **no** — ERESOLVE |
| `eslint-plugin-react-hooks` | 7.1.1 | `… \|\| ^10.0.0` | yes |

Those error counts are unreachable — the rules cannot load at all.

## Changes

- Add `eslint-plugin-react-hooks@^7.1.1`.
- Enable the **10 of 17** `recommended-latest` rules that are already at zero violations across 2,326 linted files. The other 7 are listed in `eslint.config.mjs` **with their measured counts** rather than silently omitted: `set-state-in-effect` 98, `exhaustive-deps` 34, `preserve-manual-memoization` 21, `refs` 15, `rules-of-hooks` 3, `immutability` 2, `purity` 2.
- Scope to `apps/web/src/**`, not `apps/web/**`: `apps/web/e2e/fixtures.ts:298` is **Playwright's `use()` fixture callback**, name-matched by `rules-of-hooks` but not React's `use` hook. A rule matches an identifier, and an identifier is a shape, not a referent.
- Document the measurements and two corrections in `docs/guides/engineering-practice-adoption.md`.

## Two real bugs found

`HouseholdPage.tsx:3596` and `:3608` call `useGoals()` / `useTransactions()` inside `try/catch`. A hook that throws mid-render breaks React's hook ordering for every subsequent hook. Filed as #4241 — the fix is a design change to the underlying hooks, not appropriate to bundle here.

So of 3 `rules-of-hooks` hits: 1 false positive, 2 real defects.

## Correction to the previous lock diagnosis

The last PR attributed pruning of the nested `git-raw-commits/node_modules/conventional-commits-parser@6.4.0` entry to `npm install --package-lock-only`. Wrong — a plain `npm install --save-dev` pruned it identically. The variable is the **npm version** (local npm 11.16.0 / Node 24 vs CI Node 22), which the repo already prints as a notice every run. Lock diff here: **51 lines added, 0 removed**, `npm ci` exit 0.

## Testing

- [x] `npm ci` — exit 0, full in-repo (the only reliable local lock check)
- [x] `npx eslint "apps/web/**/*.{ts,tsx}" --max-warnings 0` — exit 0
- [x] `prettier --check` on all changed files
- [x] `tool:imports:check`, `node:version:check`, `workflow:security:check`, `gradle:prefetch:check`, `eng:vendor:check`, `eng:citations` — all exit 0

## Issues

Refs #4029