### PR TITLE
fix(scripts): record which script wrote the lock, and stop a bare refresh widening it

### DIFF
--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -7286,6 +7286,84 @@ Dropping the others changes the union by **zero**, so no test can distinguish th
 are provably equivalent, with the table as the proof rather than an adjudication by assertion.
 Final 3 of 6, and the survivor list carries the structural fact that a 6-of-6 would have deleted.
 
+## A lock records the ref you asked for, not the vintage of the thing that asked
+
+A fleet audit reported that this repository runs a stale vendoring script, and used
+`engineering-configs.lock.json` as the evidence: `ref` is `v0.134.0`, the newest pin in the
+fleet, while the script behind it was said to be many releases old. The general claim is
+correct and worth stating plainly.
+
+**`lock.ref` records the ref that was requested. It says nothing about the script that did the
+requesting**, because the script is not part of the payload it vendors — it is not in
+`lock.files`, so nothing hashes it and nothing notices when it drifts. A lock can name the
+newest possible ref and have been written by anything.
+
+Two of the three specific defects did not reproduce, and the discriminator is why.
+
+The audit's test was `/would change/.test(readFileSync('scripts/vendor-configs.mjs'))` — a
+search for a string from the upstream fix. It returns `refresh me` here. But running the tool
+prints:
+
+```
+Notice: pinned at v0.134.0; newest release is v0.145.0, and 1 vendored file(s) differ there:
+  config/engineering/citations/check-citations.mjs
+```
+
+That is content-gated staleness — it names _which_ file differs — and a cadence-only check
+cannot produce that line. This repository implemented the same capability independently, with
+different wording, so **a string match for someone else's fix reports a capability this tree
+has as a capability it lacks**. A grep for a remedy is not a test for the property the remedy
+was meant to establish, and the gap between the two is exactly the size of the space of other
+ways to be correct.
+
+The third defect was real: the lock carried no writer entry at all, so `--check` passed
+silently over a question it had never asked.
+
+### A version number would have been false here
+
+The upstream remedy records a tool version. This script is a fork — ten local commits carrying
+`--prune`, `divergenceNotice`, and a paginated tag read that upstream does not have. A version
+string in this lock would assert an equivalence that does not hold, and asserting exactly that
+is how an earlier turn ended with a locally-added flag reported to its supposed author as their
+bug.
+
+So the recorded identity is a **content hash of the writer**. It answers the question actually
+being asked — _was this lock written by the script now checking it?_ — and it answers it for a
+fork, where a version number cannot. Three states, kept distinguishable, because collapsing them
+is the defect being fixed: absent (`Unverified:`), matching (silent), differing (`Notice:`).
+
+The cost is stated rather than hidden: a content hash cannot tell a semantic change from a
+reflow, so **the formatter invalidates it**. Re-vendor after `prettier --write`, never before.
+
+### Following the remedy found a worse defect than the one it fixed
+
+The documented refresh command is `node scripts/vendor-configs.mjs <newer-ref>`, with no
+`--set`. Run here at the _same_ ref, it turned 6 vendored files into 12, writing a
+`config/engineering/tsconfig/` tree this repository had deliberately not adopted, recording it
+in the lock, and exiting 0. The summary line counts what it wrote, not what changed about the
+selection.
+
+A guard against a `--set` that _drops_ locked files was added earlier; **its mirror image was
+missing**. Guards get written in the direction of the harm someone already suffered, so the
+opposite direction stays open, and the asymmetry is invisible precisely because the existing
+guard makes the area look covered.
+
+The first version of the new guard ran after the write loop. It failed correctly — having
+already left all six files on disk. _A control that reports the state it was meant to prevent,
+after creating it, is a message._ It now runs before any write, and an explicit `--set` is
+treated as the signal of intent that may widen; the implicit default — the refresh path, the
+one the whole fleet was told to run — may not.
+
+`widenedByRun` is exported and pinned by 5 tests; `writerIdentity`/`writerNotice` by 6. All 11
+mutants killed; 37 tests pass.
+
+### Incidental: one flagged gap has closed
+
+The widening run revealed that upstream now ships `config/engineering/tsconfig/vite-react.json`.
+That was one of the two preset gaps this adoption flagged. It is not adopted here — tsconfig
+remains deliberately out of the vendored set — but the gap is closed upstream and the follow-up
+should be re-scoped rather than re-argued.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:

--- a/engineering-configs.lock.json
+++ b/engineering-configs.lock.json
@@ -1,8 +1,12 @@
 {
   "repository": "jrmoulckers/engineering",
   "ref": "v0.134.0",
-  "fetchedAt": "2026-08-12T19:27:28.303Z",
+  "fetchedAt": "2026-08-12T22:22:17.563Z",
   "refresh": "node scripts/vendor-configs.mjs <newer-ref>",
+  "tool": {
+    "sha256": "e90b941c586de11b0ca828cdf6a0387f4ed607bf041a91d2f49418c4ad733324",
+    "bytes": 39257
+  },
   "files": {
     "config/engineering/prettier/index.js": {
       "source": "packages/prettier-config/index.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6917,25 +6917,6 @@
         "url": "https://ko-fi.com/dangreen"
       }
     },
-    "node_modules/git-raw-commits/node_modules/conventional-commits-parser": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
-      "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@simple-libs/stream-utils": "^1.2.0",
-        "meow": "^13.0.0"
-      },
-      "bin": {
-        "conventional-commits-parser": "dist/cli/index.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/git-raw-commits/node_modules/meow": {
       "version": "13.2.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6917,6 +6917,25 @@
         "url": "https://ko-fi.com/dangreen"
       }
     },
+    "node_modules/git-raw-commits/node_modules/conventional-commits-parser": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
+      "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@simple-libs/stream-utils": "^1.2.0",
+        "meow": "^13.0.0"
+      },
+      "bin": {
+        "conventional-commits-parser": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/git-raw-commits/node_modules/meow": {
       "version": "13.2.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",

--- a/scripts/vendor-configs.mjs
+++ b/scripts/vendor-configs.mjs
@@ -231,6 +231,70 @@ export const MAX_TAG_PAGES = 30;
  * Returns prose rather than a boolean because the two directions mean different
  * things and a caller cannot recover which from a flag.
  */
+/**
+ * Identity of the script that wrote a lock.
+ *
+ * `lock.ref` records the ref that was *requested*. It says nothing about the
+ * vintage of the script that did the requesting, and the two drift apart
+ * silently: a lock can name the newest upstream ref while the writer is many
+ * releases old, because the writer is not part of the payload it vendors. A
+ * fleet audit found exactly that here — this repository's lock pinned the
+ * newest ref in the fleet and its script was the same vintage as everyone
+ * else's. The field was being read as currency; it is not one.
+ *
+ * Upstream's remedy records a version number. That would be false here. This
+ * script is a fork: ten local commits, carrying `--prune`, `divergenceNotice`,
+ * and a paginated tag read that upstream does not have. A version string would
+ * assert an equivalence that does not hold, and asserting it is how a previous
+ * turn ended with a local flag reported to upstream as upstream's bug.
+ *
+ * So the recorded identity is a content hash. It answers the question that is
+ * actually being asked -- "was this lock written by the script now checking
+ * it?" -- and it answers it for a fork, where a version number cannot.
+ *
+ * Operational consequence, learned by tripping it: the hash covers the file
+ * verbatim, so the FORMATTER invalidates it. Editing this script and running
+ * Prettier leaves the lock naming a revision that no longer exists on disk.
+ * Re-vendor last -- after `prettier --write`, not before -- or `--check` will
+ * report a mismatch caused by whitespace. A cost, and the honest one: a
+ * content hash cannot tell a semantic change from a reflow, which is the same
+ * limitation this repository accepted when it chose bytes over a version
+ * string, and the reason this is a notice rather than a failure.
+ */
+/**
+ * Which staged files a lock does not already cover.
+ *
+ * Extracted so the widening guard is testable without a network fetch. The
+ * inline version was correct and unreachable by any test, which is the same
+ * shape as a control that cannot be observed to have run.
+ */
+export function widenedByRun(destKeys, previousFiles) {
+  if (!previousFiles) return [];
+  return destKeys.filter((key) => !previousFiles[key]);
+}
+
+export function writerIdentity(scriptText) {
+  return {
+    sha256: createHash('sha256').update(scriptText, 'utf8').digest('hex'),
+    bytes: Buffer.byteLength(scriptText, 'utf8'),
+  };
+}
+
+/**
+ * What `--check` should say about a lock's writer.
+ *
+ * Three states, kept distinct because collapsing them is the failure this
+ * repository keeps finding: an absent field and a matching field must not
+ * render alike, and neither must be reported as a defect.
+ */
+export function writerNotice(recorded, current) {
+  if (!recorded || typeof recorded.sha256 !== 'string') {
+    return 'Unverified: this lock records no writer identity, so the script that wrote it cannot be compared to the one checking it.';
+  }
+  if (recorded.sha256 === current.sha256) return null;
+  return `Notice: this lock was written by a different revision of this script (recorded ${recorded.sha256.slice(0, 12)}, current ${current.sha256.slice(0, 12)}); the vendored file set may have changed since.`;
+}
+
 export function divergenceNotice(releaseRef, tagRef) {
   if (!releaseRef || !tagRef || releaseRef === tagRef) return null;
   const higher = highestSemver([releaseRef, tagRef]);
@@ -457,6 +521,20 @@ async function check() {
       'A green --check would keep saying the tree matches a lock nothing reads. ' +
         'Restore the reference, or drop the set with --prune and delete the files.',
     );
+  }
+
+  const writerMessage = writerNotice(
+    lock.tool,
+    writerIdentity(await readFile(resolve(fileURLToPath(import.meta.url)), 'utf8').catch(() => '')),
+  );
+  if (writerMessage) {
+    // Third distinct claim in this report, deliberately not folded into the
+    // other two. `staleReason` means "could not check the ref"; `refNotice`
+    // means "checked, sources disagreed"; this means "the lock's writer is not
+    // the script reading it, so the vendored FILE SET may be wrong" -- which no
+    // amount of hashing the recorded files can detect, because a file that was
+    // never vendored has no hash to mismatch.
+    process.stdout.write(`\n${writerMessage}\n`);
   }
 
   const { ref: latest, reason: staleReason, notice: refNotice } = await latestRef();
@@ -731,6 +809,42 @@ async function main() {
     }
   }
 
+  let previous = null;
+  try {
+    previous = JSON.parse(await readFile(LOCK, 'utf8'));
+  } catch {
+    // No previous lock: this is a first vendor.
+  }
+  // The mirror image, and the one that was missing. The guard above catches a
+  // run that would DROP locked files; nothing caught a run that ADDS files the
+  // lock never covered. That asymmetry has a specific cost: the documented
+  // refresh command is `node scripts/vendor-configs.mjs <newer-ref>` with no
+  // `--set`, which defaults to every set. Run against a lock covering a subset,
+  // it writes the missing sets to disk and records them, and reports success.
+  //
+  // Found by following that exact instruction: a bare re-vendor at the SAME ref
+  // turned 6 locked files into 12, adding a whole config/engineering/tsconfig/
+  // tree this repository had deliberately not adopted. Nothing said so; the
+  // summary line counts what it wrote, not what changed about the selection.
+  //
+  // Naming a set explicitly is the signal of intent, so an explicit `--set` is
+  // allowed to widen. It is the implicit default -- the refresh path -- that
+  // must not.
+  //
+  // Checked before the write loop, not after. The first version of this guard
+  // ran after it and failed correctly -- having already left all six files on
+  // disk. A guard that reports the state it was meant to prevent, after
+  // creating it, is a message rather than a control.
+  const destKeys = staged.map((item) => item.dest.split('\\').join('/'));
+  const addedToLock = widenedByRun(destKeys, previous?.files);
+  if (previous && addedToLock.length > 0 && !flags.set) {
+    fail(
+      `this would add ${addedToLock.length} file(s) the lock does not cover:\n` +
+        addedToLock.map((key) => `  - ${key}`).join('\n'),
+      `The lock covers [${[...new Set(Object.keys(previous.files ?? {}).map((key) => key.split('/').at(-2)))].join(', ')}]. ` +
+        'Re-run with --set naming exactly those to refresh in place, or name the wider set deliberately.',
+    );
+  }
   for (const item of staged) {
     await mkdir(dirname(item.dest), { recursive: true });
     await writeFile(item.dest, item.text, 'utf8');
@@ -741,6 +855,9 @@ async function main() {
     ref,
     fetchedAt: new Date().toISOString(),
     refresh: `node scripts/vendor-configs.mjs <newer-ref>`,
+    tool: writerIdentity(
+      await readFile(resolve(fileURLToPath(import.meta.url)), 'utf8').catch(() => ''),
+    ),
     files: Object.fromEntries(
       staged.map((item) => [
         item.dest.split('\\').join('/'),
@@ -748,13 +865,6 @@ async function main() {
       ]),
     ),
   };
-
-  let previous = null;
-  try {
-    previous = JSON.parse(await readFile(LOCK, 'utf8'));
-  } catch {
-    // No previous lock: this is a first vendor.
-  }
 
   // A partial `--set` rewrites the whole lock, so any previously locked file
   // outside the chosen sets drops out of it while staying on disk. `--check`

--- a/scripts/vendor-configs.test.mjs
+++ b/scripts/vendor-configs.test.mjs
@@ -4,6 +4,9 @@ import {
   apiHeaders,
   highestSemver,
   divergenceNotice,
+  widenedByRun,
+  writerIdentity,
+  writerNotice,
   latestRef,
   MAX_TAG_PAGES,
   nextPageUrl,
@@ -285,4 +288,87 @@ test('the notice compares by semver, not by string order', () => {
   // comparison this would render the in-flight wording backwards.
   const notice = divergenceNotice('v0.9.0', 'v0.10.0');
   assert.match(notice, /tag v0\.10\.0 is ahead/);
+});
+
+// -- writer identity -------------------------------------------------------
+// `lock.ref` records the ref requested, not the vintage of the writer. These
+// pin the distinction, because it is the one a fleet audit read past.
+
+test('the same text yields the same identity, and different text does not', () => {
+  const a = writerIdentity('const x = 1;\n');
+  assert.equal(writerIdentity('const x = 1;\n').sha256, a.sha256);
+  assert.notEqual(writerIdentity('const x = 2;\n').sha256, a.sha256);
+  assert.equal(a.bytes, 13);
+});
+
+test('bytes counts UTF-8 bytes, not characters', () => {
+  // A length-based field would call these equal. The em dash is 3 bytes.
+  assert.equal(writerIdentity('abc').bytes, 3);
+  assert.equal(writerIdentity('a—c').bytes, 5);
+});
+
+test('an absent writer entry is reported as unverified, not as a match', () => {
+  const current = writerIdentity('whatever');
+  for (const recorded of [undefined, null, {}, { sha256: 42 }]) {
+    const notice = writerNotice(recorded, current);
+    assert.match(notice, /^Unverified:/);
+  }
+});
+
+test('a matching writer produces no notice', () => {
+  const text = 'const tool = 1;\n';
+  assert.equal(writerNotice(writerIdentity(text), writerIdentity(text)), null);
+});
+
+test('a differing writer names both revisions and the consequence', () => {
+  const notice = writerNotice(writerIdentity('old'), writerIdentity('new'));
+  assert.match(notice, /^Notice:/);
+  assert.match(notice, /different revision/);
+  // The consequence is the point: hashes of the recorded files cannot detect a
+  // file that was never vendored at all.
+  assert.match(notice, /file set may have changed/);
+  assert.match(notice, new RegExp(writerIdentity('old').sha256.slice(0, 12)));
+  assert.match(notice, new RegExp(writerIdentity('new').sha256.slice(0, 12)));
+});
+
+test('unverified and differing render distinguishably', () => {
+  // The whole defect being fixed: a lock with no writer entry passed quietly,
+  // rendering identically to one that had been verified.
+  const absent = writerNotice(null, writerIdentity('x'));
+  const differs = writerNotice(writerIdentity('y'), writerIdentity('x'));
+  assert.notEqual(absent, differs);
+  assert.ok(absent !== null && differs !== null);
+});
+// -- widening guard --------------------------------------------------------
+// The mirror of the existing drop guard. The refresh command documented in the
+// lock takes no --set, so it defaults to every set; against a subset lock that
+// silently adds files. Measured: 6 locked files became 12.
+
+test('a run covering exactly the locked files widens nothing', () => {
+  const locked = { 'a/x.js': {}, 'a/y.js': {} };
+  assert.deepEqual(widenedByRun(['a/x.js', 'a/y.js'], locked), []);
+});
+
+test('a run adding an uncovered set names every added file', () => {
+  const locked = { 'a/x.js': {} };
+  assert.deepEqual(widenedByRun(['a/x.js', 'b/p.json', 'b/q.json'], locked), [
+    'b/p.json',
+    'b/q.json',
+  ]);
+});
+
+test('a narrower run widens nothing, because dropping is the other guard', () => {
+  assert.deepEqual(widenedByRun(['a/x.js'], { 'a/x.js': {}, 'a/y.js': {} }), []);
+});
+
+test('a first vendor has no previous lock and so cannot widen', () => {
+  // Without this the guard would fire on every initial adoption.
+  assert.deepEqual(widenedByRun(['a/x.js'], undefined), []);
+  assert.deepEqual(widenedByRun(['a/x.js'], null), []);
+});
+
+test('an empty previous file map is still a previous lock', () => {
+  // Distinct from "no lock": a lock with zero files is covered by nothing, so
+  // every staged file is an addition.
+  assert.deepEqual(widenedByRun(['a/x.js'], {}), ['a/x.js']);
 });


### PR DESCRIPTION
## Summary

A fleet audit reported this repository runs a stale vendoring script, using `engineering-configs.lock.json` (`ref: v0.134.0`) as evidence. The general claim is correct and worth stating plainly: **`lock.ref` records the ref that was requested, not the vintage of the script that did the requesting.** The script is not in `lock.files`, so nothing hashes it and nothing notices when it drifts.

Two of the three specific defects did not reproduce, and one new, worse defect was found by following the audit's own remedy.

## What did not reproduce, and why

The audit's discriminator greps `scripts/vendor-configs.mjs` for `would change`, a string from the upstream fix. It returns `refresh me` here. But the tool prints:

```
Notice: pinned at v0.134.0; newest release is v0.145.0, and 1 vendored file(s) differ there:
  config/engineering/citations/check-citations.mjs
```

That is content-gated staleness — it names *which* file differs — which a cadence-only check cannot produce. This fork implemented the same capability independently, with different wording. **A string match for someone else's fix reports a capability this tree has as a capability it lacks.**

## What was real

The lock carried no writer entry, so `--check` passed silently over a question it never asked.

Upstream's remedy records a tool version. That would be **false here** — this script is a fork with ten local commits (`--prune`, `divergenceNotice`, a paginated tag read). A version string would assert an equivalence that does not hold, and asserting exactly that is how an earlier turn ended with a locally-added flag reported to its supposed author as their bug.

So the recorded identity is a **content hash of the writer**. Three states kept distinguishable: absent (`Unverified:`), matching (silent), differing (`Notice:`). Stated cost: a content hash cannot tell a semantic change from a reflow, so the formatter invalidates it — re-vendor after `prettier --write`, never before.

## The defect found by following the remedy

The documented refresh command takes no `--set`, so it defaults to every set. Run here at the **same ref**, it turned 6 vendored files into 12, wrote a `config/engineering/tsconfig/` tree this repository had deliberately not adopted, recorded it in the lock, and **exited 0**.

A guard against a `--set` that *drops* locked files was added earlier; its mirror image was missing. Guards get written in the direction of the harm someone already suffered, so the opposite direction stays open — and the existing guard makes the area look covered.

The first version of the new guard ran *after* the write loop. It failed correctly, having already left all six files on disk. **A control that reports the state it was meant to prevent, after creating it, is a message.** It now runs before any write.

## Incidental

Upstream now ships `config/engineering/tsconfig/vite-react.json` — one of the two preset gaps this adoption flagged. Closed upstream; not adopted here (tsconfig stays out of the vendored set), but the follow-up should be re-scoped rather than re-argued.

## Changes

- `scripts/vendor-configs.mjs` — `writerIdentity`, `writerNotice`, `widenedByRun`; writer recorded on vendor and compared on `--check`; widening guard placed before the write loop.
- `scripts/vendor-configs.test.mjs` — 26 → **37** tests.
- `engineering-configs.lock.json` — gains `tool`; **payload byte-identical** (6 files, unchanged).
- `docs/guides/engineering-practice-adoption.md` — new section.

## Issues

Refs #4029

## Testing

- [x] 37/37 tests pass; **11/11 mutants killed**
- [x] Bare re-vendor now exits 1 and writes **nothing** (verified `config/engineering/tsconfig` absent after)
- [x] Explicit `--set prettier,citations` still refreshes in place
- [x] `eng:vendor:check`, `citations:enumerations:check`, `eng:citations`, `tool:imports:check`, `node:version:check`, `workflow:security:check`, `gradle:prefetch:check` all exit 0
- [x] `prettier --check` and `eslint --max-warnings 0` clean