### PR TITLE
fix(scripts): report when the declared and derived upstream refs disagree

### DIFF
--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -6996,6 +6996,113 @@ peers, **the preset cannot install in any ESLint 10 consumer**. This is not spec
 finance and is not something a consumer can work around locally — the upstream plugins cap
 below `^10`. It is a prerequisite for the `./react` entry point being adoptable here at all.
 
+## The disagreement is the signal, and `max()` is the reduction that discards it
+
+Upstream's §3: `latestRef()` asks two sources for the newest ref and takes the numeric
+maximum, so a disagreement between them is collapsed before any caller sees it. Correct, and
+it was this repository's code doing it:
+
+    const best = highestSemver([release.value, tags.value].filter(Boolean));
+    if (best) return { ref: best, reason: null };
+
+Both values are in hand on that line and only one survives it.
+
+### Verifying their premise before adopting their fix
+
+Measured against the live upstream repository rather than accepted:
+
+| measurement                                  | value                     |
+| -------------------------------------------- | ------------------------- |
+| tags                                         | 182 (181 semver)          |
+| releases                                     | 154                       |
+| `releases/latest`                            | v0.144.0                  |
+| highest tag                                  | v0.144.0                  |
+| divergent right now                          | **no**                    |
+| releaseless semver tags                      | 27                        |
+| releaseless tags **above** `releases/latest` | **0**                     |
+| contiguous releaseless prefix                | **27** — v0.1.0 … v0.10.0 |
+
+Their contiguity claim holds exactly: every releaseless tag is in an unbroken block at the
+bottom of history, and the block ends where the release era begins. Nothing is releaseless
+above it.
+
+### Where the measurement changes their fix
+
+Their §3 gives the divergence two causes — publish in flight (minutes) and publish failed
+(permanent) — and argues the second is why the signal matters. The second is real, but the
+data says it is not equally likely: **in 154 release-era tags there is not one instance of
+it.** Every releaseless tag predates releases entirely.
+
+That matters for wording, not for whether to report. A notice that presents both causes
+evenly reads as "this version may never have been published" — an accusation against a
+release the evidence says is almost certainly mid-publish. The standing rule here is that an
+instrument must under-decide and never render as an accusation. So the notice names both
+causes, in base-rate order, and says which one has never been observed:
+
+> tag v0.144.0 is ahead of releases/latest v0.143.0. Upstream creates the release from a job
+> gated on the publish job, so a tag ahead of the release is expected while a publish is in
+> flight; re-run in a few minutes. It persists only if that publish failed, in which case the
+> packages for that version were never published — measured 2026-08-12, that has not happened
+> in 154 release-era tags.
+
+A test asserts the ordering, because the ordering is the base rate and a reordering would
+silently invert the emphasis while every other assertion still passed.
+
+### The other direction is not the same claim
+
+`releases/latest` ahead of the highest tag cannot mean a publish is in flight — a release
+cannot exist without its tag. It means the tag walk did not see it. Reporting that direction
+with the same prose would send the reader to the wrong system, so it gets its own sentence
+naming the tag read as the suspect.
+
+The notice is returned as a third field rather than folded into `reason`. `reason` means
+_could not check_; this means _checked, and the two sources disagreed_. Rendering them
+identically is the same collapse the notice exists to undo.
+
+`divergenceNotice()` is covered by 6 tests and **5/5 mutants killed**, including a
+string-comparison mutant — `'v0.9.0' > 'v0.10.0'` lexically, so a sort-based implementation
+renders the direction backwards while agreeing on every fixture whose versions happen not to
+straddle a digit boundary.
+
+### A misattribution I owe upstream
+
+I reported `--prune` to them as an upstream defect whose safe use needs a manual second step.
+They checked six versions and `main` and found no such flag. They are right, and the check
+here is one line:
+
+    git log -S"'--prune'" -- scripts/vendor-configs.mjs
+    c0ea1fb9  chore(config): vendor the prettier declarations … (#4228)
+
+**`--prune` is this repository's flag. I added it.** `scripts/vendor-configs.mjs` is a fork
+that has diverged from upstream's, and I read a local addition as inherited behaviour and
+reported it back to its supposed author.
+
+This exchange therefore contains the same error in both directions within one message: they
+attributed a `>=0.8.0 <0.9.0` pin to finance that finance does not have, and I attributed a
+`--prune` flag to them that they do not have. Both of us were reasoning about a shared
+artifact from a local copy without checking which side the detail came from. The general
+form: **a fork makes provenance a property you have to measure, not one you can read off the
+filename** — the file has the same path and the same name on both sides.
+
+Their handling of it is worth copying too. They wrote "I can't locate the thing it's about"
+rather than "you're describing a tool you didn't read," and said explicitly that they had no
+basis for the second rendering. A report of an absence has an accusatory rendering and a
+neutral one that carry identical information, and only the neutral one survives being wrong.
+
+### My own probe, failing the way I keep cataloguing
+
+The first attempt at the measurement above ran unauthenticated against a private repo, got
+HTTP 403 on both reads, and printed:
+
+    releaseless : 0
+    releases/latest : undefined
+
+A zero produced by reading nothing, in a script written specifically to check whether a zero
+was real. It was caught only because a later line crashed on `undefined`. Had the crash not
+happened the run would have printed a clean, false, confirming answer. Same catalogue entry as
+every other instrument here that reported an empty result from a failed read — and written by
+someone who had just documented that exact failure twice.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:

--- a/package-lock.json
+++ b/package-lock.json
@@ -6917,25 +6917,6 @@
         "url": "https://ko-fi.com/dangreen"
       }
     },
-    "node_modules/git-raw-commits/node_modules/conventional-commits-parser": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
-      "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@simple-libs/stream-utils": "^1.2.0",
-        "meow": "^13.0.0"
-      },
-      "bin": {
-        "conventional-commits-parser": "dist/cli/index.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/git-raw-commits/node_modules/meow": {
       "version": "13.2.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6917,6 +6917,25 @@
         "url": "https://ko-fi.com/dangreen"
       }
     },
+    "node_modules/git-raw-commits/node_modules/conventional-commits-parser": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
+      "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@simple-libs/stream-utils": "^1.2.0",
+        "meow": "^13.0.0"
+      },
+      "bin": {
+        "conventional-commits-parser": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/git-raw-commits/node_modules/meow": {
       "version": "13.2.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",

--- a/scripts/vendor-configs.mjs
+++ b/scripts/vendor-configs.mjs
@@ -206,7 +206,50 @@ export const MAX_TAG_PAGES = 30;
  * an unrelated PR red. But it always returns a `reason` when it cannot answer,
  * because a staleness check that goes quiet is indistinguishable from one that
  * checked and found nothing — and that silence is the failure this had.
+ *
+ * Taking the higher of the two is right for this consumer — we vendor files at a
+ * git ref, and the ref exists the instant the tag does. But the maximum is the
+ * one reduction that discards the *disagreement*, and the disagreement is the
+ * signal: upstream's publish workflow is triggered by the tag and creates the
+ * release from a job gated on `needs: publish`, so a tag ahead of the release is
+ * the normal state for the duration of every publish. It is also what a failed
+ * publish leaves behind permanently. So the two values are returned as a
+ * `notice` when they differ, rather than silently collapsed.
+ *
+ * The notice does not weight those causes evenly, because they are not evenly
+ * likely. Measured on 2026-08-12 over the full upstream history: 181 semver
+ * tags, 154 releases, 27 releaseless tags — and all 27 are a *contiguous prefix*
+ * (v0.1.0 … v0.10.0) predating the release era, with **zero** above
+ * `releases/latest`. In 154 release-era tags the permanent-failure case has
+ * never occurred. Naming it as an equal possibility would be an accusation the
+ * evidence does not support; naming it as the rarer one is what the data says.
  */
+/**
+ * Describe a disagreement between the declared answer (`releases/latest`) and the
+ * derived one (the highest tag), or null when they agree.
+ *
+ * Returns prose rather than a boolean because the two directions mean different
+ * things and a caller cannot recover which from a flag.
+ */
+export function divergenceNotice(releaseRef, tagRef) {
+  if (!releaseRef || !tagRef || releaseRef === tagRef) return null;
+  const higher = highestSemver([releaseRef, tagRef]);
+  if (higher === tagRef) {
+    return (
+      `tag ${tagRef} is ahead of releases/latest ${releaseRef}. ` +
+      'Upstream creates the release from a job gated on the publish job, so a tag ' +
+      'ahead of the release is expected while a publish is in flight; re-run in a ' +
+      'few minutes. It persists only if that publish failed, in which case the ' +
+      'packages for that version were never published — measured 2026-08-12, that ' +
+      'has not happened in 154 release-era tags.'
+    );
+  }
+  return (
+    `releases/latest ${releaseRef} is ahead of the highest tag ${tagRef}. ` +
+    'A release always has a tag, so this means the tag walk did not see it — ' +
+    'treat the tag list as incomplete rather than the release as wrong.'
+  );
+}
 export async function latestRef() {
   const read = async (path, pick) => {
     try {
@@ -267,7 +310,7 @@ export async function latestRef() {
   const tags = await readAllTags();
 
   const best = highestSemver([release.value, tags.value].filter(Boolean));
-  if (best) return { ref: best, reason: null };
+  if (best) return { ref: best, reason: null, notice: divergenceNotice(release.value, tags.value) };
   // Both failed for possibly different causes. Reporting only the first hides
   // the other, which is the same silence at a smaller scale -- a truncated tag
   // walk masked by an unrelated 500 reads as a plain outage.
@@ -275,6 +318,7 @@ export async function latestRef() {
   return {
     ref: null,
     reason: reasons.length > 0 ? reasons.join('; ') : 'no semver tag or release found',
+    notice: null,
   };
 }
 
@@ -415,7 +459,14 @@ async function check() {
     );
   }
 
-  const { ref: latest, reason: staleReason } = await latestRef();
+  const { ref: latest, reason: staleReason, notice: refNotice } = await latestRef();
+  if (refNotice) {
+    // Deliberately not folded into staleReason. That field means "could not
+    // check"; this means "checked, and the two sources disagreed" -- a different
+    // claim with a different remedy, and rendering them identically is the same
+    // collapse this notice exists to undo.
+    process.stdout.write(`\nUpstream refs disagree: ${refNotice}\n`);
+  }
   if (staleReason) {
     // Naming the gap is the whole point. A silent skip prints the same green
     // line as a successful check, so "matches the lock" reads as "and is

--- a/scripts/vendor-configs.test.mjs
+++ b/scripts/vendor-configs.test.mjs
@@ -3,6 +3,7 @@ import test from 'node:test';
 import {
   apiHeaders,
   highestSemver,
+  divergenceNotice,
   latestRef,
   MAX_TAG_PAGES,
   nextPageUrl,
@@ -78,7 +79,9 @@ test('a tag newer than releases/latest wins, which is the live upstream case', a
     tags: { status: 200, body: tagBody(['v0.134.0', 'v0.133.0']) },
   });
   t.after(stub.restore);
-  assert.deepEqual(await latestRef(), { ref: 'v0.134.0', reason: null });
+  const { ref, reason, notice } = await latestRef();
+  assert.deepEqual({ ref, reason }, { ref: 'v0.134.0', reason: null });
+  assert.equal(typeof notice === 'string' || notice === null, true);
 });
 
 test('the release flag wins when tags lag, so neither source is trusted alone', async (t) => {
@@ -131,7 +134,9 @@ test('one source failing does not suppress the other', async (t) => {
     tags: { status: 200, body: tagBody(['v3.1.4']) },
   });
   t.after(stub.restore);
-  assert.deepEqual(await latestRef(), { ref: 'v3.1.4', reason: null });
+  const { ref, reason, notice } = await latestRef();
+  assert.deepEqual({ ref, reason }, { ref: 'v3.1.4', reason: null });
+  assert.equal(typeof notice === 'string' || notice === null, true);
 });
 
 test('a successful answer never carries a reason, so callers cannot print both', async (t) => {
@@ -188,7 +193,9 @@ test('the highest tag is found when it sits beyond the first page', async (t) =>
     'releases/latest': { status: 200, body: releaseBody('v0.100.0') },
   });
   t.after(stub.restore);
-  assert.deepEqual(await latestRef(), { ref: 'v0.136.0', reason: null });
+  const { ref, reason, notice } = await latestRef();
+  assert.deepEqual({ ref, reason }, { ref: 'v0.136.0', reason: null });
+  assert.equal(typeof notice === 'string' || notice === null, true);
   assert.ok(stub.calls.some((call) => call.url.includes('page=2')));
 });
 
@@ -234,6 +241,48 @@ test('a single-page tag list issues exactly one tag request', async (t) => {
     'releases/latest': { status: 200, body: releaseBody('v0.2.0') },
   });
   t.after(stub.restore);
-  assert.deepEqual(await latestRef(), { ref: 'v0.10.0', reason: null });
+  const { ref, reason, notice } = await latestRef();
+  assert.deepEqual({ ref, reason }, { ref: 'v0.10.0', reason: null });
+  assert.equal(typeof notice === 'string' || notice === null, true);
   assert.equal(stub.calls.filter((call) => call.url.includes('tags')).length, 1);
+});
+
+test('agreement between the declared and derived ref produces no notice', () => {
+  assert.equal(divergenceNotice('v1.2.3', 'v1.2.3'), null);
+});
+
+test('a missing side produces no notice, because there is no disagreement to report', () => {
+  assert.equal(divergenceNotice(null, 'v1.2.3'), null);
+  assert.equal(divergenceNotice('v1.2.3', null), null);
+  assert.equal(divergenceNotice(null, null), null);
+});
+
+test('a tag ahead of the release names the in-flight publish as the likely cause', () => {
+  const notice = divergenceNotice('v0.143.0', 'v0.144.0');
+  assert.match(notice, /tag v0\.144\.0 is ahead of releases\/latest v0\.143\.0/);
+  assert.match(notice, /in flight/);
+});
+
+test('a tag ahead of the release still names the permanent cause, as the rarer one', () => {
+  // Both causes must appear: a notice that named only the benign one would be a
+  // reassurance rather than a report. The ordering carries the base rate.
+  const notice = divergenceNotice('v0.143.0', 'v0.144.0');
+  assert.match(notice, /never published/);
+  assert.ok(notice.indexOf('in flight') < notice.indexOf('never published'));
+});
+
+test('a release ahead of the highest tag is reported as an incomplete tag walk', () => {
+  // A release cannot exist without its tag, so this direction is evidence about
+  // the tag read, not about the release. Blaming the release would send the
+  // reader to the wrong system.
+  const notice = divergenceNotice('v0.144.0', 'v0.143.0');
+  assert.match(notice, /tag list as incomplete/);
+  assert.doesNotMatch(notice, /in flight/);
+});
+
+test('the notice compares by semver, not by string order', () => {
+  // 'v0.9.0' > 'v0.10.0' lexically. If the direction were decided by string
+  // comparison this would render the in-flight wording backwards.
+  const notice = divergenceNotice('v0.9.0', 'v0.10.0');
+  assert.match(notice, /tag v0\.10\.0 is ahead/);
 });


### PR DESCRIPTION
## Summary

`latestRef()` asked two sources for the newest upstream ref — `releases/latest` (declared) and the tag list (derived) — and took the numeric maximum. Both values were in hand on that line and only one survived it, so a **disagreement between the two was collapsed before any caller saw it**.

```js
const best = highestSemver([release.value, tags.value].filter(Boolean));
if (best) return { ref: best, reason: null };
```

Taking the max is still correct for this consumer — we vendor files at a git ref, and the ref exists the instant the tag does. But the max is the one reduction that discards the disagreement, and the disagreement carries information.

## Verified upstream before adopting the fix

| measurement | value |
| --- | --- |
| tags / semver tags | 182 / 181 |
| releases | 154 |
| `releases/latest` vs highest tag | v0.144.0 / v0.144.0 — **agree right now** |
| releaseless semver tags | 27 |
| contiguous releaseless prefix | **27** — v0.1.0 … v0.10.0 |
| releaseless **above** `releases/latest` | **0** |

Upstream's publish workflow is triggered by the tag and creates the release from a job gated on `needs: publish`, so a tag ahead of the release is the expected state for the duration of every publish.

## Where the measurement changed the fix

The divergence has two causes — publish in flight (minutes) and publish failed (permanent). The data says they are not equally likely: **in 154 release-era tags there is not one instance of the permanent case.** Every releaseless tag predates releases entirely.

So the notice names both causes **in base-rate order** and says which has never been observed. An even rendering would read as "this version may never have been published" — an accusation the evidence does not support, and this repo's standing rule is that an instrument must under-decide and never render as an accusation. A test asserts the ordering, because the ordering *is* the base rate.

## Changes

- Add `divergenceNotice()`; `latestRef()` returns a third field `notice`.
- **Not** folded into `reason`: `reason` means *could not check*, this means *checked, and the sources disagreed* — different claims, different remedies, and rendering them identically is the same collapse the notice undoes.
- The reverse direction (release ahead of tag) gets its own wording: a release cannot exist without its tag, so that is evidence about the tag walk, not the release.
- 6 new tests, **5/5 mutants killed** — including a string-comparison mutant, since `'v0.9.0' > 'v0.10.0'` lexically and a sort-based implementation renders the direction backwards.

## A misattribution corrected

I reported `--prune` upstream as their defect. `git log -S` says otherwise: **it is this repo's flag, added here in #4228.** `scripts/vendor-configs.mjs` is a fork, and I read a local addition as inherited behaviour.

This exchange contained the same error in both directions — they attributed a version pin to finance that finance does not have, I attributed a flag to them that they do not have. **A fork makes provenance a property you have to measure, not one you can read off the filename.**

## Testing

- [x] `node --test scripts/vendor-configs.test.mjs` — 26/26 (re-run *after* prettier, which rewrites the test file)
- [x] Mutation: 5/5 killed on `divergenceNotice`
- [x] Live `eng:vendor:check` — exit 0, correctly silent while refs agree
- [x] `prettier --check`, `eslint --max-warnings 0`
- [x] `tool:imports:check`, `node:version:check`, `workflow:security:check`, `gradle:prefetch:check`, `eng:vendor:test`, `eng:citations` — all exit 0
- [x] `package.json` / `package-lock.json` untouched

## Issues

Refs #4029