### PR TITLE
feat(docs): apply the GH-ACT-003 pinning argument to cross-repo doc links

### DIFF
--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -7607,6 +7607,78 @@ oldest. The headline counts do not depend on attribution, so the scratch run was
 clean, correct, and wrong in a field nobody read. It was caught by writing the
 test, not by re-reading the code.
 
+## The pinning argument is about references, not about YAML
+
+`workflow:security:check` enforces `GH-ACT-003`: every `uses:` ref must be a 40-character
+commit SHA. The reason given is not specific to Actions. A mutable ref resolves today and
+silently means something else tomorrow, so a reference to a moving target is a reference
+whose meaning is not recorded anywhere.
+
+That argument is about **references**. Nothing in it is about YAML. But the enforcement is,
+so one directory away the same repository links to sibling authority repositories like this:
+
+```
+docs/guides/…:  https://github.com/jrmoulckers/engineering/blob/main/practices/testing.md
+```
+
+`main` is exactly the mutable ref the gate rejects, in a repository under active development.
+Measured across 593 tracked markdown files:
+
+| target repo               | 40-char SHA | mutable `main` |
+| ------------------------- | ----------- | -------------- |
+| `jrmoulckers/product`     | 16          | 6              |
+| `jrmoulckers/engineering` | 0           | 10             |
+| `jrmoulckers/.github`     | 0           | 6              |
+| **total**                 | **16**      | **22**         |
+
+The interesting number is not 22. It is **16**: this repository already knows the discipline
+and applies it in `docs/compliance/`, where every reference to the ratified compliance
+principles carries a full commit permalink. The same repository, the same kind of claim about
+the same kind of authority document, two different disciplines — and the difference tracks
+which directory the prose lives in rather than anything about the reference.
+
+`npm run upstream:refs:check` records this. It is a ratchet against a printed baseline of 22
+rather than a demand for zero, because a link that should track the latest guidance is a
+legitimate thing to write; what is not legitimate is writing one by default and never saying
+which kind it is.
+
+### The check states what it did not measure
+
+There are two questions about a cross-repo reference and they need different instruments:
+
+1. _Is the ref immutable?_ Answerable from the text alone, offline, in the pull-request gate.
+2. _Does the path exist upstream?_ Needs the sibling repository, so it cannot run in CI.
+
+The tool answers the first and **prints the second as unmeasured**. That is the same
+correction as the temporal-scope line on the pinning gate, applied before shipping rather
+than after: an instrument may only accuse in the vocabulary it actually measured, and the
+vocabulary here is `ref immutability`, not `link validity`.
+
+### The census that produced this failed accusatory first, for four different reasons
+
+The scratch census that started this began by resolving every referenced path against the
+sibling checkouts and reported **4 of 16 unresolvable**. All four were the instrument's fault,
+and no two shared a cause:
+
+| reported missing                  | actual                                                                             |
+| --------------------------------- | ---------------------------------------------------------------------------------- |
+| `principles/foo.md`               | a deliberately fictional example inside a comment in the vendored citation checker |
+| `principles/compliance.md`        | real, but in `jrmoulckers/product`; the census assumed one upstream repo           |
+| `reusable-detect-changes.yml`     | finance's **own** local workflow                                                   |
+| `reusable-release-smoke-test.yml` | finance's **own** local workflow                                                   |
+
+This is the third consecutive census in this guide whose first result was wrong in the
+direction of accusing the thing it measured. What is new is that the four false positives had
+four distinct causes, which is worth stating because it defeats the natural response to the
+first two — that a census can be made safe by handling _the_ edge case. There was no `the`.
+
+A fifth error occurred while tabulating, in the shell rather than the tool: a nested
+`-match` inside an `if` clobbered `$Matches`, so the repository name read empty and the
+`product,branch` bucket vanished. The published figure would have been `16 of 16 pinned` for
+`product` instead of `16 of 22`, which is the more flattering number and the wrong one.
+Regex state that is global to the scope is the same defect class as `lastIndex` on a shared
+`RegExp`, and it is why the tool resets `BLOB.lastIndex` per line rather than trusting it.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:

--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
     "encoding:check": "node tools/check-text-encoding.mjs",
     "workflow:security:check": "node tools/check-workflow-security.mjs",
     "workflow:pin:history": "node tools/check-workflow-pin-history.mjs",
+    "upstream:refs:check": "node tools/check-upstream-refs.mjs",
+    "upstream:refs:test": "node --test tools/check-upstream-refs.test.mjs",
     "workflow:security:test": "node --test tools/check-workflow-security.test.mjs",
     "gradle:prefetch:check": "node tools/check-gradle-prefetch.mjs",
     "tool:imports:check": "node tools/check-tool-imports.mjs",

--- a/tools/check-upstream-refs.mjs
+++ b/tools/check-upstream-refs.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+// Reports how finance references files in sibling authority repositories.
+//
+// GH-ACT-003 requires every `uses:` ref to be a 40-character commit SHA, and
+// `workflow:security:check` enforces it. The argument is that a mutable ref
+// resolves today and silently means something else tomorrow. That argument is
+// about references, not about YAML -- but nothing applies it to prose, so a
+// documentation link to an authority repo's `main` is unpinned by exactly the
+// standard the same repository enforces one directory away.
+//
+// This is a text-only classifier. It answers "is this ref immutable?" and it
+// does NOT answer "does this path exist?" -- that needs the upstream tree, and
+// a check that reaches the network cannot run in the pull-request gate. The
+// two questions are reported separately and the second is reported as
+// unmeasured rather than assumed.
+
+import { readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+
+// Recorded, not approved. Lower it whenever the real count drops; the tool
+// prints the new floor when it can. See docs/guides/engineering-practice-adoption.md.
+export const BASELINE = 22;
+
+const BLOB =
+  /https?:\/\/github\.com\/jrmoulckers\/([A-Za-z0-9._-]+)\/blob\/([^/\s)]+)\/([^)\s"'`#>]+)/g;
+
+/** Classify one ref string as an immutable commit SHA, a tag, or a mutable branch. */
+export function refForm(ref) {
+  if (/^[0-9a-f]{40}$/.test(ref)) return 'sha40';
+  if (/^v?\d+\.\d+\.\d+$/.test(ref)) return 'tag';
+  return 'branch';
+}
+
+/** Extract every jrmoulckers cross-repo blob link from one file's text. */
+export function collectRefs(text, file = '') {
+  const out = [];
+  let fenced = false;
+  text.split(/\r?\n/).forEach((line, i) => {
+    // A link inside a fenced block is an illustration, not a reference this
+    // repository follows. Counting them made the check fail on the prose that
+    // documents the check -- the fix is scope, not a higher baseline.
+    if (/^\s*(```|~~~)/.test(line)) {
+      fenced = !fenced;
+      return;
+    }
+    if (fenced) return;
+    BLOB.lastIndex = 0;
+    for (const [, repo, ref, path] of line.matchAll(BLOB)) {
+      out.push({ file, line: i + 1, repo, ref, path, form: refForm(ref) });
+    }
+  });
+  return out;
+}
+
+/** Group refs into a { "repo,form": count } census. */
+export function census(refs) {
+  const by = new Map();
+  for (const r of refs) {
+    const k = `${r.repo},${r.form}`;
+    by.set(k, (by.get(k) ?? 0) + 1);
+  }
+  return by;
+}
+
+function listFiles() {
+  const out = execFileSync('git', ['ls-files', '--', 'docs', '*.md'], { encoding: 'utf8' });
+  return out.split('\n').filter((f) => f.endsWith('.md'));
+}
+
+function main() {
+  const files = listFiles();
+  const refs = files.flatMap((f) => collectRefs(readFileSync(f, 'utf8'), f));
+  const mutable = refs.filter((r) => r.form === 'branch');
+
+  console.log('Cross-repo documentation references:');
+  console.log(`  markdown files scanned      ${files.length}`);
+  console.log(`  jrmoulckers blob links      ${refs.length}`);
+  for (const [k, n] of [...census(refs)].sort()) console.log(`    ${k.padEnd(28)}${n}`);
+  console.log(`  on a mutable ref            ${mutable.length} (baseline ${BASELINE})`);
+
+  for (const r of mutable) console.log(`    ${r.file}:${r.line}  ${r.repo}@${r.ref}  ${r.path}`);
+
+  // Print the scope beside the verdict, including what was not measured.
+  console.log('');
+  console.log('Scope: ref immutability only, read from the text of tracked markdown.');
+  console.log('Not measured: whether any referenced path exists upstream. That needs');
+  console.log('the sibling repository and is deliberately outside this check.');
+
+  if (mutable.length > BASELINE) {
+    console.error(`\nFAIL: ${mutable.length} mutable refs exceeds the recorded ${BASELINE}.`);
+    process.exit(1);
+  }
+  if (mutable.length < BASELINE) {
+    console.log(`\nBaseline can be lowered to ${mutable.length}.`);
+  }
+}
+
+if (process.argv[1] && process.argv[1].endsWith('check-upstream-refs.mjs')) main();

--- a/tools/check-upstream-refs.test.mjs
+++ b/tools/check-upstream-refs.test.mjs
@@ -1,0 +1,121 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { refForm, collectRefs, census, BASELINE } from './check-upstream-refs.mjs';
+
+const url = (repo, ref, path) => `https://github.com/jrmoulckers/${repo}/blob/${ref}/${path}`;
+const SHA = '3a752c11856515a74eb204675d5d5198cac1e48e';
+
+test('a 40-character hex ref is immutable', () => {
+  assert.equal(refForm(SHA), 'sha40');
+});
+
+test('a 39-character hex ref is not a sha40', () => {
+  assert.equal(refForm(SHA.slice(1)), 'branch');
+});
+
+test('an uppercase 40-char ref is not treated as a sha', () => {
+  // Git object names are lowercase hex. Accepting uppercase would classify a
+  // branch literally named like a SHA as immutable.
+  assert.equal(refForm(SHA.toUpperCase()), 'branch');
+});
+
+test('a ref merely containing a sha is not immutable', () => {
+  // Survived mutation testing until this existed: without the ^$ anchors a
+  // branch named `backup-<sha>` classifies as an immutable commit ref.
+  assert.equal(refForm(`backup-${SHA}`), 'branch');
+  assert.equal(refForm(`${SHA}-old`), 'branch');
+});
+test('a semver tag is its own form, not a branch', () => {
+  assert.equal(refForm('v0.1.0'), 'tag');
+  assert.equal(refForm('0.1.0'), 'tag');
+});
+
+test('main and other names are mutable branches', () => {
+  for (const r of ['main', 'master', 'release', 'v1']) assert.equal(refForm(r), 'branch');
+});
+
+test('extracts repo, ref and path from a blob link', () => {
+  const [r] = collectRefs(`see ${url('engineering', 'main', 'practices/testing.md')}`);
+  assert.deepEqual(
+    { repo: r.repo, ref: r.ref, path: r.path, form: r.form },
+    { repo: 'engineering', ref: 'main', path: 'practices/testing.md', form: 'branch' },
+  );
+});
+
+test('a fragment is not captured as part of the path', () => {
+  const [r] = collectRefs(url('engineering', 'main', 'practices/testing.md') + '#heading');
+  assert.equal(r.path, 'practices/testing.md');
+});
+
+test('a markdown autolink does not leave a trailing angle bracket', () => {
+  // Found by running the tool: `<url>` form captured the closing bracket into
+  // the path, so the reported path did not exist even when the real one did.
+  const [r] = collectRefs(`<${url('.github', 'main', 'SECURITY.md')}>`);
+  assert.equal(r.path, 'SECURITY.md');
+});
+
+test('a markdown link does not capture the closing paren', () => {
+  const [r] = collectRefs(`[x](${url('product', SHA, 'principles/compliance.md')})`);
+  assert.equal(r.path, 'principles/compliance.md');
+});
+
+test('two links on one line are both found', () => {
+  const line = `${url('a', 'main', 'x.md')} and ${url('b', SHA, 'y.md')}`;
+  assert.equal(collectRefs(line).length, 2);
+});
+
+test('line numbers are 1-based and per-line', () => {
+  const [r] = collectRefs(`\n\n${url('engineering', 'main', 'p.md')}`, 'f.md');
+  assert.equal(r.line, 3);
+  assert.equal(r.file, 'f.md');
+});
+
+test('a link inside a fenced block is an illustration, not a reference', () => {
+  const body = ['```', url('engineering', 'main', 'practices/testing.md'), '```'].join('\n');
+  assert.equal(collectRefs(body).length, 0);
+});
+
+test('links after a closed fence are counted again', () => {
+  const body = ['```', 'x', '```', url('engineering', 'main', 'a.md')].join('\n');
+  assert.equal(collectRefs(body).length, 1);
+});
+
+test('a tilde fence also suppresses', () => {
+  const body = ['~~~', url('engineering', 'main', 'a.md'), '~~~'].join('\n');
+  assert.equal(collectRefs(body).length, 0);
+});
+test('a non-jrmoulckers owner is ignored', () => {
+  assert.equal(collectRefs('https://github.com/other/repo/blob/main/x.md').length, 0);
+});
+
+test('a non-blob github url is ignored', () => {
+  assert.equal(collectRefs('https://github.com/jrmoulckers/engineering/tree/main/x').length, 0);
+});
+
+test('a repository name containing a dot is captured whole', () => {
+  const [r] = collectRefs(url('.github', 'main', 'x.md'));
+  assert.equal(r.repo, '.github');
+});
+
+test('census groups by repo and form', () => {
+  const refs = collectRefs(
+    [
+      url('engineering', 'main', 'a.md'),
+      url('product', SHA, 'b.md'),
+      url('product', SHA, 'c.md'),
+    ].join('\n'),
+  );
+  const c = census(refs);
+  assert.equal(c.get('engineering,branch'), 1);
+  assert.equal(c.get('product,sha40'), 2);
+});
+
+test('census of no refs is empty rather than absent', () => {
+  assert.equal(census([]).size, 0);
+});
+
+test('the baseline is a recorded number, not a target of zero', () => {
+  // A baseline of 0 would mean the ratchet had been silently reset; a baseline
+  // below the count would fail the gate on unchanged input.
+  assert.ok(BASELINE > 0);
+});


### PR DESCRIPTION
## Summary

`workflow:security:check` enforces `GH-ACT-003`: every `uses:` ref must be a 40-character commit SHA, because **a mutable ref resolves today and silently means something else tomorrow.**

That argument is about **references**. Nothing in it is about YAML. But the enforcement is — so one directory away, this repository links to sibling authority repositories like this:

`https://github.com/jrmoulckers/engineering/blob/main/practices/testing.md`

Measured across 593 tracked markdown files:

| target repo | 40-char SHA | mutable `main` |
| --- | --- | --- |
| `jrmoulckers/product` | 16 | 6 |
| `jrmoulckers/engineering` | 0 | 10 |
| `jrmoulckers/.github` | 0 | 6 |
| **total** | **16** | **22** |

**The interesting number is 16, not 22.** This repository already knows the discipline and applies it in `docs/compliance/`, where every reference to the ratified compliance principles carries a full commit permalink. Same repo, same kind of claim about the same kind of authority document, two disciplines — and the difference tracks *which directory the prose lives in*, not anything about the reference.

## What changed

`tools/check-upstream-refs.mjs` + `npm run upstream:refs:check`. A **ratchet against a printed baseline of 22**, not a demand for zero: a link meant to track the latest guidance is legitimate. What isn't legitimate is writing one by default and never saying which kind it is.

It answers *is this ref immutable?* — text-only, offline, gate-safe — and prints **unconditionally** that it does **not** answer *does this path exist upstream?*, which needs the sibling repo and can't run in a PR gate. Same correction as the temporal-scope line on the pinning gate, applied *before* shipping rather than after.

## The census behind this failed accusatory first — four times, four causes

It began by resolving every referenced path against the sibling checkouts: **4 of 16 unresolvable.** All four were my instrument's fault, and no two shared a cause:

| reported missing | actual |
| --- | --- |
| `principles/foo.md` | a deliberately fictional example inside a comment in the vendored citation checker |
| `principles/compliance.md` | real, but in `jrmoulckers/product` — the census assumed one upstream repo |
| `reusable-detect-changes.yml` | finance's **own** local workflow |
| `reusable-release-smoke-test.yml` | finance's **own** local workflow |

Third consecutive census here whose first result accused the thing it measured. What's new is the **four distinct causes** — which defeats the natural response to the earlier two, that the class is fixable by handling *the* edge case. There was no `the`.

**A fifth error, in the shell rather than the tool:** a nested `-match` inside an `if` clobbered `$Matches`, erasing the `product,branch` bucket. The published figure would have been **`16 of 16` pinned instead of `16 of 22`** — the more flattering number and the wrong one. Shared regex state is the same defect class as `lastIndex` on a reused `RegExp`, which is why the tool resets it per line.

## The gate fired on the prose documenting the gate

Adding the section above pushed the count to 23 — an illustrative URL inside a fenced block. **Fixed by scoping fences out, not by raising the baseline.** The count returned to exactly 38/22, which also proves no pre-existing reference was suppressed.

## Verification

`21 tests, 10/10 mutants killed`. One mutant survived until a test existed: without the `^…$` anchors, a branch named `backup-<sha>` classifies as an **immutable commit**.

All gates exit 0: `tool:imports:check`, `node:version:check`, `workflow:security:check`, `gradle:prefetch:check`, `citations:enumerations:check`, `eng:vendor:check`, `eng:citations`, plus `eslint --max-warnings 0` and `prettier --check`.

## Issues

Refs #4029

## Testing

- [x] 21 unit tests; 10 mutants, 10 killed
- [x] Census cross-checked by hand against both sibling checkouts
- [x] All seven repo gates, lint, format