### PR TITLE
fix(tools): report the manifest check's own trigger blind spot (#4251)

### DIFF
--- a/tools/check-ai-manifest.js
+++ b/tools/check-ai-manifest.js
@@ -398,7 +398,7 @@ function validateActivationDoc() {
 
 function validateSyncLock() {
   const findings = [];
-  const lock = readJson('.studio-sync.lock.json', findings);
+  const lock = readJson(SYNC_LOCK, findings);
   if (!lock) return findings;
   if (lock.version !== 1) findings.push(`sync lock version is ${lock.version}; expected 1`);
   if (lock.backbone !== 'jrmoulckers/.github') {
@@ -571,6 +571,7 @@ function citationFindings(text, citations = CANON_CITATIONS) {
 // does rewriting the sentence without flipping STRICT.
 const ENFORCEMENT_WORKFLOW = '.github/workflows/ai-manifest-check.yml';
 const ENFORCEMENT_STEP = 'Check for drift';
+const SYNC_LOCK = '.studio-sync.lock.json';
 
 /**
  * Determine whether the drift step blocks, by reading the workflow rather than believing prose.
@@ -615,6 +616,77 @@ function enforcementFindings(workflowText, docText) {
   }
   if (read.mode === 'blocking' && saysWarn) {
     findings.push('the drift step now blocks, but the docs still describe it as warn-only');
+  }
+  return findings;
+}
+
+/**
+ * Parse the workflow's `pull_request.paths` trigger globs.
+ *
+ * Fails closed: an unparseable or absent trigger is an error, not an empty list, because an
+ * empty list would read as "nothing is excluded" — the inverse of the truth.
+ *
+ * @param {string} workflowText Contents of the manifest-check workflow.
+ * @returns {{globs: string[]}|{error: string}}
+ */
+function triggerPaths(workflowText) {
+  const at = workflowText.indexOf('pull_request:');
+  if (at < 0) return { error: 'no pull_request trigger' };
+  const rest = workflowText.slice(at);
+  const pathsAt = rest.indexOf('paths:');
+  if (pathsAt < 0) return { error: 'pull_request trigger declares no paths filter' };
+  const globs = [...rest.slice(pathsAt).matchAll(/^\s+- '([^']+)'/gm)].map((m) => m[1]);
+  if (globs.length === 0) return { error: 'paths filter is empty' };
+  return { globs };
+}
+
+/**
+ * Does a trigger glob cover this repository-relative path?
+ *
+ * @param {string[]} globs Trigger globs.
+ * @param {string} file Repository-relative path.
+ * @returns {boolean}
+ */
+function triggerCovers(globs, file) {
+  return globs.some((glob) =>
+    glob.endsWith('/**') ? file.startsWith(`${glob.slice(0, -3)}/`) : glob === file,
+  );
+}
+
+/**
+ * Report inputs this check reads that its own trigger cannot fire on.
+ *
+ * A path-filtered check is only as good as its filter: an edit outside the filter produces no run
+ * at all, which renders in the PR list as an absent check rather than a failing one — and an
+ * absent section is not a report (#4212). The self-referential case is the sharp one:
+ * `enforcementFindings` above reads the workflow to catch prose/workflow disagreement, so a
+ * workflow-only edit is precisely the change that guard exists to catch and precisely the change
+ * that cannot trigger it (#4251).
+ *
+ * @param {string} workflowText Contents of the manifest-check workflow.
+ * @param {string[]} managedKeys Managed entry paths from the sync lock.
+ * @returns {string[]} Findings; empty when every input is covered.
+ */
+function triggerFindings(workflowText, managedKeys) {
+  const read = triggerPaths(workflowText);
+  if (read.error) return [`cannot read the trigger: ${read.error}`];
+
+  const findings = [];
+  // Read by validateEnforcementDoc and validateSyncLock respectively. Named explicitly because
+  // neither is a managed entry, so neither appears in the lock walk below.
+  for (const file of [ENFORCEMENT_WORKFLOW, SYNC_LOCK]) {
+    if (!triggerCovers(read.globs, file)) {
+      findings.push(`${file} is read by this check but cannot trigger it`);
+    }
+  }
+
+  const uncovered = managedKeys.filter((key) => !triggerCovers(read.globs, key));
+  if (uncovered.length > 0) {
+    const groups = [...new Set(uncovered.map((key) => key.split('/').slice(0, 2).join('/')))];
+    findings.push(
+      `${uncovered.length} of ${managedKeys.length} managed entries cannot trigger this check ` +
+        `(${groups.join(', ')})`,
+    );
   }
   return findings;
 }
@@ -1120,6 +1192,15 @@ function readEnforcementMode() {
   return read.error ? `unreadable (${read.error})` : read.mode;
 }
 
+function validateTriggerCoverage() {
+  const workflowPath = path.join(ROOT, ENFORCEMENT_WORKFLOW);
+  const lockPath = path.join(ROOT, SYNC_LOCK);
+  if (!fs.existsSync(workflowPath)) return [`missing workflow: ${ENFORCEMENT_WORKFLOW}`];
+  if (!fs.existsSync(lockPath)) return [`missing ${SYNC_LOCK}`];
+  const lock = JSON.parse(fs.readFileSync(lockPath, 'utf8'));
+  return triggerFindings(fs.readFileSync(workflowPath, 'utf8'), Object.keys(lock.entries ?? lock));
+}
+
 /**
  * Compare the workflow's real drift enforcement with how AGENTS.md describes it.
  *
@@ -1162,6 +1243,7 @@ function main() {
     ...validateActivationDoc(),
     ...validateSyncLock(),
     ...validateEnforcementDoc(),
+    ...validateTriggerCoverage(),
   ];
   for (const doc of scan.missing) process.stdout.write(`- ${doc}: not found\n`);
   // Printed unconditionally, in both the passing and the failing branch. The old report emitted
@@ -1289,6 +1371,10 @@ module.exports = {
   ENFORCEMENT_WORKFLOW,
   driftEnforcement,
   enforcementFindings,
+  SYNC_LOCK,
+  triggerPaths,
+  triggerCovers,
+  triggerFindings,
   HELP_TEXT,
   EXPECTED_AGENTS,
   MANAGED_COUNTS,

--- a/tools/check-ai-manifest.test.mjs
+++ b/tools/check-ai-manifest.test.mjs
@@ -32,6 +32,10 @@ const {
   ENFORCEMENT_WORKFLOW,
   driftEnforcement,
   enforcementFindings,
+  SYNC_LOCK,
+  triggerPaths,
+  triggerCovers,
+  triggerFindings,
   METRICS,
   HELP_TEXT,
   EXPECTED_AGENTS,
@@ -940,4 +944,59 @@ test('the report states CI enforcement, not just this invocation mode (#4233)', 
     out.indexOf('CI drift enforcement') < out.indexOf('Canonical runtime activation:'),
     'enforcement disclosure must precede the verdict it qualifies',
   );
+});
+
+// --- #4251: a path-filtered check cannot fire on the files outside its filter ------------
+//
+// An edit outside `on.pull_request.paths` produces no run, which renders as an ABSENT check in
+// the PR list rather than a failing one. The self-referential case is the sharp one and it is
+// why this exists: `enforcementFindings` reads the workflow to catch prose/workflow
+// disagreement, so a workflow-only edit is exactly what that guard is for and exactly what
+// cannot trigger it.
+
+test('an unreadable trigger is an error, never an empty glob list (#4251)', () => {
+  // Failing closed matters more here than elsewhere: an empty list would make triggerCovers
+  // return false for everything, which reads as "total coverage gap" rather than "unknown",
+  // while a silently-empty parse would read as "nothing excluded". Both are wrong; error is not.
+  assert.ok('error' in triggerPaths('name: x\non:\n  workflow_dispatch:\n'));
+  assert.ok('error' in triggerPaths('on:\n  pull_request:\n    branches: [main]\n'));
+  assert.ok('error' in triggerPaths('on:\n  pull_request:\n    paths:\n'));
+  const ok = triggerPaths("on:\n  pull_request:\n    paths:\n      - 'AGENTS.md'\n");
+  assert.deepEqual(ok.globs, ['AGENTS.md']);
+});
+
+test('trigger globs cover a subtree only via /** (#4251)', () => {
+  const globs = ['.github/agents/**', 'AGENTS.md'];
+  assert.equal(triggerCovers(globs, '.github/agents/architect.agent.md'), true);
+  assert.equal(triggerCovers(globs, 'AGENTS.md'), true);
+  // A prefix match without the separator would wrongly cover a sibling directory.
+  assert.equal(triggerCovers(globs, '.github/agents-extra/x.md'), false);
+  assert.equal(triggerCovers(globs, 'vendor/@jrm/tokens/css/default/tokens.css'), false);
+  assert.equal(triggerCovers(globs, 'AGENTS.md.bak'), false);
+});
+
+test('the workflow this check reads must be able to trigger it (#4251)', () => {
+  const covering =
+    "on:\n  pull_request:\n    paths:\n      - '.github/workflows/ai-manifest-check.yml'\n" +
+    "      - '.studio-sync.lock.json'\n";
+  assert.deepEqual(triggerFindings(covering, []), [], 'fully covered inputs are not a finding');
+
+  const blind = "on:\n  pull_request:\n    paths:\n      - 'AGENTS.md'\n";
+  const findings = triggerFindings(blind, []);
+  assert.equal(findings.length, 2);
+  assert.ok(findings.some((f) => f.includes(ENFORCEMENT_WORKFLOW)));
+  assert.ok(findings.some((f) => f.includes(SYNC_LOCK)));
+});
+
+test('uncovered managed entries are counted against the whole population (#4251)', () => {
+  const globs =
+    "on:\n  pull_request:\n    paths:\n      - '.github/workflows/ai-manifest-check.yml'\n" +
+    "      - '.studio-sync.lock.json'\n      - '.github/agents/**'\n";
+  const keys = ['.github/agents/a.md', 'vendor/@jrm/tokens/x.css', 'agency.toml'];
+  const findings = triggerFindings(globs, keys);
+  assert.equal(findings.length, 1);
+  // The denominator is the point: "2 uncovered" alone cannot be read without the population.
+  assert.match(findings[0], /2 of 3 managed entries/);
+  assert.match(findings[0], /vendor\/@jrm/);
+  assert.deepEqual(triggerFindings(globs, ['.github/agents/a.md']), []);
 });


### PR DESCRIPTION
## Summary

The AI Manifest Check is path-filtered, and the filter excludes most of the surface it validates:

```
managed entries covered by the trigger:   47 / 81
                                   GAP:   34

  vendor/@jrm                       0 / 23
  .github/prompts                   0 /  8
  agency.toml / .gitattributes / .github/copilot-instructions.md   0 / 3

files this check READS but that cannot trigger it:
  .studio-sync.lock.json                       <- validateSyncLock()
  .github/workflows/ai-manifest-check.yml      <- validateEnforcementDoc()
```

An edit outside the filter produces **no run at all** — an *absent* check in the PR list, not a
failing one. That is strictly quieter than warn-only, which at least prints (#4212).

## The self-referential case

One PR old. #4233 added `enforcementFindings` to catch the workflow and `AGENTS.md` disagreeing
about enforcement — but the workflow is not in its own `paths` filter. **A workflow-only edit is
precisely the change that guard exists to catch, and precisely the change that cannot trigger it.**
Flipping `STRICT` or renaming the step would sail through.

Root cause is the class `jrmoulckers/.github` named this week: *a hazard named at one call site does
not generalise to the call site next to it.* I added a guard that reads the workflow and did not add
the workflow to the trigger that runs the guard.

## Changes

- `triggerPaths()` — **fails closed**. An absent or empty filter is an error, never an empty glob
  list; an empty list would read as "nothing is excluded", the inverse of the truth.
- `triggerCovers()` — subtree match requires the separator, so `.github/agents-extra/` is not
  covered by `.github/agents/**`.
- `triggerFindings()` — counts uncovered entries **against the whole population** (`34 of 81`),
  because a bare "34" cannot be read.

**Detection only — the workflow is not modified.**

## Still needed (human-gated)

The repair is added globs in the workflow's `paths:` filter (`.studio-sync.lock.json`, the workflow
itself, `.github/prompts/**`, `vendor/@jrm/**`, `agency.toml`, `.gitattributes`,
`.github/copilot-instructions.md`). Out of scope for me here.

**CI is unaffected:** the drift arm runs `STRICT: '0'`, so this surfaces as a warning and the check
stays green. `--strict` exits 1 until the trigger is widened — the intended direction. The finding
self-liquidates the moment it is.

## Issues

Closes #4251

## Testing

- [ ] `node --test tools/check-ai-manifest.test.mjs` — **57 pass, 0 fail** (was 53)
- [ ] `npx eslint --max-warnings 0` and `npx prettier --check` on both touched files — clean

4 mutants, 4 killed by distinct failing test name, source restored byte-identical:

```
A empty paths returns [] not error   -> an unreadable trigger is an error, never an empty glob list
B prefix match drops the separator   -> trigger globs cover a subtree only via /**
C self-read files unchecked          -> the workflow this check reads must be able to trigger it
D uncovered count loses denominator  -> uncovered managed entries are counted against the whole population
```