### PR TITLE
fix(ci): state the temporal scope of the workflow pinning gate

### DIFF
--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -7499,6 +7499,114 @@ as current carries the command that would refute it, so re-checking costs one
 invocation rather than a re-derivation. The `.tsx` claim above survived many restatements
 precisely because it read as a conclusion and not as a measurement.
 
+## A state census cannot answer an event question, and repair is what hides the difference
+
+The sibling session found this in its own tree: a claim of the form _"this has
+never happened in 154 release-era tags"_ was a census of surviving **states**,
+while the thing being claimed was an **event**. The event had occurred that same
+day and had been repaired within two minutes, and the repair removed it from the
+census. Worse, the repair was cheap by design, so the census under-counts by an
+amount the design guarantees will be most of them.
+
+finance has the same shape, and here it is measurable, because git keeps the
+history that a working tree does not.
+
+`workflow:security:check` verifies every `uses:` ref is pinned to a 40-character
+SHA. It passes, and it is right to pass:
+
+```
+31 workflow(s) scanned; 30 of 30 named assertion target(s) present
+```
+
+Walking the 209 commits that touched `.github/workflows` on `main`:
+
+| measure                                    | value                                            |
+| ------------------------------------------ | ------------------------------------------------ |
+| commits examined                           | 209                                              |
+| commits carrying at least one unpinned ref | **89 (42.6%)**                                   |
+| distinct unpinned refs over time           | 23                                               |
+| most recent                                | `actions/attest-build-provenance@v4`, 2026-08-07 |
+| working tree                               | clean                                            |
+
+So the compliance the gate reports was **achieved, not maintained**, and the most
+recent lapse was five days before the gate was read, not in some distant
+pre-adoption era. Nothing in the gate's output is false. What the output invites
+is an inference about the repository from a measurement of the tree.
+
+**This is a different axis from every previous scope defect in this document.**
+All the earlier ones were about _which files_ an instrument looked at: excluded
+tests, missing workspaces, unreached steps, and the remedy was to print the
+denominator. That remedy does not touch this one, because the file denominator
+was already complete and correct -- 31 of 31. The narrowing is **temporal**, and a
+file count cannot express it at any level of detail.
+
+The fix is the same sentence in a different dimension. The gate now says what
+point in time it speaks for, and `npm run workflow:pin:history` answers the event
+question directly, so the claim can be re-measured in one invocation instead of
+re-derived. It is deliberately not a CI gate: it needs full history, which shallow
+CI clones lack, and a check that fails a pull request for what an earlier commit
+did is pointed at the wrong target.
+
+### The census was wrong first, in the accusatory direction
+
+The first version reported **209 of 209** commits dirty, including a HEAD the gate
+passes. Three refs drove it -- `actions/setup-python@v5`, `setup-dotnet@v4`,
+`setup-java@v4` -- and all three are inside a commented-out block of future setup
+steps in `copilot-setup-steps.yml`:
+
+```yaml
+# - name: Setup Python
+#   uses: actions/setup-python@v5
+```
+
+`git grep uses:` matches comments. The gate does not, and the gate was correct
+throughout. Had the disagreement not been checked by hand before being written
+down, it would have shipped as a finding that the pinning gate was broken.
+
+That is the failure mode the sibling named in the same message and then found in
+its own wording: **an instrument that fails toward accusation.** Both halves
+occurred here within the same hour -- their clause said a published package was
+never published, and my census said a compliant tree was non-compliant. The
+common structure is that both instruments were measuring a proxy (`publish` job
+conclusion; `uses:` text) and reporting the conclusion in the vocabulary of the
+target (registry state; pinning compliance).
+
+The rule that follows is narrower and more useful than "fail toward silence":
+**an instrument may only accuse in the vocabulary it actually measured.** The
+census can say _"this line of text is not a 40-hex ref"_. It cannot say _"this
+repository is unpinned"_ until it knows what a step is.
+
+Both exclusions are now pinned by name in `check-workflow-pin-history.test.mjs`,
+including one asserting that a commented-out step next to a real one does not
+mask it -- the over-correction is as available as the original defect.
+
+A fourth surfaced only under mutation testing, and it is the subtlest. The tool
+excluded local reusable workflows with `if (action.startsWith('./')) continue;`,
+and a test asserted that `uses: ./.github/workflows/ci-shared.yml` produced no
+finding. The test passed. Deleting the guard entirely did not fail it.
+
+The reason is that the match pattern requires an `@ref`, and a local reusable
+workflow has none, so such a line never reaches the guard. The test was green
+because the fixture could not get that far -- **coverage of a branch by a fixture
+that never enters it.** The guard was dead code, and the test was documentation
+of an intention rather than a constraint on behaviour.
+
+This is the same structure as the deferred-rule count elsewhere in this document:
+a number, or a green, that is true of the wrong population. Here the population
+was "inputs that reach line N", and it was empty. The guard is now removed and
+the test asserts the _reason_ -- that the string contains no `@` -- so it fails if
+the pattern is ever widened to match refless `uses:` entries.
+
+Mutation testing is what separated these. The test suite was 16 for 16 green both
+before and after the guard existed, and no amount of re-reading the tests would
+have said which. Six mutants, six killed, after.
+A third defect surfaced only in the extraction. The scratch census recorded
+first-seen attribution with `if (!refs.has(entry))`, which -- because `git log` is
+reverse-chronological -- kept the **newest** commit under a name meaning the
+oldest. The headline counts do not depend on attribution, so the scratch run was
+clean, correct, and wrong in a field nobody read. It was caught by writing the
+test, not by re-reading the code.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:

--- a/package-lock.json
+++ b/package-lock.json
@@ -6917,25 +6917,6 @@
         "url": "https://ko-fi.com/dangreen"
       }
     },
-    "node_modules/git-raw-commits/node_modules/conventional-commits-parser": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
-      "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@simple-libs/stream-utils": "^1.2.0",
-        "meow": "^13.0.0"
-      },
-      "bin": {
-        "conventional-commits-parser": "dist/cli/index.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/git-raw-commits/node_modules/meow": {
       "version": "13.2.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6917,6 +6917,25 @@
         "url": "https://ko-fi.com/dangreen"
       }
     },
+    "node_modules/git-raw-commits/node_modules/conventional-commits-parser": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
+      "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@simple-libs/stream-utils": "^1.2.0",
+        "meow": "^13.0.0"
+      },
+      "bin": {
+        "conventional-commits-parser": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/git-raw-commits/node_modules/meow": {
       "version": "13.2.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "ai:manifest:test": "node --test tools/check-ai-manifest.test.mjs",
     "encoding:check": "node tools/check-text-encoding.mjs",
     "workflow:security:check": "node tools/check-workflow-security.mjs",
+    "workflow:pin:history": "node tools/check-workflow-pin-history.mjs",
     "workflow:security:test": "node --test tools/check-workflow-security.test.mjs",
     "gradle:prefetch:check": "node tools/check-gradle-prefetch.mjs",
     "tool:imports:check": "node tools/check-tool-imports.mjs",

--- a/tools/check-workflow-pin-history.mjs
+++ b/tools/check-workflow-pin-history.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Answers the event question that `check-workflow-security.mjs` cannot.
+ *
+ * The pinning gate is a state census over the working tree. Unpinned action
+ * refs are remediable, and remediation removes the evidence, so a green tree
+ * says nothing about whether the violation ever landed. This walks the history
+ * of `.github/workflows` and counts the commits that actually carried one.
+ *
+ * Deliberately not wired into CI. It needs full history, which shallow CI
+ * clones do not have, and a historical report that fails a pull request for
+ * something a previous commit did is a gate pointed at the wrong target.
+ */
+
+import { execFileSync } from 'node:child_process';
+
+const SHA_RE = /^[0-9a-f]{40}$/;
+const USES_RE = /uses:\s*['"]?([^\s'"@]+)@([^\s'"#]+)/;
+
+/**
+ * Extract unpinned `uses:` refs from raw workflow text.
+ *
+ * One exclusion, load-bearing, and discovered by getting it wrong: fully
+ * commented-out lines are not steps. A first version of this census omitted the
+ * comment rule and reported 209 of 209 commits dirty, including a HEAD the gate
+ * passes -- an instrument defect pointing in the accusatory direction, which is
+ * the one direction an instrument must not fail in.
+ *
+ * Local reusable workflows (`uses: ./.github/workflows/x.yml`) need no
+ * exclusion: they carry no `@ref`, so the pattern never matches them. An
+ * explicit `startsWith('./')` guard was removed after mutation testing showed
+ * it could be deleted without failing anything -- the test that appeared to
+ * cover it was passing because the fixture had no `@` either, not because the
+ * guard did any work.
+ *
+ * @param {string} text Raw lines containing candidate `uses:` entries.
+ * @returns {Set<string>} Distinct `action@ref` strings that are not SHA-pinned.
+ */
+export function unpinnedRefs(text) {
+  const found = new Set();
+  for (const line of text.split('\n')) {
+    if (/^\s*#/.test(line)) continue;
+    const match = line.match(USES_RE);
+    if (!match) continue;
+    const [, action, ref] = match;
+    if (!SHA_RE.test(ref)) found.add(`${action}@${ref}`);
+  }
+  return found;
+}
+
+/**
+ * Census the pinning state of every commit that touched the workflow directory.
+ *
+ * @param {(args: string[]) => string} git Runner returning git stdout.
+ * @param {string} ref Git ref to walk.
+ * @returns {{examined: number, dirty: number, refs: Map<string, string>, lastDirty: object | null, headClean: boolean}}
+ *   `refs` maps each unpinned `action@ref` to the oldest commit that carried it.
+ */
+export function censusHistory(git, ref = 'origin/main') {
+  const listed = git([
+    'log',
+    '--format=%H %ad',
+    '--date=short',
+    ref,
+    '--',
+    '.github/workflows',
+  ]).trim();
+  const commits = listed === '' ? [] : listed.split('\n').map((line) => line.split(' '));
+
+  const refs = new Map();
+  let dirty = 0;
+  let lastDirty = null;
+  let headClean = true;
+
+  for (const [sha, date] of commits) {
+    let text;
+    try {
+      text = git(['grep', '-h', '-E', 'uses:', sha, '--', '.github/workflows']);
+    } catch {
+      continue;
+    }
+    const bad = unpinnedRefs(text);
+    if (bad.size === 0) continue;
+    dirty += 1;
+    if (lastDirty === null) lastDirty = { sha: sha.slice(0, 8), date, refs: [...bad] };
+    if (sha === commits[0][0]) headClean = false;
+    for (const entry of bad) {
+      // git log is reverse-chronological, so overwriting on every pass leaves
+      // the oldest commit carrying the ref -- when it was introduced. Keeping
+      // the first write would record the most recent occurrence under a name
+      // that says the opposite; the scratch census this was extracted from had
+      // that inverted and never noticed, because the headline counts do not
+      // depend on which commit gets attributed.
+      refs.set(entry, `${sha.slice(0, 8)} ${date}`);
+    }
+  }
+
+  return { examined: commits.length, dirty, refs, lastDirty, headClean };
+}
+
+function main() {
+  const ref = process.argv[2] ?? 'origin/main';
+  const git = (args) =>
+    execFileSync('git', args, { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+
+  const { examined, dirty, refs, lastDirty, headClean } = censusHistory(git, ref);
+
+  if (examined === 0) {
+    console.log(`No commits touching .github/workflows found on ${ref}.`);
+    return;
+  }
+
+  const percent = ((dirty / examined) * 100).toFixed(1);
+  console.log(`Workflow pin history for ${ref}:`);
+  console.log(`  commits examined            ${examined}`);
+  console.log(`  commits with >=1 unpinned   ${dirty} (${percent}%)`);
+  console.log(`  distinct unpinned refs      ${refs.size}`);
+  console.log(`  working tree at ${ref}      ${headClean ? 'clean' : 'UNPINNED REFS PRESENT'}`);
+  if (lastDirty) {
+    console.log(`  most recent occurrence      ${lastDirty.sha} ${lastDirty.date}`);
+    console.log(`    ${lastDirty.refs.slice(0, 4).join(', ')}`);
+  }
+  console.log('');
+  console.log('This is a history report, not a gate. A clean working tree means the');
+  console.log('violations were repaired, not that they never happened; the pinning gate');
+  console.log('cannot distinguish those two and does not claim to.');
+}
+
+if (process.argv[1] && process.argv[1].endsWith('check-workflow-pin-history.mjs')) {
+  main();
+}

--- a/tools/check-workflow-pin-history.test.mjs
+++ b/tools/check-workflow-pin-history.test.mjs
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { censusHistory, unpinnedRefs } from './check-workflow-pin-history.mjs';
+
+const SHA = 'a'.repeat(40);
+
+test('a SHA-pinned ref is not reported', () => {
+  assert.equal(unpinnedRefs(`      - uses: actions/checkout@${SHA} # v7.0.0`).size, 0);
+});
+
+test('a tag-pinned ref is reported', () => {
+  const found = unpinnedRefs('      - uses: actions/checkout@v4');
+  assert.deepEqual([...found], ['actions/checkout@v4']);
+});
+
+test('a branch-pinned ref is reported', () => {
+  const found = unpinnedRefs('      - uses: trufflesecurity/trufflehog@main');
+  assert.deepEqual([...found], ['trufflesecurity/trufflehog@main']);
+});
+
+test('a fully commented-out step is not reported', () => {
+  // The defect that produced 209-of-209 on the first census: `git grep uses:`
+  // matches commented-out future steps, and those are not steps.
+  const text = [
+    '      # - name: Setup Python',
+    '      #   uses: actions/setup-python@v5',
+    '      #   uses: actions/setup-dotnet@v4',
+  ].join('\n');
+  assert.equal(unpinnedRefs(text).size, 0);
+});
+
+test('a commented-out step does not mask a real one on another line', () => {
+  const text = ['      #   uses: actions/setup-python@v5', '      - uses: actions/stale@v9'].join(
+    '\n',
+  );
+  assert.deepEqual([...unpinnedRefs(text)], ['actions/stale@v9']);
+});
+
+test('a trailing comment does not hide the ref before it', () => {
+  const found = unpinnedRefs('      - uses: actions/checkout@v4 # not pinned');
+  assert.deepEqual([...found], ['actions/checkout@v4']);
+});
+
+test('a local reusable workflow never matches, because it carries no @ref', () => {
+  // Asserting the reason, not just the outcome. An earlier version of this test
+  // read as coverage for an explicit `./` guard; mutation testing showed the
+  // guard could be deleted with the test still green, because the fixture has
+  // no `@` and so never reaches the guard at all. The guard was removed.
+  assert.equal(unpinnedRefs('      uses: ./.github/workflows/ci-shared.yml').size, 0);
+  assert.doesNotMatch('      uses: ./.github/workflows/ci-shared.yml', /@/);
+});
+
+test('duplicate refs collapse to one entry', () => {
+  const text = ['      - uses: actions/stale@v9', '      - uses: actions/stale@v9'].join('\n');
+  assert.equal(unpinnedRefs(text).size, 1);
+});
+
+test('quoted refs are handled', () => {
+  assert.deepEqual([...unpinnedRefs("      - uses: 'actions/stale@v9'")], ['actions/stale@v9']);
+});
+
+function fakeGit(log, grepBySha) {
+  return (args) => {
+    if (args[0] === 'log') return log;
+    if (args[0] === 'grep') {
+      const sha = args[4];
+      if (!(sha in grepBySha)) throw new Error('no match');
+      return grepBySha[sha];
+    }
+    throw new Error(`unexpected git call: ${args.join(' ')}`);
+  };
+}
+
+test('census counts only the commits that carried a violation', () => {
+  const git = fakeGit('aaa 2026-01-03\nbbb 2026-01-02\nccc 2026-01-01', {
+    aaa: `      - uses: actions/checkout@${SHA}`,
+    bbb: '      - uses: actions/stale@v9',
+    ccc: '      - uses: actions/stale@v9',
+  });
+  const result = censusHistory(git, 'origin/main');
+  assert.equal(result.examined, 3);
+  assert.equal(result.dirty, 2);
+  assert.equal(result.refs.size, 1);
+});
+
+test('census reports a clean head separately from a clean history', () => {
+  const git = fakeGit('aaa 2026-01-02\nbbb 2026-01-01', {
+    aaa: `      - uses: actions/checkout@${SHA}`,
+    bbb: '      - uses: actions/stale@v9',
+  });
+  const result = censusHistory(git, 'origin/main');
+  assert.equal(result.headClean, true, 'head is pinned');
+  assert.equal(result.dirty, 1, 'history is not');
+});
+
+test('census flags a dirty head', () => {
+  const git = fakeGit('aaa 2026-01-01', { aaa: '      - uses: actions/stale@v9' });
+  assert.equal(censusHistory(git, 'origin/main').headClean, false);
+});
+
+test('most recent occurrence is the newest dirty commit, not the newest commit', () => {
+  const git = fakeGit('aaa 2026-01-03\nbbb 2026-01-02\nccc 2026-01-01', {
+    aaa: `      - uses: actions/checkout@${SHA}`,
+    bbb: '      - uses: actions/stale@v9',
+    ccc: '      - uses: actions/checkout@v4',
+  });
+  const result = censusHistory(git, 'origin/main');
+  assert.equal(result.lastDirty.sha, 'bbb');
+  assert.equal(result.lastDirty.date, '2026-01-02');
+});
+
+test('first-seen attribution keeps the oldest commit for a ref', () => {
+  const git = fakeGit('aaa 2026-01-02\nbbb 2026-01-01', {
+    aaa: '      - uses: actions/stale@v9',
+    bbb: '      - uses: actions/stale@v9',
+  });
+  const result = censusHistory(git, 'origin/main');
+  assert.match(result.refs.get('actions/stale@v9'), /bbb 2026-01-01/);
+});
+
+test('a commit whose grep finds nothing is skipped, not counted dirty', () => {
+  const git = fakeGit('aaa 2026-01-01\nbbb 2026-01-02', {
+    aaa: '      - uses: actions/stale@v9',
+  });
+  const result = censusHistory(git, 'origin/main');
+  assert.equal(result.examined, 2);
+  assert.equal(result.dirty, 1);
+});
+
+test('an empty history reports zero rather than throwing', () => {
+  const result = censusHistory(fakeGit('', {}), 'origin/main');
+  assert.equal(result.examined, 0);
+  assert.equal(result.dirty, 0);
+  assert.equal(result.lastDirty, null);
+});

--- a/tools/check-workflow-security.mjs
+++ b/tools/check-workflow-security.mjs
@@ -652,6 +652,14 @@ function main() {
     return;
   }
   console.log(`Workflow security regression check passed. ${scopeLine}`);
+  // The file denominator above is complete; the temporal one is not, and no
+  // file count can expose that. Pinning violations are remediable, so this
+  // check reports the state of the tree it was handed and cannot distinguish
+  // "never happened" from "happened and was repaired". Run
+  // `npm run workflow:pin:history` for the event question.
+  console.log(
+    'Scope is the working tree at this commit, not the history: a repaired violation leaves no trace here.',
+  );
 }
 
 if (resolve(process.argv[1] ?? '') === fileURLToPath(import.meta.url)) {


### PR DESCRIPTION
## Summary

`workflow:security:check` verifies every `uses:` ref is pinned to a 40-character SHA (`GH-ACT-003`). It passes, and it is right to pass.

It is also a **state census answering an event question**. Pinning violations are remediable, and repair removes the evidence — so a green tree cannot distinguish *never happened* from *happened and was fixed*.

Walking the 209 commits touching `.github/workflows` on `main`:

| measure | value |
| --- | --- |
| commits examined | 209 |
| commits carrying ≥1 unpinned ref | **89 (42.6%)** |
| distinct unpinned refs over time | 23 |
| most recent | `actions/attest-build-provenance@v4`, 2026-08-07 |
| working tree | clean |

Compliance was **achieved, not maintained**, and the most recent lapse was five days before the gate was read. Nothing the gate prints is false; what it invites is an inference about the repository from a measurement of the tree.

## Why this is a new axis

Every previous scope fix here was about *which files* an instrument looked at, and the remedy was to print the denominator. **That remedy does not reach this one** — the file denominator was already complete and correct at 31 of 31. The narrowing is *temporal*, and a file count cannot express it at any level of detail.

## What changed

- `check-workflow-security.mjs` now states what point in time it speaks for, on the passing path.
- `tools/check-workflow-pin-history.mjs` + `npm run workflow:pin:history` answers the event question in one invocation, so the claim can be re-measured instead of re-derived.
- **Not wired into CI**, deliberately: it needs full history that shallow CI clones lack, and failing a PR for what an earlier commit did points the check at the wrong target.

## The census was wrong first, in the accusatory direction

Version one reported **209 of 209** dirty — including a HEAD the gate passes. Cause: `git grep uses:` matches commented-out future steps in `copilot-setup-steps.yml`:

```yaml
      # - name: Setup Python
      #   uses: actions/setup-python@v5
```

The gate was correct throughout. Checking the disagreement by hand before writing it down is the only reason this didn't ship as a finding that the pinning gate was broken. Both sessions produced an accusation-shaped instrument within the same hour, and the shared structure is measuring a *proxy* while reporting in the vocabulary of the *target*. The rule that follows is narrower than "fail toward silence": **an instrument may only accuse in the vocabulary it actually measured.**

## Two further defects, found while extracting the scratch census

1. **Inverted attribution.** `git log` is reverse-chronological, so `if (!refs.has(entry))` recorded the *newest* commit under a name meaning *oldest*. Invisible because the headline counts don't depend on attribution — the scratch run was clean, correct, and wrong in a field nobody read. Caught by writing the test, not by re-reading the code.
2. **A dead guard with a test that appeared to cover it.** `startsWith('./')` excluded local reusable workflows, and a test asserted they produce no finding. Deleting the guard didn't fail it — the pattern requires an `@ref` and local workflows have none, so such lines never reach the guard. **Coverage of a branch by a fixture that never enters it.** Guard removed; the test now asserts the reason.

Mutation testing is what separated these: 16/16 green both with and without the guard. **6 mutants, 6 killed** after.

## Verification

`workflow:pin:history` reproduces the census exactly (209 / 89 / 23), unchanged after the guard removal. Gates all exit 0: `tool:imports:check`, `node:version:check`, `workflow:security:check`, `gradle:prefetch:check`, `citations:enumerations:check`, `eng:vendor:check`, `eng:citations`, plus `eslint --max-warnings 0` and `prettier --check`.

## Issues

Closes #4250

## Testing

- [x] 16 unit tests, 6/6 mutants killed
- [x] Tool output cross-checked against the scratch census it replaces
- [x] All seven repo gates, lint, format