### PR TITLE
docs(engineering): cite ENG-TEST-004 instead of restating its enumeration

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -131,6 +131,11 @@ jobs:
       - name: Tooling imports are declared
         run: npm run tool:imports:check
 
+      - name: Principle enumerations are cited, not restated
+        run: npm run citations:enumerations:check
+
+      - name: Enumeration checker tests
+        run: npm run citations:enumerations:test
   pr-title:
     name: Semantic PR Title
     needs: changes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,9 +41,12 @@ ID via
 The principles above are finance's own product obligations and are additional to, not a
 restatement of, the ratified set.
 
-Notably, `ENG-TEST-004` (distinct static signals) requires lint, format, type-check, and tests
-to report independently — which is why `ci:check` chains them as separate scripts rather than
-collapsing them into one command.
+Notably, `ENG-TEST-004` (distinct static signals) is why `ci:check` chains its checks as
+separate scripts rather than collapsing them into one command, and why the build and the
+security scans report as their own CI checks rather than folding into a single green. Read
+the obligation at the ID, not here: this sentence used to enumerate the signals itself and
+had silently dropped two of the five the principle names, understating what finance already
+does. `npm run citations:enumerations:check` now fails on that shape.
 
 ## ⚠️ MANDATORY: Pre-Push Lint & Format (NEVER skip)
 

--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -2305,8 +2305,9 @@ was never real. The exemption had also propagated into a **metric definition** �
 `workflow-metrics.md` excluded type failures from avoidable-CI-failure rate on its authority, so the
 false claim was quietly improving a number finance reports on itself.
 
-**What this changes for adoption.** `ENG-TEST-004` (Distinct static signals) requires format, lint
-and type-check to report independently. finance's `ci:check` satisfies the structure, but a
+**What this changes for adoption.** `ENG-TEST-004` (Distinct static signals) is the principle at
+stake; read the signals it names at the ID rather than from this paragraph. finance's `ci:check`
+satisfies the structure, but a
 documented exemption that stops anyone running one of the three signals defeats it just as
 thoroughly as merging them would. The exemption is withdrawn; PP-0018 is marked withdrawn rather
 than deleted, so the corpus keeps the lesson.
@@ -7102,6 +7103,98 @@ was real. It was caught only because a later line crashed on `undefined`. Had th
 happened the run would have printed a clean, false, confirming answer. Same catalogue entry as
 every other instrument here that reported an empty result from a failed read — and written by
 someone who had just documented that exact failure twice.
+
+## Existence is not correctness: an enumeration that lost two of five
+
+The vendored citation checker ends every run with "Existence is not correctness — re-run with
+`--review`." It had said that on every run of this adoption and had never been taken up. Run for
+the first time this turn:
+
+```
+171 citations · 43 of 66 principles · 4692 files · 0 unknown · 0 badLinks · 0 badAnchors · 0 badTitles
+```
+
+Every ID resolves, every title matches, every anchor lands. And one of the 171 is wrong.
+
+`AGENTS.md` said: "`ENG-TEST-004` (distinct static signals) requires lint, format, type-check, and <!-- enumeration-fixture -->
+tests to report independently." The principle's statement names **five** — type, lint, **build**,
+format, and **security**. The restatement dropped two.
+
+The interesting part is the direction of the error. finance's CI _does_ report build and security
+as independent signals: `Build`, `Build & Test`, three CodeQL analyses, `Secret Scan (gitleaks)`,
+`Secret Detection`, `npm Audit`, `Dependency Review`, `Gradle Dependency Check`, `detekt Analysis`,
+`License Compliance`. So the defect **understated finance's own compliance**. It was not a gap
+between what finance does and what the principle demands; it was a gap between what finance does
+and what finance _said about itself_. A compliance audit reading the prose would have found finance
+less compliant than it is.
+
+ADR-0003 says no authority may copy another's normative text into its own source tree — reference
+by link or ID only. A paraphrase is the softer version of the same move, and an enumeration is its
+most fragile form: a list has a fixed arity, so it can lose an item while every word that remains
+stays true. Nothing in a citation checker can see that, because the ID exists and the title matches.
+
+Both sites are fixed by deleting the enumeration rather than correcting it to five. The remedy for
+restated normative text is not a better restatement.
+
+### The control, and the four times measurement overruled preference
+
+`tools/check-citation-enumerations.mjs` fires on the _shape_ — an obligation verb attributed to an
+`ENG-*` ID on a line that also contains an enumeration — and never compares the list against the
+principle, because deciding whether two lists mean the same thing is exactly the judgement citing
+was supposed to avoid. Four design choices, each decided by running the variant over the real
+corpus:
+
+| Variant                            | Measured                       | Taken                      |
+| ---------------------------------- | ------------------------------ | -------------------------- |
+| Multi-line sentence reconstruction | +0 true, +1 false              | rejected                   |
+| Two-item lists (no comma)          | +0 true, +2 false              | rejected                   |
+| Closing "and"/"or" optional        | +0 true, +0 false, wider reach | **taken**                  |
+| Serial comma required              | blind to one real instance     | kept, and pinned by a test |
+
+The last row is the honest one. The adoption guide's own instance read "requires format, lint and
+type-check" — three items, no serial comma — and the check cannot see it. That one was fixed by
+hand. A test now pins the blind spot so it cannot be mistaken for coverage.
+
+### Three failures in the method, found while building the instrument
+
+**The test file matched its own needle.** First run after widening: five violations, all fixtures in
+the checker's own tests. The catalogued failure — a probe containing its search needle — reproduced
+by the probe written to catch it.
+
+**The corpus was stale, and stale reads exactly like correct.** The widening had been measured as
+"costing nothing" against a citation census captured _before_ the test file existed. The corpus
+could not have contained the thing the widening would fire on. The measurement was not wrong; its
+referent had moved. This is the parent session's _as of when, on which ref_ applied to a corpus
+rather than a status line, and it is the second time this session that a number was true and its
+subject had changed underneath it.
+
+**A test passed for a reason unrelated to what it claimed.** The two-item test used comma-less prose
+("budgets and Lighthouse"), which fails the pattern whether the floor is two or three. It asserted
+nothing about the floor, and a mutant lowering the floor survived it. Only mutation testing
+distinguished a passing test from a testing test — a green produced by a property of the fixture
+rather than by the thing under test, which is the same mechanism as every other item in the
+catalogue, now in the assertion rather than the instrument.
+
+Final: **15 tests, 9 of 10 mutants killed**, the survivor (`\r?\n` → `\n`) adjudicated equivalent by
+showing line numbers and both output fields are byte-identical on CRLF input. The survivor list is
+the artifact; the ratio would have been 10/10 by deleting it.
+
+### Exemption by marker, not by path
+
+The fixtures opt out with a trailing `// enumeration-fixture`, the same shape as the
+`# exercises-engines-range` marker on the Node-version check. Per line, visible at the site,
+greppable, and unable to grow silently the way an ignored directory would — a test asserts that
+exempting one line does not exempt its neighbour. The clean run prints the count (`17 line(s)
+exempted`), because a narrowing that is not reported is a narrowing that can widen unobserved.
+
+### A refuted hypothesis
+
+The `ENG Citations` CI job runs with no token against a private repository, so it looked like a
+candidate for the failure this adoption has hit twice — a green produced by reading nothing.
+Tested rather than assumed: `raw.githubusercontent.com/.../principles/index.json` returns **HTTP
+200** unauthenticated, while the GitHub **API** returns **403**. Raw content and API auth are
+different surfaces. The job genuinely validates. Recorded because a refuted hypothesis is evidence
+and the record otherwise fills only with confirmed ones.
 
 ## Worth hoisting up
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6917,25 +6917,6 @@
         "url": "https://ko-fi.com/dangreen"
       }
     },
-    "node_modules/git-raw-commits/node_modules/conventional-commits-parser": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
-      "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@simple-libs/stream-utils": "^1.2.0",
-        "meow": "^13.0.0"
-      },
-      "bin": {
-        "conventional-commits-parser": "dist/cli/index.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/git-raw-commits/node_modules/meow": {
       "version": "13.2.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6917,6 +6917,25 @@
         "url": "https://ko-fi.com/dangreen"
       }
     },
+    "node_modules/git-raw-commits/node_modules/conventional-commits-parser": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
+      "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@simple-libs/stream-utils": "^1.2.0",
+        "meow": "^13.0.0"
+      },
+      "bin": {
+        "conventional-commits-parser": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/git-raw-commits/node_modules/meow": {
       "version": "13.2.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
     "workflow:security:test": "node --test tools/check-workflow-security.test.mjs",
     "gradle:prefetch:check": "node tools/check-gradle-prefetch.mjs",
     "tool:imports:check": "node tools/check-tool-imports.mjs",
+    "citations:enumerations:check": "node tools/check-citation-enumerations.mjs",
+    "citations:enumerations:test": "node --test tools/check-citation-enumerations.test.mjs",
     "gradle:prefetch:test": "node --test tools/check-gradle-prefetch.test.mjs",
     "agent:worktree": "node tools/agent-scripts/setup-worktree.js",
     "agent:check": "node tools/agent-scripts/pre-push-check.js",

--- a/tools/check-citation-enumerations.mjs
+++ b/tools/check-citation-enumerations.mjs
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+/**
+ * Fail when finance restates a ratified principle's enumeration instead of citing it.
+ *
+ * ADR-0003's four-authority topology says no authority may copy another's
+ * normative text into its own source tree — reference by link or ID only. A
+ * paraphrase is the softer version of the same move, and an *enumeration* is its
+ * most fragile form: it has a fixed arity, so it can drift silently by dropping
+ * an item while every word that remains is still true.
+ *
+ * This is not hypothetical. AGENTS.md carried, for the whole life of this
+ * adoption, "`ENG-TEST-004` (distinct static signals) requires lint, format,
+ * type-check, and tests to report independently." The principle's statement
+ * names five static signals — type, lint, build, format, and security — so the
+ * restatement dropped two. It understated finance's own compliance: CI does
+ * report Build and CodeQL/Secret Scan/npm Audit as independent signals. Nothing
+ * caught it, because every ID existed and every title matched. The vendored
+ * `check-citations.mjs` says so in its own last line: existence is not
+ * correctness.
+ *
+ * The check is deliberately syntactic rather than semantic. It does not compare
+ * the enumeration against the principle — that would require deciding whether
+ * two lists mean the same thing, which is the judgement the citation was
+ * supposed to avoid making. It fires on the *shape*: an obligation attributed to
+ * an ENG-* ID together with an enumeration. The remedy is always the same and
+ * needs no adjudication — cite the ID and describe finance's implementation,
+ * which is finance's to describe.
+ *
+ * Narrowing, stated because an unannounced one is how a ratcheting check starts:
+ * this reads ONE LINE at a time. An enumeration wrapped across a line break is
+ * not seen. Reconstructing sentences from a multi-line window was measured and
+ * rejected — on the current tree it caught nothing new and added a false
+ * positive on a passage that *quotes* a withdrawn claim in order to retract it.
+ * A gate must under-decide rather than accuse.
+ */
+
+import { readdir, readFile, stat } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+/** Directories never scanned: build output, dependencies, and vendored upstream text. */
+export const SKIPPED_DIRECTORIES = new Set([
+  'node_modules',
+  '.git',
+  'build',
+  'dist',
+  '.gradle',
+  'coverage',
+  'vendor',
+]);
+
+/** Prose files. Citations in code comments are covered too, via .mjs/.ts. */
+export const SCANNED_EXTENSIONS = new Set(['.md', '.mjs', '.js', '.ts', '.tsx', '.yml', '.yaml']);
+
+export const CITATION = /ENG-[A-Z]+-\d{3}/;
+
+/**
+ * Opt-out marker for lines that must contain the offending shape on purpose.
+ *
+ * This check's own tests are the motivating case, and finding them was the
+ * point: the first run after the pattern was widened reported five violations,
+ * all of them fixtures in the test file — a probe matching its own search
+ * needle. Worse, the widening had been "measured as costing nothing" against a
+ * citation corpus captured before that test file existed, so the corpus could
+ * not have contained the thing the widening would fire on. The measurement was
+ * not wrong; it was stale, which reads identically in the output.
+ *
+ * A marker rather than a path exclusion, so the exemption is per line, visible
+ * at the site, greppable, and cannot silently grow to cover a real defect the
+ * way an ignored directory would. Same shape as the `# exercises-engines-range`
+ * marker used by the Node-version check.
+ */
+export const EXEMPTION = 'enumeration-fixture';
+export const OBLIGATION = /\b(requires?|mandates?|forbids?|prohibits?|obliges?)\b/i;
+
+/**
+ * Three or more items, comma-separated including before the closing "and"/"or".
+ *
+ * Two stated narrowings, both measured rather than assumed:
+ *
+ * 1. The floor of three rejects "requires a, and b". It does NOT reject
+ *    "requires budgets and Lighthouse" — that form has no comma and fails the
+ *    pattern regardless of the floor. A test asserting the floor via comma-less
+ *    two-item prose passes for an unrelated reason; the test here uses
+ *    "a, and b", which is the only shape the floor actually decides.
+ * 2. A serial comma is required. "requires format, lint and type-check" does not
+ *    match. That is not a corner case: it is the exact wording of the second
+ *    real instance of this defect, in the adoption guide, which was corrected by
+ *    hand because this check could not see it. The tool's reach is narrower than
+ *    the class of defect it is named after, and this comment is where that is
+ *    recorded rather than left for a later reader to rediscover.
+ *
+ * Widening to catch shape 2 was measured against all 171 citations on this tree
+ * and rejected: it fires on ordinary prose and on passages that quote a
+ * withdrawn claim in order to retract it. A gate must under-decide.
+ *
+ * The closing conjunction is optional, so "requires a, b, c" is caught as well
+ * as "requires a, b, and c". That widening WAS measured on the same 171 and
+ * costs nothing — same one hit, no new false positives — so it is taken. The
+ * two rejections above and this acceptance were decided the same way, by
+ * running the variant over the real corpus rather than by preferring a shape.
+ */
+export const ENUMERATION = /([A-Za-z][\w-]*(?:\s+[\w-]+)?,\s+){2,}(?:and|or)?\s*[\w-]+/;
+
+export function isScannedFile(filePath) {
+  return SCANNED_EXTENSIONS.has(path.extname(filePath).toLowerCase());
+}
+
+/**
+ * Lines that attribute an enumerated obligation to a ratified principle.
+ *
+ * @param {string} text file contents
+ * @returns {{line: number, id: string, enumeration: string, text: string}[]}
+ */
+export function findRestatedEnumerations(text) {
+  const found = [];
+  const lines = text.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (line.includes(EXEMPTION)) continue;
+    const id = CITATION.exec(line);
+    if (!id) continue;
+    if (!OBLIGATION.test(line)) continue;
+    const list = ENUMERATION.exec(line);
+    if (!list) continue;
+    found.push({ line: i + 1, id: id[0], enumeration: list[0], text: line.trim() });
+  }
+  return found;
+}
+
+/** How many lines opted out via the marker. Reported so an exemption cannot grow unseen. */
+export function countExemptions(text) {
+  return text.split(/\r?\n/).filter((line) => line.includes(EXEMPTION)).length;
+}
+
+async function* walk(directory) {
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    if (entry.name.startsWith('.') && entry.name !== '.github') continue;
+    const full = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      if (SKIPPED_DIRECTORIES.has(entry.name)) continue;
+      yield* walk(full);
+    } else if (entry.isFile() && isScannedFile(full)) {
+      yield full;
+    }
+  }
+}
+
+export async function main(root) {
+  const violations = [];
+  let scanned = 0;
+  let exempted = 0;
+  for await (const file of walk(root)) {
+    scanned += 1;
+    const text = await readFile(file, 'utf8');
+    exempted += countExemptions(text);
+    for (const hit of findRestatedEnumerations(text)) {
+      violations.push({ ...hit, file: path.relative(root, file) });
+    }
+  }
+
+  if (violations.length > 0) {
+    process.stdout.write(
+      `\nRestated principle enumeration(s) — ${violations.length} across ${scanned} scanned file(s):\n\n`,
+    );
+    for (const v of violations) {
+      process.stdout.write(`  ${v.file}:${v.line}  ${v.id}\n`);
+      process.stdout.write(`    enumerates: ${v.enumeration}\n`);
+      process.stdout.write(`    ${v.text}\n\n`);
+    }
+    process.stdout.write(
+      'An enumeration copied from a principle drifts by losing an item while every\n' +
+        'remaining word stays true. Cite the ID and describe what finance does; let the\n' +
+        'principle state what it requires. See ADR-0003 (four-authority topology).\n',
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  process.stdout.write(
+    `No principle enumeration is restated as an obligation. ${scanned} file(s) scanned, ` +
+      `${exempted} line(s) exempted via the "${EXEMPTION}" marker. Read one line at a ` +
+      'time, so a list wrapped across a line break is not seen.\n',
+  );
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const root = process.argv[2] ? path.resolve(process.argv[2]) : process.cwd();
+  await stat(root);
+  await main(root);
+}

--- a/tools/check-citation-enumerations.test.mjs
+++ b/tools/check-citation-enumerations.test.mjs
@@ -1,0 +1,131 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  CITATION,
+  EXEMPTION,
+  ENUMERATION,
+  OBLIGATION,
+  SCANNED_EXTENSIONS,
+  countExemptions,
+  findRestatedEnumerations,
+  isScannedFile,
+} from './check-citation-enumerations.mjs';
+
+test('the defect this was written for is caught', () => {
+  const text =
+    'Notably, `ENG-TEST-004` (distinct static signals) requires lint, format, type-check, and tests'; // enumeration-fixture
+  const found = findRestatedEnumerations(text);
+  assert.equal(found.length, 1);
+  assert.equal(found[0].id, 'ENG-TEST-004'); // enumeration-fixture
+  assert.equal(found[0].line, 1);
+  assert.match(found[0].enumeration, /lint, format, type-check, and tests/);
+});
+
+test('a citation with no obligation verb is not a restatement', () => {
+  // Citing a principle beside a list is normal prose. Only an attributed
+  // obligation makes the list a restatement of what the principle demands.
+  assert.deepEqual(
+    findRestatedEnumerations('`ENG-TEST-004` covers lint, format, type-check, and tests'), // enumeration-fixture
+    [],
+  );
+});
+
+test('an obligation with no enumeration is not a restatement', () => {
+  assert.deepEqual(
+    findRestatedEnumerations('`ENG-PERF-009` forbids trading accessibility away'),
+    [],
+  );
+});
+
+test('an enumeration with no citation is ordinary prose', () => {
+  assert.deepEqual(findRestatedEnumerations('CI requires lint, format, type-check, and tests'), []);
+});
+
+test('the floor of three rejects a two-item serial list', () => {
+  // "a, and b" is the ONLY shape the floor decides. An earlier version of this
+  // test used comma-less prose ("budgets and Lighthouse"), which passes whether
+  // the floor is two or three — it asserted nothing, and a mutant lowering the
+  // floor survived it.
+  assert.deepEqual(findRestatedEnumerations('`ENG-SEC-001` requires alpha, and beta'), []); // enumeration-fixture
+});
+
+test('comma-less two-item prose is not an enumeration', () => {
+  assert.deepEqual(findRestatedEnumerations('`ENG-PERF-007` requires budgets and Lighthouse'), []);
+  assert.deepEqual(
+    findRestatedEnumerations('`ENG-TEST-004` requires automated and deterministic gates'),
+    [],
+  );
+});
+
+test('the closing conjunction is optional', () => {
+  // Measured on the same 171 citations as the rejected widenings: allowing a
+  // bare "a, b, c" adds reach at no false-positive cost. Pinned so that
+  // narrowing it back to a required "and"/"or" fails here.
+  const found = findRestatedEnumerations('`ENG-SEC-001` requires alpha, beta, gamma'); // enumeration-fixture
+  assert.equal(found.length, 1);
+  assert.equal(found[0].id, 'ENG-SEC-001'); // enumeration-fixture
+});
+test('a list without a serial comma is a known blind spot, not a pass', () => {
+  // The adoption guide's "requires format, lint and type-check" was a real
+  // instance of this defect and is invisible here. Pinned so the limit cannot
+  // be mistaken for coverage, and so widening the pattern fails this test
+  // loudly rather than silently changing the tool's reach.
+  assert.deepEqual(
+    findRestatedEnumerations('`ENG-TEST-004` requires format, lint and type-check'), // enumeration-fixture
+    [],
+  );
+});
+
+test('the line number is the line of the violation, not of the file', () => {
+  const text = ['first', 'second', '`ENG-SEC-001` requires a, b, and c'].join('\n'); // enumeration-fixture
+  assert.equal(findRestatedEnumerations(text)[0].line, 3);
+});
+
+test('every violation on a line is reported once, not once per matching word', () => {
+  const found = findRestatedEnumerations(
+    '`ENG-SEC-001` requires a, b, and c and mandates d, e, and f', // enumeration-fixture
+  ); // enumeration-fixture
+  assert.equal(found.length, 1);
+});
+
+test('CRLF input is split the same as LF', () => {
+  const text = 'x\r\n`ENG-SEC-001` requires a, b, and c\r\n'; // enumeration-fixture
+  assert.equal(findRestatedEnumerations(text)[0].line, 2);
+});
+
+test('the patterns are anchored to the shapes they claim', () => {
+  assert.match('ENG-TEST-004', CITATION); // enumeration-fixture
+  assert.doesNotMatch('ENG-TEST-4', CITATION);
+  assert.match('mandates', OBLIGATION);
+  assert.doesNotMatch('suggests', OBLIGATION);
+  assert.match('a, b, and c', ENUMERATION);
+  assert.doesNotMatch('a and b', ENUMERATION);
+});
+
+test('only prose and source extensions are scanned', () => {
+  assert.equal(isScannedFile('AGENTS.md'), true);
+  assert.equal(isScannedFile('tools/x.mjs'), true);
+  assert.equal(isScannedFile('image.png'), false);
+  assert.equal(isScannedFile('lock.json'), false);
+  assert.ok(SCANNED_EXTENSIONS.has('.md'));
+});
+test('a marked line is exempt and is counted', () => {
+  const text = '`ENG-SEC-001` requires a, b, and c // enumeration-fixture';
+  assert.deepEqual(findRestatedEnumerations(text), []);
+  assert.equal(countExemptions(text), 1);
+  assert.equal(EXEMPTION, 'enumeration-fixture');
+});
+
+test('exempting one line does not exempt its neighbours', () => {
+  // The failure mode a path exclusion would have: one deliberate fixture
+  // silently covering a real defect beside it.
+  const text = [
+    '`ENG-SEC-001` requires a, b, and c // enumeration-fixture', // enumeration-fixture
+    '`ENG-SEC-002` requires d, e, and f', // enumeration-fixture
+  ].join('\n');
+  const found = findRestatedEnumerations(text);
+  assert.equal(found.length, 1);
+  assert.equal(found[0].id, 'ENG-SEC-002');
+  assert.equal(countExemptions(text), 1);
+});


### PR DESCRIPTION
## Summary

The vendored citation checker has ended every run of this adoption with *"Existence is not correctness — re-run with `--review`."* Run for the first time this turn:

```
171 citations · 43 of 66 principles · 4692 files · 0 unknown · 0 badLinks · 0 badAnchors · 0 badTitles
```

Every ID resolves, every title matches, every anchor lands — and one of the 171 is wrong.

`AGENTS.md` said `ENG-TEST-004` *"requires lint, format, type-check, and tests to report independently."* The principle names **five** static signals: type, lint, **build**, format, and **security**.

The direction of the error is the interesting part. finance's CI already reports build and security as independent signals — `Build`, `Build & Test`, three CodeQL analyses, `Secret Scan (gitleaks)`, `Secret Detection`, `npm Audit`, `Dependency Review`, `Gradle Dependency Check`, `detekt Analysis`, `License Compliance`. **The defect understated finance's own compliance.** An auditor reading the prose would have found finance less compliant than it is.

ADR-0003 forbids copying another authority's normative text. A paraphrase is the same move, and an enumeration is its most fragile form: a list has a fixed arity, so it can lose an item while every remaining word stays true. Both sites are fixed by **deleting** the enumeration, not by correcting it to five.

## Changes

- `AGENTS.md`, `docs/guides/engineering-practice-adoption.md` — cite the ID; stop restating it
- `tools/check-citation-enumerations.mjs` + tests — new gate, wired into `ci-lint.yml`
- `package.json` — `citations:enumerations:check`, `citations:enumerations:test`

## Four design choices, each decided by measurement over the real corpus

| Variant | Measured | Taken |
| --- | --- | --- |
| Multi-line sentence reconstruction | +0 true, +1 false | rejected |
| Two-item lists (no comma) | +0 true, +2 false | rejected |
| Closing "and"/"or" optional | +0 true, +0 false, wider reach | **taken** |
| Serial comma required | blind to one real instance | kept, pinned by a test |

The last row is the honest one: the adoption guide's own instance read `requires format, lint and type-check` and the check **cannot see it**. Fixed by hand; a test pins the blind spot so it cannot be mistaken for coverage.

## Three failures in the method, found while building the instrument

1. **The test file matched its own needle.** First run after widening: five violations, all fixtures in the checker's own tests.
2. **The corpus was stale, and stale reads exactly like correct.** The widening was measured as "costing nothing" against a citation census captured *before* that test file existed — the corpus could not have contained what the widening would fire on. The measurement was not wrong; its referent had moved.
3. **A test passed for a reason unrelated to its claim.** The two-item test used comma-less prose, which fails the pattern whether the floor is two or three. Only mutation testing distinguished a passing test from a testing test.

## Verification

- `node --test` — **15 pass, 0 fail**
- Mutation — **9 of 10 killed**; survivor (`\r?\n` → `\n`) adjudicated equivalent by showing line numbers and both output fields are byte-identical on CRLF input
- `citations:enumerations:check` — clean over **3160 files**, printing `19 line(s) exempted`
- `prettier --check`, scoped `eslint --max-warnings 0`, `tool:imports:check`, `node:version:check`, `workflow:security:check`, `gradle:prefetch:check`, `eng:vendor:check`, `eng:citations` — all pass
- `package-lock.json` untouched

Fixtures opt out per line via an `enumeration-fixture` marker (same shape as `# exercises-engines-range`) rather than a path exclusion — a test asserts exempting one line does not exempt its neighbour, and the clean run prints the count, because a narrowing that is not reported can widen unobserved.

**A refuted hypothesis:** the tokenless `ENG Citations` job looked like a green produced by reading nothing, but `raw.githubusercontent.com` returns **200** unauthenticated where the API returns **403**. The job genuinely validates.

Refs #4029