### PR TITLE
fix(tools): measure engines.node in both directions, not just one

### DIFF
--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -6764,7 +6764,9 @@ dependency declarations state:
 Two separate falsehoods, in opposite directions from the one being discussed:
 
 1. **The floor was below the real floor.** `>=22.22.1` and `^22.13.0` bounds put the true minimum at
-   **22.23.0**, not 22.0.0.
+   **22.22.1**, not 22.0.0. _(Corrected. This sentence originally concluded **22.23.0** — one patch
+   above the `>=22.22.1` it names as the binding constraint, in the same sentence. See
+   "The falsifying value was inside the argument" below.)_
 2. **The range has a hole.** Twenty packages declare `^20.19.0 || ^22.13.0 || >=24.0.0`, skipping
    Node 23 entirely — it is an odd, non-LTS line. An open-ended `>=22.0.0` claims 23 works. It does
    not, and nothing above it is monotonic: 23 fails while 24 is clean.
@@ -7678,6 +7680,69 @@ A fifth error occurred while tabulating, in the shell rather than the tool: a ne
 `product` instead of `16 of 22`, which is the more flattering number and the wrong one.
 Regex state that is global to the scope is the same defect class as `lastIndex` on a shared
 `RegExp`, and it is why the tool resets `BLOB.lastIndex` per line rather than trusting it.
+
+## A range can be wrong in two directions and only one was ever measured
+
+`check-node-version-consistency.mjs` verifies `engines.node` against the 452 `engines.node`
+declarations in the installed tree, and it passed. It checked one direction:
+
+```js
+for (const version of probeVersions(...)) {
+  if (!semver.satisfies(version, declared)) continue;   // <- everything excluded, discarded here
+```
+
+Versions the range **admits** are compared against the dependencies. Versions the range
+**excludes** are dropped on the first line of the loop, so no question is ever asked about
+them. That is not a sampling gap. `22.22.1` was already in the probe set — `probeVersions`
+harvests literal versions out of dependency ranges, and `lint-staged` declares `>=22.22.1`.
+The falsifying version was in the population and the filter threw it away.
+
+Measured against the real tree, the declared `>=22.23.0 <23 || >=24` excluded Node
+**22.22.1**, which all 452 declarations accept. A dense patch sweep puts the excluded run at
+`22.22.1`–`22.22.6`; the check reports only `22.22.1`, because it probes versions some package
+names rather than every version that exists, and it now says so.
+
+The two directions are different defects and it is worth being precise about which is which:
+
+| direction        | what it claims                                  | who it hurts                                                     |
+| ---------------- | ----------------------------------------------- | ---------------------------------------------------------------- |
+| over-permissive  | support for a runtime installed packages reject | a consumer, who is told it works                                 |
+| over-restrictive | no support for a runtime every package accepts  | a contributor, whose working environment is declared unsupported |
+
+Only the first was measured, and the second is the one this repository had. Corrected to
+`>=22.22.1 <23 || >=24`; both directions now read zero, and both are printed even when clean,
+because _"admits no bad version"_ reads as _"the range is right"_ and is half the claim.
+
+### The falsifying value was inside the argument
+
+The floor came from this repository's own earlier work, which recorded its reasoning as:
+
+> `>=22.22.1` and `^22.13.0` bounds put the true minimum at **22.23.0**, not 22.0.0.
+
+The premise names `>=22.22.1`. The conclusion says `22.23.0`. They are one patch apart, in one
+sentence, and it survived review, a checker, and several later re-readings of the same
+paragraph.
+
+This is a harder case than a version missing from a probe set. There the instrument could not
+see the counterexample; here the counterexample is **quoted in the evidence for the claim it
+refutes**. No widening of a population would have helped, because the population was not the
+problem — the step from evidence to conclusion was, and nothing in the toolchain reads that
+step. What caught it was recomputing the floor from the tree instead of re-reading the
+sentence, which is the same distinction as _reading a control tells you what it says; only
+running it tells you which way it fails_, applied to prose.
+
+### The odd major is a fact about Node, not about this tree
+
+The excluded direction reports any version all dependencies accept, including Node 23 when
+nothing happens to reject it. That is not a false positive and it is not suppressed. Odd Node
+majors never reach LTS, so mature packages write `18 || 20 || >=22` and skip them by cadence,
+which means **the expected shape of a correct `engines.node` is non-contiguous** and a
+contiguous one is more likely wrong than right. Measured here: of the 20 declarations that
+reject Node 23, **4 of 4 distinct ranges use `||` alternation**, and they come from unrelated
+maintainers — the `@eslint/*` family, `@asamuzakjp/*`, `whatwg-url`, `data-urls`,
+`@exodus/bytes`. The check therefore states a fact — _every dependency accepts this and you
+exclude it_ — and leaves intent to the reader, rather than demanding a contiguous range that
+would be wrong.
 
 ## Worth hoisting up
 

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "url": "https://github.com/jrmoulckers/finance.git"
   },
   "engines": {
-    "node": ">=22.23.0 <23 || >=24"
+    "node": ">=22.22.1 <23 || >=24"
   },
   "packageManager": "npm@10.9.4",
   "overrides": {

--- a/tools/check-node-version-consistency.mjs
+++ b/tools/check-node-version-consistency.mjs
@@ -236,6 +236,33 @@ export function findAdmittedIncompatibilities(declared, dependencies) {
   return admitted.sort((a, b) => semver.compare(a.version, b.version));
 }
 
+/**
+ * Versions every installed dependency accepts but the declared range excludes.
+ *
+ * The complement of `findAdmittedIncompatibilities`, and it has to be written
+ * separately because that function cannot express this: its loop opens with
+ * `if (!semver.satisfies(version, declared)) continue`, so a version the range
+ * excludes is discarded before anything is asked about it. The blind spot is a
+ * direction, not a sample -- `22.22.1` was already in the probe set, harvested
+ * from `lint-staged`'s own `>=22.22.1`, and was skipped by that first line.
+ *
+ * The two directions are not the same defect. An over-permissive range claims
+ * support that installed packages reject, which misleads a consumer. An
+ * over-restrictive one refuses a runtime that every installed package accepts,
+ * which turns a working environment into an unsupported one. Only the first
+ * was ever measured here, and the second is what this repository had.
+ */
+export function findExcludedCompatibilities(declared, dependencies) {
+  if (!declared || !semver.validRange(declared)) return [];
+  const usable = dependencies.filter((dep) => dep.range && semver.validRange(dep.range));
+  if (usable.length === 0) return [];
+  const excluded = [];
+  for (const version of probeVersions(usable.map((dep) => dep.range))) {
+    if (semver.satisfies(version, declared)) continue;
+    if (usable.every((dep) => semver.satisfies(version, dep.range))) excluded.push({ version });
+  }
+  return excluded.sort((a, b) => semver.compare(a.version, b.version));
+}
 /** Every installed dependency that states an `engines.node`, walked from disk. */
 export function collectDependencyEngines(root, depth = 0) {
   const found = [];
@@ -325,6 +352,28 @@ function main() {
         `engines.node "${engines?.node}" admits no version rejected by any of ${dependencies.length} dependency declaration(s).`,
       );
     }
+    // The other direction. Reported as a notice because a dependency relaxing
+    // its own floor widens what is admissible without any local edit, and this
+    // check only fails on disagreements a local edit causes.
+    const excluded = findExcludedCompatibilities(engines?.node, dependencies);
+    if (excluded.length > 0) {
+      notices.push(
+        `engines.node "${engines?.node}" excludes Node ${excluded
+          .map((entry) => entry.version)
+          .join(
+            ', ',
+          )}, which every one of ${dependencies.length} dependency declaration(s) accepts.`,
+      );
+    } else {
+      notices.push(
+        `engines.node excludes no version that all ${dependencies.length} dependency declaration(s) accept.`,
+      );
+    }
+    // Both directions are named even when both are clean, because "admits no
+    // bad version" reads as "the range is right" and is only half the claim.
+    notices.push(
+      'scope: both directions were checked, over versions named by some dependency range.',
+    );
   }
   const runningMajor = process.versions.node.split('.')[0];
   if (runningMajor !== expectedMajor) {

--- a/tools/check-node-version-consistency.test.mjs
+++ b/tools/check-node-version-consistency.test.mjs
@@ -8,6 +8,7 @@ import {
   enginesAdmitsAbove,
   exercisedMajorsAbove,
   findAdmittedIncompatibilities,
+  findExcludedCompatibilities,
   findNodeVersionMismatches,
   findNodeVersionPins,
   findRangeExerciseViolations,
@@ -268,4 +269,69 @@ test('findAdmittedIncompatibilities sorts by version, not by probe order', () =>
   ]);
   assert.equal(admitted[0].version, '22.0.0');
   assert.equal(admitted[1].version, '22.22.1');
+});
+
+test('reports a version every dependency accepts but the range excludes', () => {
+  // Mirrors the real tree: something rejects 23, so the only disagreement left
+  // is the patch-level floor. Without that, 23.0.0 is also reported -- see below.
+  const deps = [{ range: '>=22.22.1 <23 || >=24' }, { range: '>=20' }];
+  const found = findExcludedCompatibilities('>=22.23.0 <23 || >=24', deps);
+  assert.deepEqual(
+    found.map((f) => f.version),
+    ['22.22.1'],
+  );
+});
+
+test('the excluded direction is invisible to the admitted direction', () => {
+  // findAdmittedIncompatibilities opens with `if (!satisfies) continue`, so the
+  // excluded version is discarded before anything is asked about it. This is
+  // the asymmetry the second function exists to close, and asserting both on
+  // the same input is what makes it a measurement rather than a claim.
+  // Mirrors the real tree: something rejects 23, so the only disagreement left
+  // is the patch-level floor. Without that, 23.0.0 is also reported -- see below.
+  const deps = [{ range: '>=22.22.1 <23 || >=24' }, { range: '>=20' }];
+  assert.equal(findAdmittedIncompatibilities('>=22.23.0 <23 || >=24', deps).length, 0);
+  assert.equal(findExcludedCompatibilities('>=22.23.0 <23 || >=24', deps).length, 1);
+});
+
+test('a range that excludes nothing acceptable reports nothing', () => {
+  // Mirrors the real tree: something rejects 23, so the only disagreement left
+  // is the patch-level floor. Without that, 23.0.0 is also reported -- see below.
+  const deps = [{ range: '>=22.22.1 <23 || >=24' }, { range: '>=20' }];
+  assert.equal(findExcludedCompatibilities('>=22.22.1 <23 || >=24', deps).length, 0);
+});
+
+test('a version rejected by one dependency is not reported as excluded', () => {
+  // Excluding a version some dependency rejects is correct, not a defect.
+  const deps = [{ range: '>=22.22.1' }, { range: '>=24' }];
+  assert.equal(findExcludedCompatibilities('>=24', deps).length, 0);
+});
+
+test('an unparseable declared range yields no excluded findings', () => {
+  assert.deepEqual(findExcludedCompatibilities('not a range', [{ range: '>=20' }]), []);
+});
+
+test('no dependencies means nothing is claimed in either direction', () => {
+  // Without a population, "every dependency accepts it" is vacuously true and
+  // would report every probe version as wrongly excluded.
+  assert.deepEqual(findExcludedCompatibilities('>=24', []), []);
+});
+
+test('excluded findings are sorted by version', () => {
+  const deps = [{ range: '>=20.1.0 || >=22.5.0' }];
+  const found = findExcludedCompatibilities('>=24', deps).map((f) => f.version);
+  assert.deepEqual(
+    found,
+    [...found].sort((a, b) => (a < b ? -1 : 1)),
+  );
+});
+
+test('a deliberately excluded odd major is reported when nothing rejects it', () => {
+  // Not a false positive, and worth pinning rather than suppressing. Odd Node
+  // majors never reach LTS, so excluding one is usually intentional -- but the
+  // function measures "every dependency accepts this", not "you should support
+  // it". Encoding the behaviour here keeps the notice readable as a fact.
+  const permissive = [{ range: '>=20' }];
+  const found = findExcludedCompatibilities('>=22.22.1 <23 || >=24', permissive);
+  assert.ok(found.some((f) => f.version === '23.0.0'));
 });


### PR DESCRIPTION
## Summary

`check-node-version-consistency.mjs` verifies `engines.node` against the **452** `engines.node` declarations in the installed tree, and it passed. It checked **one direction**:

```js
for (const version of probeVersions(...)) {
  if (!semver.satisfies(version, declared)) continue;   // <- everything excluded, discarded here
```

Versions the range **admits** get compared against the dependencies. Versions the range **excludes** are dropped on the first line of the loop, so no question is ever asked about them.

**This is not a sampling gap.** `probeVersions` harvests literal versions out of dependency ranges, and `lint-staged` declares `>=22.22.1` — so `22.22.1` was already in the probe set. The falsifying version was in the population and the filter threw it away.

## The finding

Declared `>=22.23.0 <23 || >=24` excluded Node **22.22.1**, which all 452 declarations accept. A dense patch sweep puts the excluded run at `22.22.1`–`22.22.6`; the check reports only `22.22.1`, because it probes versions some package *names* rather than every version that exists — and it now says so.

| direction | what it claims | who it hurts |
| --- | --- | --- |
| over-permissive | support for a runtime installed packages reject | a **consumer**, told it works |
| over-restrictive | no support for a runtime every package accepts | a **contributor**, whose working environment is declared unsupported |

Only the first was ever measured; the second is what this repo had. Corrected to **`>=22.22.1 <23 || >=24`** — both directions now read zero, and **both are printed even when clean**, because *"admits no bad version"* reads as *"the range is right"* and is half the claim.

## The falsifying value was inside the argument

The floor came from this repository's own earlier work, which recorded its reasoning as:

> `>=22.22.1` and `^22.13.0` bounds put the true minimum at **22.23.0**, not 22.0.0.

The premise names `>=22.22.1`. The conclusion says `22.23.0`. **One patch apart, in one sentence** — and it survived review, a checker, and several later re-readings of that same paragraph.

This is harder than a version missing from a probe set. There the instrument couldn't see the counterexample; here the counterexample is **quoted in the evidence for the claim it refutes**. No widening of a population would have helped, because the population wasn't the problem — the step from evidence to conclusion was, and nothing in the toolchain reads that step. Recomputing the floor from the tree caught it; re-reading the sentence never did.

## The odd major is a fact about Node, not about this tree

The excluded direction will report Node 23 when nothing happens to reject it. That is **not suppressed**. Odd Node majors never reach LTS, so mature packages write `18 || 20 || >=22` and skip them by cadence — meaning **the expected shape of a correct `engines.node` is non-contiguous**, and a contiguous one is more likely wrong than right.

Measured here: of the 20 declarations rejecting Node 23, **4 of 4 distinct ranges use `||` alternation**, from unrelated maintainers — `@eslint/*`, `@asamuzakjp/*`, `whatwg-url`, `data-urls`, `@exodus/bytes`. So the check states a *fact* — *every dependency accepts this and you exclude it* — and leaves intent to the reader rather than demanding a contiguous range that would be wrong.

## Verification

`39 tests, 5/5 mutants killed`. All eight gates exit 0: `tool:imports:check`, `node:version:check`, `workflow:security:check`, `gradle:prefetch:check`, `citations:enumerations:check`, `eng:vendor:check`, `eng:citations`, `upstream:refs:check`, plus `eslint --max-warnings 0` and `prettier --check`.

## Issues

Refs #4029

## Testing

- [x] 39 unit tests; 5 mutants, 5 killed
- [x] Both directions re-measured against the real 452-declaration tree
- [x] All eight repo gates, lint, format