### PR TITLE
fix(tools): state the scope on the failure branch, not only the green one

### DIFF
--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -7364,6 +7364,63 @@ That was one of the two preset gaps this adoption flagged. It is not adopted her
 remains deliberately out of the vendored set — but the gap is closed upstream and the follow-up
 should be re-scoped rather than re-argued.
 
+## Every scope line in this repository was on the green path
+
+Four independent routes had converged on one rule: _print the scope beside the verdict._ This
+repository shipped it — `summarizeScope()`, an excluded-test count, an exemption count. Then a
+sibling session observed that a partition has to sum or one of its parts is invisible, which
+prompted the obvious next question, which nobody in four rounds had asked.
+
+**Which branch does the scope print on?**
+
+All of them printed it on success only. Forcing each gate red:
+
+| Gate                           | Red-path output                 | Missing                |
+| ------------------------------ | ------------------------------- | ---------------------- |
+| `tool:imports:check`           | `1 undeclared import`           | the entire denominator |
+| `citations:enumerations:check` | `1 across 3161 scanned file(s)` | the exempted bucket    |
+| `workflow:security:check`      | `N errors`                      | the entire denominator |
+
+The failure branch `return`ed before the scope line in two of the three, and printed two of
+three buckets in the third.
+
+This inverts the rule as it had been stated. **The green path is where the denominator matters
+least** — nothing was found, so how much was searched is a question about confidence. The red
+path is where it matters most: _1 undeclared import across 45 files with 8 excluded_ and _1
+across 3_ are different claims, and only one of them is a small problem. A reader triaging a
+red check is precisely the reader who cannot afford to guess at the population.
+
+The sharpest instance is the one shipped last turn. `summarizeScope()` was added to answer
+"the population is never in the output" — and was called _after_ the failure return. **The
+remedy for the rule reproduced the defect the rule describes, on the branch where it is worse.**
+A control written from a lesson can inherit the exact blind spot the lesson was about, because
+the lesson gets applied to the case that prompted it and the symmetric case is never enumerated.
+Same shape as the missing widening guard, one section up, found the same week.
+
+Fixed in all three: the scope is computed before the branch and emitted on both, and the
+enumeration checker now names the exempted bucket on failure — the bucket that can _hide_ a
+violation, since an exempted line is one the check chose not to see.
+
+### The test fixture was itself a violation
+
+Adding a red-path test for the enumeration checker required writing a restated enumeration into
+a fixture. The suite went red — the checker found the string in its own test file.
+
+That is not a mistake to avoid; it is **entailed by the subject matter**. Any checker whose
+input language is the language it is written in will find itself: a linter's fixtures, a
+secret-scanner's test vectors, an import checker's sample modules. `tool:imports:check` already
+excludes 8 test files for exactly this reason.
+
+The consequence is what makes it worth naming. The exclusion is _forced_, so the denominator is
+permanently narrower than the tree — not a temporary narrowing to be ratcheted back later. Which
+is precisely why `8 test file(s) excluded` has to be printed: it is the only thing distinguishing
+a structural exclusion from a scope bug, and the two are indistinguishable from a bare green.
+
+The fixture is exempted with the existing per-line `enumeration-fixture` marker rather than by
+adding a path exclusion, so the narrowing stays one line wide and stays counted.
+
+5 mutants killed across the three gates; suites now 20, 17, and 29 tests.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:

--- a/package-lock.json
+++ b/package-lock.json
@@ -6917,25 +6917,6 @@
         "url": "https://ko-fi.com/dangreen"
       }
     },
-    "node_modules/git-raw-commits/node_modules/conventional-commits-parser": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
-      "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@simple-libs/stream-utils": "^1.2.0",
-        "meow": "^13.0.0"
-      },
-      "bin": {
-        "conventional-commits-parser": "dist/cli/index.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/git-raw-commits/node_modules/meow": {
       "version": "13.2.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6917,6 +6917,25 @@
         "url": "https://ko-fi.com/dangreen"
       }
     },
+    "node_modules/git-raw-commits/node_modules/conventional-commits-parser": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
+      "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@simple-libs/stream-utils": "^1.2.0",
+        "meow": "^13.0.0"
+      },
+      "bin": {
+        "conventional-commits-parser": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/git-raw-commits/node_modules/meow": {
       "version": "13.2.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",

--- a/tools/check-citation-enumerations.mjs
+++ b/tools/check-citation-enumerations.mjs
@@ -161,7 +161,13 @@ export async function main(root) {
 
   if (violations.length > 0) {
     process.stdout.write(
-      `\nRestated principle enumeration(s) — ${violations.length} across ${scanned} scanned file(s):\n\n`,
+      // The exemption count belongs here, not only on the green path. A failure
+      // reporting "1 across 3161 scanned file(s)" states two of three buckets,
+      // and the missing one is the only bucket that can HIDE a violation --
+      // an exempted line is one this check chose not to see. A partition has
+      // to sum, or one of its parts is invisible.
+      `\nRestated principle enumeration(s) — ${violations.length} across ${scanned} scanned ` +
+        `file(s), with ${exempted} line(s) exempted via the "${EXEMPTION}" marker:\n\n`,
     );
     for (const v of violations) {
       process.stdout.write(`  ${v.file}:${v.line}  ${v.id}\n`);

--- a/tools/check-citation-enumerations.test.mjs
+++ b/tools/check-citation-enumerations.test.mjs
@@ -1,5 +1,9 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { spawnSync } from 'node:child_process';
+import { writeFileSync, unlinkSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
 
 import {
   CITATION,
@@ -128,4 +132,37 @@ test('exempting one line does not exempt its neighbours', () => {
   assert.equal(found.length, 1);
   assert.equal(found[0].id, 'ENG-SEC-002');
   assert.equal(countExemptions(text), 1);
+});
+
+// -- scope on the failure path ---------------------------------------------
+// The green path printed scanned AND exempted; the red path printed scanned
+// only. The missing bucket is the one that can HIDE a violation, since an
+// exempted line is one this check chose not to see.
+
+const enumToolDirectory = dirname(fileURLToPath(import.meta.url));
+const ENUM_TOOL = join(enumToolDirectory, 'check-citation-enumerations.mjs');
+const enumRepositoryRoot = resolve(enumToolDirectory, '..');
+
+test('a failing run states both the scanned and the exempted bucket', () => {
+  const probe = join(enumRepositoryRoot, 'docs', '_scope_probe_fixture.md');
+  // enumeration-fixture -- this literal IS a violation, which is the point: a
+  // test for an enumeration checker cannot avoid containing an enumeration as
+  // data. The exclusion is structural, not a temporary narrowing.
+  const violatingLine = 'ENG-TEST-004 requires type, lint, build, format, and security checks.\n'; // enumeration-fixture
+  writeFileSync(probe, violatingLine, 'utf8');
+  let result;
+  try {
+    result = spawnSync(process.execPath, [ENUM_TOOL], { encoding: 'utf8' });
+  } finally {
+    unlinkSync(probe);
+  }
+  assert.equal(result.status, 1, 'the probe must actually fail, or this asserts nothing');
+  const output = `${result.stdout}${result.stderr}`;
+  assert.match(output, /\d+ across \d+ scanned file\(s\), with \d+ line\(s\) exempted/);
+});
+
+test('a passing run states the same two buckets', () => {
+  const result = spawnSync(process.execPath, [ENUM_TOOL], { encoding: 'utf8' });
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /\d+ file\(s\) scanned, \d+ line\(s\) exempted/);
 });

--- a/tools/check-tool-imports.mjs
+++ b/tools/check-tool-imports.mjs
@@ -143,6 +143,16 @@ function main() {
       '\nAn undeclared import resolves only while an unrelated package happens to hoist it.',
     );
     console.error('Add it to devDependencies so the requirement is stated where it is checked.');
+    // The scope belongs on this branch too. It used to print only below, on
+    // the green path, so a failure said "1 undeclared import" over an unstated
+    // denominator -- and 1 of 45 files with 8 excluded is a different claim
+    // from 1 of 3. The excluded count matters most here: test files are
+    // structurally excluded, because a test for an import checker cannot avoid
+    // containing import statements as data, so that exclusion is permanent and
+    // must never look like a scope bug.
+    console.error(
+      `Scope: ${references} module reference(s) across ${scanned} file(s) in ${SCANNED_DIRECTORIES.join(', ')}; ${skipped} test file(s) excluded.`,
+    );
     process.exitCode = 1;
     return;
   }

--- a/tools/check-tool-imports.test.mjs
+++ b/tools/check-tool-imports.test.mjs
@@ -1,5 +1,9 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
+import { spawnSync } from 'node:child_process';
+import { writeFileSync, unlinkSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
 
 import {
   bareSpecifier,
@@ -129,4 +133,40 @@ test('isScannedFile declines a file that is not a module', () => {
   assert.equal(isScannedFile('README.md'), false);
   assert.equal(isScannedFile('config.json'), false);
   assert.equal(isScannedFile(undefined), false);
+});
+
+// -- scope on the failure path ---------------------------------------------
+// The scope line used to print only on success, so a failure named a count
+// over an unstated denominator. 1 of 45 files with 8 excluded is a different
+// claim from 1 of 3.
+
+const toolDirectory = dirname(fileURLToPath(import.meta.url));
+const TOOL = join(toolDirectory, 'check-tool-imports.mjs');
+
+function runWithProbe(source) {
+  const probe = join(toolDirectory, '_scope_probe_fixture.mjs');
+  writeFileSync(probe, source, 'utf8');
+  try {
+    return spawnSync(process.execPath, [TOOL], { encoding: 'utf8' });
+  } finally {
+    unlinkSync(probe);
+  }
+}
+
+test('a failing run states the scope it failed over', () => {
+  const result = runWithProbe("import q from 'no-such-package-scope-probe';\nexport default q;\n");
+  assert.equal(result.status, 1, 'the probe must actually fail, or this asserts nothing');
+  const output = `${result.stdout}${result.stderr}`;
+  assert.match(output, /Scope: \d+ module reference\(s\) across \d+ file\(s\)/);
+  // The excluded bucket is the one that must never look like a scope bug: a
+  // test for an import checker cannot avoid containing imports as data, so the
+  // exclusion is structural and permanent.
+  assert.match(output, /\d+ test file\(s\) excluded/);
+});
+
+test('a passing run states the same scope, so the two branches agree', () => {
+  const result = spawnSync(process.execPath, [TOOL], { encoding: 'utf8' });
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /\d+ module reference\(s\) across \d+ file\(s\)/);
+  assert.match(result.stdout, /\d+ test file\(s\) excluded/);
 });

--- a/tools/check-workflow-security.mjs
+++ b/tools/check-workflow-security.mjs
@@ -629,19 +629,29 @@ function main() {
   );
   const workflows = loadWorkflows();
   const errors = scanWorkflowSecurity(workflows, productionCompose);
+
+  // Computed before the branch, deliberately. The previous version called
+  // summarizeScope() after the failure return, so the scope printed on the
+  // green path and vanished on the red one -- the branch where a reader most
+  // needs the denominator, because "3 errors" is a different claim over 31
+  // workflows than over 3. The scope line was added to answer "the population
+  // is never in the output"; putting it on the success path only reproduced
+  // that defect on the branch that matters more.
+  const scope = summarizeScope(workflows);
+  const universalOnly = scope.loaded - scope.present;
+  const scopeLine =
+    `${scope.loaded} workflow(s) scanned in ${relative(repositoryRoot, workflowDirectory)}; ` +
+    `${scope.present} of ${scope.named} named assertion target(s) present; ` +
+    `${universalOnly} covered by the universal checks only.`;
+
   if (errors.length > 0) {
     console.error('Workflow security regression check failed:');
     for (const error of errors) console.error(`- ${error}`);
+    console.error(`Scope: ${scopeLine}`);
     process.exitCode = 1;
     return;
   }
-  const scope = summarizeScope(workflows);
-  const universalOnly = scope.loaded - scope.present;
-  console.log(
-    `Workflow security regression check passed (${relative(repositoryRoot, workflowDirectory)}): ` +
-      `${scope.loaded} workflow(s) scanned; ${scope.present} of ${scope.named} named ` +
-      `assertion target(s) present; ${universalOnly} covered by the universal checks only.`,
-  );
+  console.log(`Workflow security regression check passed. ${scopeLine}`);
 }
 
 if (resolve(process.argv[1] ?? '') === fileURLToPath(import.meta.url)) {

--- a/tools/check-workflow-security.test.mjs
+++ b/tools/check-workflow-security.test.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
 import { readFileSync, readdirSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -389,4 +390,36 @@ test('summarizeScope counts what it is given, not what is on disk', () => {
     named: NAMED_WORKFLOW_ASSERTIONS.size,
     present: 0,
   });
+});
+
+// -- scope on the failure path ---------------------------------------------
+// summarizeScope() was added to answer "the population is never in the
+// output", then called AFTER the failure return -- so the remedy reproduced
+// the defect on the branch where the denominator matters more. "3 errors" over
+// 31 workflows is a different claim from "3 errors" over 3.
+
+const SECURITY_TOOL = resolve(testRoot, 'tools', 'check-workflow-security.mjs');
+
+test('a passing run states the scope', () => {
+  const result = spawnSync(process.execPath, [SECURITY_TOOL], { encoding: 'utf8' });
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /\d+ workflow\(s\) scanned in /);
+  assert.match(result.stdout, /\d+ of \d+ named assertion target\(s\) present/);
+  assert.match(result.stdout, /\d+ covered by the universal checks only/);
+});
+
+test('the failure branch emits the scope before returning', () => {
+  // Pinned by source rather than by running a mutated tree, because forcing a
+  // real failure would mean writing a broken workflow into .github/workflows.
+  // Stated as the narrowing it is: this asserts the ordering, not the text.
+  const source = readFileSync(SECURITY_TOOL, 'utf8');
+  const scopeAssigned = source.indexOf('const scope = summarizeScope(workflows);');
+  const failureBranch = source.indexOf('if (errors.length > 0) {');
+  const scopeOnFailure = source.indexOf('console.error(`Scope: ${scopeLine}`);');
+  assert.ok(scopeAssigned > -1 && failureBranch > -1 && scopeOnFailure > -1);
+  assert.ok(scopeAssigned < failureBranch, 'scope must be computed before the branch');
+  assert.ok(
+    scopeOnFailure > failureBranch && scopeOnFailure < source.indexOf('process.exitCode = 1;'),
+    'the failure branch must print the scope before it sets the exit code',
+  );
 });


### PR DESCRIPTION
## Summary

Four independent routes across this exchange converged on one rule: **print the scope beside the verdict.** This repository shipped it — `summarizeScope()`, an excluded-test count, an exemption count. A sibling session then observed that *a partition has to sum, or one of its parts is invisible*, which prompted the obvious next question that nobody had asked in four rounds:

**Which branch does the scope print on?**

All of them printed it on success only. Forcing each gate red:

| Gate | Red-path output | Missing |
| --- | --- | --- |
| `tool:imports:check` | `1 undeclared import` | the entire denominator |
| `citations:enumerations:check` | `1 across 3161 scanned file(s)` | the exempted bucket |
| `workflow:security:check` | `N errors` | the entire denominator |

Two `return`ed before the scope line; the third printed two of three buckets.

## This inverts the rule as stated

**The green path is where the denominator matters least** — nothing was found, so how much was searched is a question about confidence. The red path is where it matters most: *1 undeclared import across 45 files with 8 excluded* and *1 across 3* are different claims, and only one is a small problem. The reader triaging a red check is exactly the reader who cannot afford to guess at the population.

The sharpest instance is the one shipped **last turn**. `summarizeScope()` was added to answer "the population is never in the output" — and called *after* the failure return. **The remedy for the rule reproduced the defect the rule describes, on the branch where it is worse.** A control written from a lesson can inherit the blind spot the lesson was about, because the lesson gets applied to the case that prompted it and the symmetric case is never enumerated. Same shape as the missing widening guard in #4246, found the same week.

The enumeration checker now names the **exempted** bucket on failure — the one bucket that can *hide* a violation, since an exempted line is one the check chose not to see.

## The test fixture was itself a violation

Writing a red-path test for the enumeration checker required a restated enumeration in a fixture. The suite went red: the checker found the string in its own test file.

That is **entailed by the subject matter**, not a mistake — any checker whose input language is the language it is written in will find itself. `tool:imports:check` already excludes 8 test files for exactly this reason.

So the exclusion is *forced*, and the denominator is **permanently** narrower than the tree — not a temporary narrowing to ratchet back. Which is why `8 test file(s) excluded` has to be printed: it is the only thing distinguishing a structural exclusion from a scope bug, and the two are indistinguishable from a bare green. Exempted with the existing per-line marker rather than a path exclusion, so the narrowing stays one line wide and stays counted.

## Changes

- `tools/check-workflow-security.mjs` — scope computed before the branch, emitted on both.
- `tools/check-tool-imports.mjs` — scope on the failure branch, including the excluded count.
- `tools/check-citation-enumerations.mjs` — exempted bucket added to the failure header.
- Three test suites: 18→**20**, 15→**17**, 27→**29**.
- `docs/guides/engineering-practice-adoption.md` — new section.

## Issues

Refs #4029

## Testing

- [x] Each gate forced red and inspected; scope present on every failure path
- [x] **5/5 mutants killed** (removing the failure scope, dropping the excluded bucket, dropping the exempted clause, removing the red scope, relocating `summarizeScope` below the branch)
- [x] All seven gates exit 0; `eslint --max-warnings 0` and `prettier --check` clean