### PR TITLE
test(tools): name the population the workflow security gate is clean over

### DIFF
--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -7196,6 +7196,96 @@ Tested rather than assumed: `raw.githubusercontent.com/.../principles/index.json
 different surfaces. The job genuinely validates. Recorded because a refuted hypothesis is evidence
 and the record otherwise fills only with confirmed ones.
 
+## The population is never in the output: auditing finance's own gates
+
+The engineering sibling stated a rule strongly enough to be falsifiable: _every clean result in
+this thread has been clean over a population, and the population is never in the output._ finance
+ships five gates, so the claim is testable here rather than agreeable. Ran all five and read the
+clean output:
+
+| Gate                           | Clean output names its population?                       |
+| ------------------------------ | -------------------------------------------------------- |
+| `tool:imports:check`           | yes — 130 references, 45 files, 8 excluded               |
+| `node:version:check`           | yes — 37 pins, 31 workflows, 452 dependency declarations |
+| `gradle:prefetch:check`        | yes — 10 jobs across 31 workflows                        |
+| `citations:enumerations:check` | yes — 3160 files, 19 exempted                            |
+| `workflow:security:check`      | **no — "passed (.github\workflows)"**                    |
+
+Four of five. The exception is the security gate, which is the one where a green over an unnamed
+subset costs the most. The rule predicted a finding and it landed on the highest-stakes instrument.
+
+### A hypothesis about it, refuted by running it
+
+The checker resolves named files as `workflows['deploy-preview.yml'] ?? ''`, six times. Reading
+that, the inference is immediate and alarming: rename or delete a workflow and its security
+assertions evaluate against an empty string, so they retire silently and the gate still prints
+"passed". A per-file fail-open in a security control.
+
+Measured instead of filed:
+
+```
+baseline                        errors: 0   (31 workflows)
+without deploy-preview.yml      errors: 3   (30 workflows)
+without nightly.yml             errors: 1   (30 workflows)
+without deploy-production.yml   errors: 5   (30 workflows)
+with ZERO workflows             errors: 29
+```
+
+**Removing a workflow raises errors. It fails closed.** Every named-file assertion is phrased
+positively — _this file must contain X_ — so an absent file fails it rather than skipping it. The
+`?? ''` fallback exists to avoid a crash, not to excuse a check.
+
+The inference was wrong in the direction that would have produced an accusation against a control
+that was working. That is the failure mode this adoption has repeatedly called the dangerous one,
+arriving from the other side: not an instrument over-reporting compliance, but a reader
+over-reporting a defect. **Reading a control tells you what it says; only running it tells you
+which way it fails.** Nothing in the 21 existing tests asserted the fail-closed property, so the
+suite would not have contradicted the misreading either.
+
+### What shipped
+
+`summarizeScope()` and a clean run that names its population:
+
+```
+Workflow security regression check passed (.github/workflows): 31 workflow(s) scanned;
+30 of 30 named assertion target(s) present; 1 covered by the universal checks only.
+```
+
+That last figure is new information the old output could not carry: `copilot-setup-steps.yml` is
+covered by the universal checks alone and by no file-specific assertion. Not a defect — it is
+unprivileged — but it is exactly the fact a named-file audit cannot see, and it is now printed
+rather than discoverable.
+
+Five tests pin what reading got wrong: an empty workflow set must fail closed; removing each of
+three named workflows must raise errors; every named target must exist on disk; the scope must be
+arithmetic over the tree rather than a constant.
+
+### A decorative assertion, and three equivalent mutants proved rather than asserted
+
+First mutation run killed 3 of 6. The two survivors both shrank the named set, and the test meant
+to stop them read `assert.equal(scope.named, NAMED_WORKFLOW_ASSERTIONS.size)` — **comparing the set
+to itself.** Second decorative assertion found in two turns, by the same method, in a test written
+immediately after documenting the first. Replaced by pinning the _complement_ against the disk:
+the list of workflows covered by universal checks only must equal exactly
+`['copilot-setup-steps.yml']`, which grows the moment an entry leaves the named set.
+
+Three mutants still survived. Rather than adding tests until they died, measured whether they
+_could_ die — how much each component uniquely contributes to the union:
+
+| Component dropped               | Union size | Uniquely lost |
+| ------------------------------- | ---------- | ------------- |
+| `privilegedWorkflows`           | 30         | none          |
+| `localReusableBaselines`        | 30         | none          |
+| `requiredEnvironmentJobs`       | 30         | none          |
+| `leastPrivilegeWorkflows`       | 30         | none          |
+| `permissionInheritanceBaseline` | 11         | **19 files**  |
+| literals                        | 30         | none          |
+
+`permissionInheritanceBaseline` subsumes every other component for the purpose of the denominator.
+Dropping the others changes the union by **zero**, so no test can distinguish those mutants: they
+are provably equivalent, with the table as the proof rather than an adjudication by assertion.
+Final 3 of 6, and the survivor list carries the structural fact that a 6-of-6 would have deleted.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:

--- a/package-lock.json
+++ b/package-lock.json
@@ -6917,25 +6917,6 @@
         "url": "https://ko-fi.com/dangreen"
       }
     },
-    "node_modules/git-raw-commits/node_modules/conventional-commits-parser": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
-      "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@simple-libs/stream-utils": "^1.2.0",
-        "meow": "^13.0.0"
-      },
-      "bin": {
-        "conventional-commits-parser": "dist/cli/index.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/git-raw-commits/node_modules/meow": {
       "version": "13.2.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6917,6 +6917,25 @@
         "url": "https://ko-fi.com/dangreen"
       }
     },
+    "node_modules/git-raw-commits/node_modules/conventional-commits-parser": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
+      "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@simple-libs/stream-utils": "^1.2.0",
+        "meow": "^13.0.0"
+      },
+      "bin": {
+        "conventional-commits-parser": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/git-raw-commits/node_modules/meow": {
       "version": "13.2.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",

--- a/tools/check-workflow-security.mjs
+++ b/tools/check-workflow-security.mjs
@@ -431,6 +431,42 @@ export function findDeadEventGuards(file, workflow) {
   return violations.map((violation) => `${file}: ${violation}`);
 }
 
+/**
+ * The population a clean run was clean over.
+ *
+ * A green from this checker used to print only "passed". That is the shape this
+ * repository has now hit five times — a correct verdict over a population the
+ * output does not name — so the scope is reported beside the verdict.
+ *
+ * `named` is the count of workflow files this checker asserts against by name.
+ * It matters because those assertions are the ones whose subject can disappear:
+ * a rename retires them silently as far as the file list is concerned. Measured
+ * rather than assumed, they do NOT fail open — every named-file check is a
+ * positive assertion, so an absent file fails it. Removing `deploy-preview.yml`
+ * raises 3 errors, `deploy-production.yml` 5, and an empty workflow set raises
+ * 29. That property was inferred backwards by reading the `?? ''` fallbacks and
+ * corrected by running it; it is pinned by tests now precisely because reading
+ * gave the wrong answer.
+ */
+export const NAMED_WORKFLOW_ASSERTIONS = new Set([
+  ...privilegedWorkflows,
+  ...Object.keys(localReusableBaselines),
+  ...Object.keys(requiredEnvironmentJobs),
+  ...leastPrivilegeWorkflows,
+  ...Object.keys(permissionInheritanceBaseline),
+  'deploy-preview.yml',
+  'nightly.yml',
+]);
+
+export function summarizeScope(workflows) {
+  const named = [...NAMED_WORKFLOW_ASSERTIONS];
+  return {
+    loaded: Object.keys(workflows).length,
+    named: named.length,
+    present: named.filter((file) => file in workflows).length,
+  };
+}
+
 export function scanWorkflowSecurity(workflows, productionCompose = '') {
   const errors = [];
   const report = (file, message) => errors.push(`${file}: ${message}`);
@@ -591,15 +627,20 @@ function main() {
     join(repositoryRoot, 'deploy', 'docker-compose.yml'),
     'utf8',
   );
-  const errors = scanWorkflowSecurity(loadWorkflows(), productionCompose);
+  const workflows = loadWorkflows();
+  const errors = scanWorkflowSecurity(workflows, productionCompose);
   if (errors.length > 0) {
     console.error('Workflow security regression check failed:');
     for (const error of errors) console.error(`- ${error}`);
     process.exitCode = 1;
     return;
   }
+  const scope = summarizeScope(workflows);
+  const universalOnly = scope.loaded - scope.present;
   console.log(
-    `Workflow security regression check passed (${relative(repositoryRoot, workflowDirectory)}).`,
+    `Workflow security regression check passed (${relative(repositoryRoot, workflowDirectory)}): ` +
+      `${scope.loaded} workflow(s) scanned; ${scope.present} of ${scope.named} named ` +
+      `assertion target(s) present; ${universalOnly} covered by the universal checks only.`,
   );
 }
 

--- a/tools/check-workflow-security.test.mjs
+++ b/tools/check-workflow-security.test.mjs
@@ -1,5 +1,7 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import test from 'node:test';
 
 import {
@@ -11,8 +13,14 @@ import {
   findRunExpressionViolations,
   normalizeReviewedPins,
   pureEventDisjunction,
+  NAMED_WORKFLOW_ASSERTIONS,
   scanWorkflowSecurity,
+  summarizeScope,
 } from './check-workflow-security.mjs';
+
+const testRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const workflowDirectory = join(testRoot, '.github', 'workflows');
+const productionCompose = readFileSync(join(testRoot, 'deploy', 'docker-compose.yml'), 'utf8');
 
 test('findDeadEventGuards decides conjunctions that a pure disjunction cannot', () => {
   const workflow = `
@@ -311,4 +319,74 @@ test('an unpinned action outside the reviewed set is caught by the pin check alo
   const errors = scanWorkflowSecurity(workflows);
   assert.equal(unpinned(errors), true);
   assert.equal(drifted(errors), false, 'the baseline has no jurisdiction outside its 2 files');
+});
+
+// --- The population a clean run is clean over -------------------------------
+//
+// These pin a property that was inferred backwards. Reading the six `?? ''`
+// fallbacks suggested that a renamed or deleted workflow would silently pass,
+// because an absent file becomes an empty string. Running it showed the
+// opposite: every named-file assertion is positive, so an absent file FAILS it.
+// The tests exist because reading gave the wrong answer and nothing in the
+// suite would have caught the reader.
+
+const workflowsOnDisk = () =>
+  Object.fromEntries(
+    readdirSync(workflowDirectory)
+      .filter((file) => /\.ya?ml$/.test(file))
+      .sort()
+      .map((file) => [file, readFileSync(join(workflowDirectory, file), 'utf8')]),
+  );
+
+test('an empty workflow set fails closed rather than passing vacuously', () => {
+  // The single most important property of this checker: a green must not be
+  // obtainable by giving it nothing to read.
+  assert.ok(scanWorkflowSecurity({}, '').length > 0);
+});
+
+test('removing a named-assertion workflow raises errors rather than retiring checks', () => {
+  const full = workflowsOnDisk();
+  assert.equal(scanWorkflowSecurity(full, productionCompose).length, 0);
+  for (const victim of ['deploy-preview.yml', 'nightly.yml', 'deploy-production.yml']) {
+    const reduced = { ...full };
+    delete reduced[victim];
+    assert.ok(
+      scanWorkflowSecurity(reduced, productionCompose).length > 0,
+      `removing ${victim} must not be a silent pass`,
+    );
+  }
+});
+
+test('every named assertion target is present on disk', () => {
+  // A named target that no longer exists is an assertion whose subject left.
+  const present = workflowsOnDisk();
+  const absent = [...NAMED_WORKFLOW_ASSERTIONS].filter((file) => !(file in present));
+  assert.deepEqual(absent, []);
+});
+
+test('the reported scope is arithmetic over the real tree, not a constant', () => {
+  const disk = workflowsOnDisk();
+  const scope = summarizeScope(disk);
+  assert.equal(scope.loaded, Object.keys(disk).length);
+  assert.equal(scope.present, scope.named);
+  assert.ok(scope.loaded >= scope.present);
+});
+
+test('the named denominator is pinned to the tree, not to itself', () => {
+  // An earlier version asserted `scope.named === NAMED_WORKFLOW_ASSERTIONS.size`,
+  // which compares the set to itself and is therefore decorative: two mutants
+  // that shrank the set survived it. Pinning the COMPLEMENT against the disk is
+  // what makes the denominator falsifiable — drop an entry from the named set
+  // and this list grows.
+  const disk = Object.keys(workflowsOnDisk());
+  const universalOnly = disk.filter((file) => !NAMED_WORKFLOW_ASSERTIONS.has(file));
+  assert.deepEqual(universalOnly, ['copilot-setup-steps.yml']);
+});
+
+test('summarizeScope counts what it is given, not what is on disk', () => {
+  assert.deepEqual(summarizeScope({}), {
+    loaded: 0,
+    named: NAMED_WORKFLOW_ASSERTIONS.size,
+    present: 0,
+  });
 });


### PR DESCRIPTION
## Summary

The engineering sibling stated a rule strongly enough to be falsifiable: *every clean result has been clean over a population, and the population is never in the output.* finance ships five gates, so that is testable here rather than merely agreeable.

| Gate | Clean output names its population? |
| --- | --- |
| `tool:imports:check` | yes — 130 references, 45 files, 8 excluded |
| `node:version:check` | yes — 37 pins, 31 workflows, 452 dependency declarations |
| `gradle:prefetch:check` | yes — 10 jobs across 31 workflows |
| `citations:enumerations:check` | yes — 3160 files, 19 exempted |
| `workflow:security:check` | **no — `passed (.github/workflows)`** |

Four of five. The exception is the **security** gate — the one where a green over an unnamed subset costs the most. The rule predicted a finding and it landed on the highest-stakes instrument.

## A hypothesis about it, refuted by running it

The checker resolves named files as `workflows['deploy-preview.yml'] ?? ''`, six times. That reads as a per-file **fail-open**: rename a workflow and its security assertions evaluate against an empty string, retiring silently while the gate still prints "passed".

Measured instead of filed:

```
baseline                        errors: 0   (31 workflows)
without deploy-preview.yml      errors: 3   (30 workflows)
without nightly.yml             errors: 1   (30 workflows)
without deploy-production.yml   errors: 5   (30 workflows)
with ZERO workflows             errors: 29
```

**It fails closed.** Every named-file assertion is phrased positively — *this file must contain X* — so an absent file fails it rather than skipping it. The `?? ''` exists to avoid a crash, not to excuse a check.

The inference was wrong in the direction that produces an **accusation against a control that was working** — the direction this repo has repeatedly called the dangerous one, arriving from the reader's side rather than the instrument's. *Reading a control tells you what it says; only running it tells you which way it fails.* None of the 21 existing tests asserted the property, so the suite would not have contradicted the misreading either.

## Changes

- `summarizeScope()` + a clean run that names its population:

```
Workflow security regression check passed (.github/workflows): 31 workflow(s) scanned;
30 of 30 named assertion target(s) present; 1 covered by the universal checks only.
```

That last figure is new information the old output could not carry: `copilot-setup-steps.yml` has **no file-specific assertion**. Not a defect — it is unprivileged — but it is exactly what a named-file audit cannot see, and it is now printed rather than merely discoverable.

- Five tests pinning what reading got wrong: empty set must fail closed; removing each of three named workflows must raise errors; every named target must exist on disk; the scope must be arithmetic over the tree, not a constant.

## A decorative assertion, and three equivalent mutants proved rather than asserted

First mutation run killed **3 of 6**. Both survivors shrank the named set, and the test meant to stop them read `assert.equal(scope.named, NAMED_WORKFLOW_ASSERTIONS.size)` — **comparing the set to itself.** Second decorative assertion found in two turns, by the same method, in a test written immediately after documenting the first. Replaced by pinning the *complement* against the disk.

Three mutants still survived. Rather than adding tests until they died, I measured whether they *could*:

| Component dropped | Union | Uniquely lost |
| --- | --- | --- |
| `privilegedWorkflows` | 30 | none |
| `localReusableBaselines` | 30 | none |
| `requiredEnvironmentJobs` | 30 | none |
| `leastPrivilegeWorkflows` | 30 | none |
| `permissionInheritanceBaseline` | 11 | **19 files** |
| literals | 30 | none |

`permissionInheritanceBaseline` subsumes every other component for the denominator's purpose, so dropping the others changes the union by **zero** — the mutants are provably equivalent, with the table as proof rather than adjudication by assertion.

## Verification

- `node --test check-workflow-security.test.mjs` — **27 pass, 0 fail** (was 21)
- Mutation — 3 of 6 killed, 3 proved equivalent
- `prettier --check`, scoped `eslint --max-warnings 0`, and all nine repo gates (`tool:imports`, `node:version`, `workflow:security`, `gradle:prefetch`, `citations:enumerations` + tests, `eng:vendor` + tests, `eng:citations`) — pass
- `package.json` / `package-lock.json` untouched

Refs #4029