### PR TITLE
fix(lint): detect hooks called in try blocks that rules-of-hooks misses

### DIFF
--- a/apps/web/src/components/DataExport.tsx
+++ b/apps/web/src/components/DataExport.tsx
@@ -89,6 +89,7 @@ async function gatherExportData(db: AsyncDb, includeMoodTags: boolean): Promise<
 
 function useExportDatabase(): AsyncDb | null {
   try {
+    // eslint-disable-next-line finance/no-hook-call-in-try -- provider-tolerance pattern, tracked in #4248
     return useDatabase();
   } catch {
     return null;

--- a/apps/web/src/components/settings/AccountDeletionModal.tsx
+++ b/apps/web/src/components/settings/AccountDeletionModal.tsx
@@ -37,6 +37,7 @@ import {
  */
 function useOptionalDatabase() {
   try {
+    // eslint-disable-next-line finance/no-hook-call-in-try -- provider-tolerance pattern, tracked in #4248
     return useDatabase();
   } catch {
     return null;

--- a/apps/web/src/hooks/useHousehold.ts
+++ b/apps/web/src/hooks/useHousehold.ts
@@ -3114,6 +3114,7 @@ export function useHousehold(): UseHouseholdResult {
  */
 function useOptionalAuthUser(): { id: string; email: string; name?: string } | null {
   try {
+    // eslint-disable-next-line finance/no-hook-call-in-try -- provider-tolerance pattern, tracked in #4248
     return useAuth().user;
   } catch {
     return null;
@@ -3133,6 +3134,7 @@ function useOptionalAuthUser(): { id: string; email: string; name?: string } | n
  */
 function useOptionalDatabase(): AsyncDb | null {
   try {
+    // eslint-disable-next-line finance/no-hook-call-in-try -- provider-tolerance pattern, tracked in #4248
     return useDatabase();
   } catch {
     return null;

--- a/apps/web/src/pages/GoalsPage.tsx
+++ b/apps/web/src/pages/GoalsPage.tsx
@@ -153,6 +153,7 @@ function saveDismissedNudges(value: readonly string[]): void {
 
 function useOptionalToast(): ReturnType<typeof useToast> | null {
   try {
+    // eslint-disable-next-line finance/no-hook-call-in-try -- provider-tolerance pattern, tracked in #4248
     return useToast();
   } catch {
     return null;

--- a/apps/web/src/pages/HouseholdPage.tsx
+++ b/apps/web/src/pages/HouseholdPage.tsx
@@ -3549,6 +3549,7 @@ export default HouseholdPage;
  */
 function useOptionalAuthUser(): { id: string; email: string; name?: string } | null {
   try {
+    // eslint-disable-next-line finance/no-hook-call-in-try -- provider-tolerance pattern, tracked in #4248
     return useAuth().user;
   } catch {
     return null;
@@ -3567,6 +3568,7 @@ function useOptionalAuthUser(): { id: string; email: string; name?: string } | n
  */
 function useOptionalToast(): ReturnType<typeof useToast> | null {
   try {
+    // eslint-disable-next-line finance/no-hook-call-in-try -- provider-tolerance pattern, tracked in #4248
     return useToast();
   } catch {
     return null;
@@ -3576,6 +3578,7 @@ function useOptionalToast(): ReturnType<typeof useToast> | null {
 /** Read budget data without crashing if no DatabaseProvider is mounted. */
 function useOptionalBudgets(): Pick<UseBudgetsResult, 'budgets'> {
   try {
+    // eslint-disable-next-line finance/no-hook-call-in-try -- provider-tolerance pattern, tracked in #4248
     return { budgets: useBudgets().budgets };
   } catch {
     return { budgets: [] };
@@ -3585,6 +3588,7 @@ function useOptionalBudgets(): Pick<UseBudgetsResult, 'budgets'> {
 /** Read account data without crashing if no DatabaseProvider is mounted. */
 function useOptionalAccounts(): Pick<UseAccountsResult, 'accounts'> {
   try {
+    // eslint-disable-next-line finance/no-hook-call-in-try -- provider-tolerance pattern, tracked in #4248
     return { accounts: useAccounts().accounts };
   } catch {
     return { accounts: [] };
@@ -3593,6 +3597,7 @@ function useOptionalAccounts(): Pick<UseAccountsResult, 'accounts'> {
 
 function useOptionalGoals(): Pick<UseGoalsResult, 'goals' | 'createGoal'> {
   try {
+    // eslint-disable-next-line finance/no-hook-call-in-try -- provider-tolerance pattern, tracked in #4248
     const { goals, createGoal } = useGoals();
     return { goals, createGoal };
   } catch {
@@ -3605,6 +3610,7 @@ function useOptionalTransactions(): Pick<
   'transactions' | 'updateTransaction'
 > {
   try {
+    // eslint-disable-next-line finance/no-hook-call-in-try -- provider-tolerance pattern, tracked in #4248
     const { transactions, updateTransaction } = useTransactions({ type: 'EXPENSE' });
     return { transactions, updateTransaction };
   } catch {
@@ -3614,6 +3620,7 @@ function useOptionalTransactions(): Pick<
 
 function useOptionalCategories(): Pick<UseCategoriesResult, 'categories'> {
   try {
+    // eslint-disable-next-line finance/no-hook-call-in-try -- provider-tolerance pattern, tracked in #4248
     return { categories: useCategories().categories };
   } catch {
     return { categories: [] };

--- a/apps/web/src/pages/TransactionsPage.tsx
+++ b/apps/web/src/pages/TransactionsPage.tsx
@@ -284,6 +284,7 @@ function flattenTransactionGroups(
 
 function useOptionalToast(): ReturnType<typeof useToast> | null {
   try {
+    // eslint-disable-next-line finance/no-hook-call-in-try -- provider-tolerance pattern, tracked in #4248
     return useToast();
   } catch {
     return null;

--- a/apps/web/src/pages/settings/SettingsAdvancedPage.tsx
+++ b/apps/web/src/pages/settings/SettingsAdvancedPage.tsx
@@ -16,6 +16,7 @@ import {
 
 function useOptionalDatabase() {
   try {
+    // eslint-disable-next-line finance/no-hook-call-in-try -- provider-tolerance pattern, tracked in #4248
     return useDatabase();
   } catch {
     return null;

--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -7421,6 +7421,84 @@ adding a path exclusion, so the narrowing stays one line wide and stays counted.
 
 5 mutants killed across the three gates; suites now 20, 17, and 29 tests.
 
+## A rule can be silent about a defect it names, depending on how the line is written
+
+`react-hooks/rules-of-hooks` was one of seven rules deferred when the plugin was
+adopted, recorded in `eslint.config.mjs` with a measured count of 3 violations.
+Re-measuring on the parent session's request found 2 — a small drift, and not the
+interesting part.
+
+The interesting part is that the count is not a count of the defect. Measured with a
+fixture matrix, one case per file, using `if` as a known-positive control:
+
+| guard | form                                           | detected |
+| ----- | ---------------------------------------------- | -------- |
+| `if`  | const, return, destructure, bare call          | all 4    |
+| `try` | destructuring declaration                      | yes      |
+| `try` | simple const, return-member, bare call, nested | no       |
+
+Under `if` every form is caught. Under `try` only the destructuring form is. The
+rule's message — _"React Hooks must be called in the exact same order in every
+render"_ — is equally true of all of them.
+
+`apps/web/src/pages/HouseholdPage.tsx` shows the consequence directly. It holds seven
+hook calls inside `try` blocks, five of them structurally identical `useOptional*`
+provider-tolerance wrappers. The rule reports two. Fixing those two would turn the
+file green over five surviving instances of the same defect, and the green would be
+the evidence that nothing remained.
+
+Repo-wide, forcing the rule on reports 2 findings in 1 file. A local rule that asks
+the question directly — is a `use*` call lexically inside a `try` block — reports **14
+across 7 files**. Read as a deferral budget, the recorded number understates the work
+by 7x.
+
+Three things generalise.
+
+**The population here is a set of syntactic forms, not a set of files.** Every earlier
+instance in this adoption narrowed over paths: files excluded, workspaces missing,
+steps not reached. This one narrows over _shapes_, inside files that were all scanned,
+by a rule that was correctly configured and correctly scoped. Printing a denominator
+would not have exposed it — the denominator was right. Only a differential against an
+instrument that asks the question a different way separates them.
+
+**The useful instrument was the one not built for the question.** The local rule was
+written to close the gap, so it is not independent evidence. The evidence is that the
+same tree yields 2 and 14 depending only on how the question is phrased, and the
+fixture matrix — five forms of one violation, one per file so attribution is not
+inferred — is what makes the divergence attributable to form rather than to scope.
+
+**Where coverage is not yours, relocate the claim.** The plugin's detection cannot be
+widened from here. What can be done here is to state the obligation in a rule this
+repository owns, at the granularity the repository actually cares about. That is the
+same move as moving a version assertion out of `engines` and into a check: not a
+second opinion on the same question, but the same claim relocated to a field where it
+can be made true.
+
+Two smaller notes from the same measurement, both corrections to things this document
+previously carried forward:
+
+- The claim that finance's 601 `.tsx` files load **zero** React rules is false and has
+  been since it was written. The same change that measured the gap also closed part of
+  it: 10 of the plugin's 17 rules have been enabled since. The finding was carried
+  forward and the fix was not — the defect the parent session named, occurring here.
+- `eslint-plugin-react` (peer `^9.7`) and `eslint-plugin-jsx-a11y` (peer `^9`) still
+  exclude ESLint 10, re-verified against installed 10.6.0. `eslint-plugin-react-hooks`
+  at 7.1.1 now admits `^10.0.0`, which is why the hooks rules could be adopted and the
+  other two still cannot. That half of the gap is real and unchanged.
+
+## Re-check carried-forward items at send time, not at discovery time
+
+Three separate items in this adoption have now been re-broadcast after they were
+closed, twice by the parent session and once here. The failure is not carelessness; it
+is that a finding and its fix are recorded at different moments and only the finding is
+carried in the running summary.
+
+The correction is cheap and belongs at the boundary: before restating a standing claim,
+re-run the measurement that produced it. In this document that means every claim stated
+as current carries the command that would refute it, so re-checking costs one
+invocation rather than a re-derivation. The `.tsx` claim above survived many restatements
+precisely because it read as a conclusion and not as a measurement.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -44,6 +44,71 @@ const moneyTemplateRule = {
   },
 };
 
+// react-hooks/rules-of-hooks detects a hook called inside `try` only when the
+// call is a destructuring declaration. Measured against a fixture matrix, one
+// case per file, with `if` as the known-positive control:
+//
+//   if  / const / return / destructure / bare-call  -> all FIRE
+//   try / destructuring declaration                 -> FIRES
+//   try / simple const, return-member, bare call    -> silent
+//
+// The consequence is not a missed edge case, it is a false denominator:
+// apps/web/src/pages/HouseholdPage.tsx has five structurally identical
+// `useOptional*` try/catch hook wrappers and the upstream rule reports two of
+// them. Fixing those two turns the file green over three surviving instances
+// of the same defect. The coverage of a rule this repository does not own is
+// not something this repository can widen, so the claim is relocated to a rule
+// it does own: any `use*` call lexically inside a `try` block is reported here,
+// independent of the syntactic form the call happens to take.
+const hookInTryRule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow React hook calls inside a try block; hook order must not depend on control flow.',
+    },
+    schema: [],
+    messages: {
+      hookInTry:
+        'React Hook "{{name}}" is called inside a try block, so its execution depends on control flow. Hooks must run unconditionally; use a provider default instead of catching a missing provider.',
+    },
+  },
+  create(context) {
+    const filename = context.filename ?? context.getFilename?.() ?? '';
+    const normalized = filename.replace(/\\/g, '/');
+    const isTestFile =
+      /\.test\.[cm]?[jt]sx?$/.test(normalized) || normalized.includes('/__tests__/');
+
+    function hookName(callee) {
+      if (callee?.type === 'Identifier') return callee.name;
+      if (callee?.type === 'MemberExpression' && callee.property?.type === 'Identifier') {
+        return callee.property.name;
+      }
+      return null;
+    }
+
+    return {
+      CallExpression(node) {
+        if (isTestFile) return;
+        const name = hookName(node.callee);
+        if (name == null || !/^use[A-Z]/.test(name)) return;
+
+        // Only the `try` block itself is conditional in the sense that matters:
+        // a hook in `catch`/`finally` is reported too, since neither runs on
+        // every render either. Walking ancestors keeps this independent of how
+        // deeply the call is nested inside the block.
+        const ancestors = context.sourceCode.getAncestors(node);
+        for (let i = ancestors.length - 1; i > 0; i -= 1) {
+          if (ancestors[i].type === 'TryStatement') {
+            context.report({ node, messageId: 'hookInTry', data: { name } });
+            return;
+          }
+        }
+      },
+    };
+  },
+};
+
 const dateLocaleRule = {
   meta: {
     type: 'problem',
@@ -136,6 +201,7 @@ export default [
         rules: {
           'no-money-template-interpolation': moneyTemplateRule,
           'no-hardcoded-date-locale': dateLocaleRule,
+          'no-hook-call-in-try': hookInTryRule,
         },
       },
     },
@@ -170,10 +236,17 @@ export default [
   //
   // Only the rules that are already at zero violations are enabled. The
   // remaining 7 of the plugin's 17 recommended-latest rules are NOT enabled;
-  // measured counts across 2,326 linted files are recorded in
+  // re-measured across 2,301 linted files (was 2,326) and recorded in
   // docs/guides/engineering-practice-adoption.md and tracked as follow-up work:
   //   set-state-in-effect 98, exhaustive-deps 34, preserve-manual-memoization 21,
-  //   refs 15, rules-of-hooks 3, immutability 2, purity 2.
+  //   refs 15, immutability 2, purity 2, rules-of-hooks 2.
+  //
+  // Every count above is a tool output, not a population, and rules-of-hooks
+  // shows how far those two can diverge: it reports 2, while the number of
+  // hooks actually called inside a `try` block in the same tree is 14 across 7
+  // files. Read as a deferral budget, "2" understates the work by 7x. The gap
+  // is a syntactic blind spot, not a severity choice -- see finance/no-hook-call-in-try
+  // above -- so this list is safe to use for sequencing and unsafe to use for sizing.
   {
     files: ['apps/web/src/**/*.{ts,tsx}'],
     plugins: { 'react-hooks': reactHooks },
@@ -188,6 +261,7 @@ export default [
       'react-hooks/unsupported-syntax': 'warn',
       'react-hooks/use-memo': 'error',
       'react-hooks/void-use-memo': 'error',
+      'finance/no-hook-call-in-try': 'error',
     },
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6917,25 +6917,6 @@
         "url": "https://ko-fi.com/dangreen"
       }
     },
-    "node_modules/git-raw-commits/node_modules/conventional-commits-parser": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
-      "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@simple-libs/stream-utils": "^1.2.0",
-        "meow": "^13.0.0"
-      },
-      "bin": {
-        "conventional-commits-parser": "dist/cli/index.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/git-raw-commits/node_modules/meow": {
       "version": "13.2.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6917,6 +6917,25 @@
         "url": "https://ko-fi.com/dangreen"
       }
     },
+    "node_modules/git-raw-commits/node_modules/conventional-commits-parser": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
+      "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@simple-libs/stream-utils": "^1.2.0",
+        "meow": "^13.0.0"
+      },
+      "bin": {
+        "conventional-commits-parser": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/git-raw-commits/node_modules/meow": {
       "version": "13.2.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",


### PR DESCRIPTION
## Summary

`react-hooks/rules-of-hooks` detects a hook called inside a `try` block **only when the call is a destructuring declaration**. Every other form of the identical violation is silent.

Measured with a fixture matrix, one case per file so attribution is not inferred, using `if` as a known-positive control:

| guard | form | detected |
| --- | --- | --- |
| `if` | const / return / destructure / bare call | **all 4** |
| `try` | destructuring declaration | yes |
| `try` | simple const, return-member, bare call, nested | **no** |

## Why this is a false denominator, not an edge case

`apps/web/src/pages/HouseholdPage.tsx` holds seven hook calls inside `try` blocks, five of them structurally identical `useOptional*` provider-tolerance wrappers. The rule reports **two**. Fixing those two turns the file green over five surviving instances of the same defect — and the green is what would make it credible.

Repo-wide:

| instrument | findings | files |
| --- | --- | --- |
| `react-hooks/rules-of-hooks` (forced on) | 2 | 1 |
| `finance/no-hook-call-in-try` (this PR) | **14** | **7** |

`eslint.config.mjs` recorded a deferral budget of `rules-of-hooks 3`. That was a tool output, not a population. Read as a sizing estimate it understates the work **7x**.

## What changed

- **`finance/no-hook-call-in-try`** — new local rule, `error`, scoped to `apps/web/src`. Reports any `use*` call lexically inside a `try` block, independent of syntactic form. Coverage of a rule this repository does not own cannot be widened here, so the claim is relocated to one it does own.
- **14 per-line suppressions** with `-- provider-tolerance pattern, tracked in #4248`. Per-line rather than path-scoped, so the narrowing stays one line wide and stays counted. `--report-unused-disable-directives` reports none unused, which confirms every one fired.
- **Deferred-rule counts re-measured** across 2,301 files (was 2,326). Only `rules-of-hooks` drifted, 3 → 2. The comment now states these are tool outputs: safe for sequencing, unsafe for sizing.

## Verification

Differential run with the upstream rule **explicitly forced on** — it is otherwise disabled, so a naive comparison would have measured configuration rather than coverage:

```
barecall       finance: FIRES | upstream(forced on): silent
destructure    finance: FIRES | upstream(forced on): FIRES
nested         finance: FIRES | upstream(forced on): FIRES
returnmem      finance: FIRES | upstream(forced on): silent
simpleconst    finance: FIRES | upstream(forced on): silent
--- forms detected: finance 5/5, upstream 2/5
```

Gates, all exit 0: `tool:imports:check`, `node:version:check`, `workflow:security:check`, `gradle:prefetch:check`, `citations:enumerations:check`, `eng:vendor:check`, `eng:citations`, `type-check`, `eslint --max-warnings 0 --report-unused-disable-directives`, `prettier --check`.

## Two carried-forward claims corrected

- **"601 `.tsx` files load zero React rules" is false**, and has been since it was written — the same change that measured the gap also enabled 10 of the plugin's 17 rules. The finding was carried forward and the fix was not.
- **`eslint-plugin-react` (peer `^9.7`) and `eslint-plugin-jsx-a11y` (peer `^9`) still exclude ESLint 10**, re-verified against installed 10.6.0. `eslint-plugin-react-hooks@7.1.1` now admits `^10.0.0`, which is why hooks rules could be adopted and the other two still cannot. That half of the gap is real and unchanged.

## Issues

Refs #4248

## Testing

- [x] Fixture matrix, one case per file, with a known-positive control
- [x] Differential against the upstream rule forced on
- [x] All seven repo gates, type-check, lint, format