### PR TITLE
feat(tools): name the index a citation failure resolved against

### DIFF
--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -7744,6 +7744,65 @@ maintainers — the `@eslint/*` family, `@asamuzakjp/*`, `whatwg-url`, `data-url
 exclude it_ — and leaves intent to the reader, rather than demanding a contiguous range that
 would be wrong.
 
+## A control that omits its resolution source cannot implicate itself
+
+The vendored citation checker prints its version and the index URL it resolved against on
+the passing path, and prints neither on the failing path. An unknown-ID failure is
+therefore ambiguous between two readings — the ID is wrong, or the index this repository
+resolves against is stale — and the output only supports the first. The suppressed reading
+accuses the instrument, which is one of the two suspects every time.
+
+That is not a hypothetical here. Three facts were looked up rather than assumed:
+
+- the vendored checker reports `--version` **10**; the current upstream release reports **11**
+- `engineering-configs.lock.json` pins the vendored files at **v0.134.0**, and the newest
+  release is **v0.145.0**
+- of the six vendored files, the **one** that differs between those releases is
+  `check-citations.mjs` itself
+
+So the instrument is a version behind, and the failing path is the one place a reader would
+act on that fact without being told it.
+
+The disambiguating information already existed in this repository. `npm run eng:vendor:check`
+prints the pin, the newest release, and the differing files unconditionally — it is simply a
+different control, which a reader chasing a citation failure has no reason to run. The
+defect was never missing knowledge; it was knowledge printed somewhere the reader is not.
+
+`tools/run-citations-check.mjs` wraps the vendored checker without diverging it. It adds no
+check and changes no verdict: it passes arguments through, streams the checker's output
+unmodified, exits with the checker's status, and on a non-zero exit appends what the checker
+resolved against.
+
+Two decisions in that wrapper are worth stating, because both were forced by evidence:
+
+- **It asks for the version rather than reading it.** `--version` is a lookup; a regex over
+  the source is a name. The index URL cannot be obtained that way, so the scraper refuses to
+  guess — it reports how many URL candidates it found and returns one only when the count is
+  exactly one. Zero or many is reported as an instrument fault, not silently resolved.
+- **It names the ref, and the ref moves.** The index URL points at
+  `.../engineering/main/principles/index.json`. Reading an authority from a branch means the
+  set of valid IDs can change with no diff in this repository, so two runs over an identical
+  tree can legitimately disagree. The warning is emitted only while the ref is mutable, so a
+  repository that later pins the index by SHA stops being told about a problem it has fixed.
+
+Two things went wrong while building it, and both are the failure this repository keeps
+finding rather than new ones.
+
+The first probe of two other gates reported them **green**, and the probes had not fired:
+`upstream:refs:check` reads _tracked_ markdown and the probe file was untracked, and the
+undeclared-import probe named a package that is already declared. A control that never ran
+reported as a control that passed. Re-probed with tampers that bite, both gates print their
+scope on the failing path — but that is now a measurement rather than the recollection it
+would otherwise have been.
+
+The second is sharper. `refMutability` read the ref from the wrong URL segment, and the test
+covering the real branch URL **passed anyway**, because the segment it wrongly read
+(`principles`) is also not a forty-character SHA. Only the pinned-SHA case could tell the two
+apart. The test that failed was the one asserting the warning _disappears_, which is the
+assertion that had no reason to exist except that a repository which fixed the problem should
+stop being told it has it. A test suite where every case expects the same verdict cannot
+distinguish a correct implementation from one that always returns that verdict.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "format": "npx prettier --write .",
     "format:check": "npx prettier --check .",
     "i18n:validate-glossary": "node scripts/i18n/validate-glossary.js",
-    "eng:citations": "node config/engineering/citations/check-citations.mjs .",
-    "eng:citations:review": "node config/engineering/citations/check-citations.mjs . --review",
+    "eng:citations": "node tools/run-citations-check.mjs .",
+    "eng:citations:review": "node tools/run-citations-check.mjs . --review",
     "eng:vendor:check": "node scripts/vendor-configs.mjs --check",
     "eng:vendor:test": "node --test scripts/vendor-configs.test.mjs",
     "i18n:validate": "node scripts/i18n/validate-locale-catalogs.js && node scripts/i18n/validate-glossary.js",
@@ -67,7 +67,8 @@
     "changeset": "changeset",
     "version": "changeset version",
     "node:version:check": "node tools/check-node-version-consistency.mjs",
-    "node:version:test": "node --test tools/check-node-version-consistency.test.mjs"
+    "node:version:test": "node --test tools/check-node-version-consistency.test.mjs",
+    "citations:context:test": "node --test tools/citations-context.test.mjs"
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx,mjs}": [

--- a/tools/citations-context.mjs
+++ b/tools/citations-context.mjs
@@ -1,0 +1,95 @@
+/**
+ * Resolution context for the vendored citation checker.
+ *
+ * The vendored checker (config/engineering/citations/check-citations.mjs) prints its
+ * version and the index URL it resolved against on the passing path only. On the failing
+ * path it prints the unknown IDs and nothing else, so an unknown-ID failure is ambiguous
+ * between "the ID is wrong" and "the index this repository resolves against is stale".
+ *
+ * That second reading is not hypothetical here: the checker is vendored at a pinned
+ * release, and the index URL points at a branch, so the authority can change with no diff
+ * in this repository. A control that omits its resolution source on failure cannot
+ * implicate itself, and it is one of the two suspects every time.
+ *
+ * These helpers are deliberately separate from the vendored file, which must not diverge
+ * from upstream. See ENG-OBS-004.
+ */
+
+/** Raw-content URL shape: raw.githubusercontent.com/{owner}/{repo}/{ref}/{path} */
+const RAW_URL = /https:\/\/raw\.githubusercontent\.com\/[^\s'"`]+/g;
+
+const SHA40 = /^[0-9a-f]{40}$/;
+
+/**
+ * Extract the single index URL literal from the vendored checker's source.
+ *
+ * Scraping a source file for a constant is reading a name, so this refuses to guess:
+ * it reports how many candidates it saw and returns a URL only when there is exactly
+ * one. Zero or many is an instrument fault, not a missing value.
+ *
+ * @param {string} source Text of the vendored checker.
+ * @returns {{ url: string | null, matches: number }}
+ */
+export function extractIndexUrl(source) {
+  RAW_URL.lastIndex = 0;
+  const found = [...new Set(String(source).match(RAW_URL) ?? [])];
+  return { url: found.length === 1 ? found[0] : null, matches: found.length };
+}
+
+/**
+ * Classify the ref embedded in a raw-content URL.
+ *
+ * A 40-character hex ref names one immutable commit. Anything else is a branch or tag
+ * that can move, which means the resolved index can change without a diff here.
+ *
+ * @param {string | null} url
+ * @returns {{ ref: string | null, mutable: boolean }}
+ */
+export function refMutability(url) {
+  if (!url) return { ref: null, mutable: true };
+  //  0       1  2                         3     4    5    6+
+  // 'https:' '' raw.githubusercontent.com owner repo ref ...path
+  const segments = String(url).split('/');
+  const ref = segments[5] ?? null;
+  if (!ref) return { ref: null, mutable: true };
+  return { ref, mutable: !SHA40.test(ref) };
+}
+
+/**
+ * Build the lines appended to the checker's failing output.
+ *
+ * Every line states something that was looked up, and the mutable-ref warning is emitted
+ * only when the ref actually is mutable, so a repository that later pins the index by SHA
+ * stops being told about a problem it no longer has.
+ *
+ * @param {{ version: string | null, url: string | null, matches: number, pin: string | null }} input
+ * @returns {string[]}
+ */
+export function contextLines({ version, url, matches, pin }) {
+  const lines = [];
+  lines.push(
+    'Before treating this as a bad ID, note what it was resolved against — a stale index reads the same way.',
+  );
+  lines.push(
+    `  checker: v${version ?? 'unknown'} (asked via --version), vendored at ${pin ?? 'an unrecorded pin'}`,
+  );
+
+  if (url) {
+    lines.push(`  index:   ${url}`);
+    const { ref, mutable } = refMutability(url);
+    if (mutable) {
+      lines.push(
+        `  This index is read from "${ref}", which moves. The set of valid IDs can change with no diff here.`,
+      );
+    }
+  } else {
+    lines.push(
+      `  index:   not determined — ${matches} URL candidate(s) in the vendored checker, expected exactly 1.`,
+    );
+  }
+
+  lines.push(
+    '  Run `npm run eng:vendor:check` to see whether a newer checker and index are published.',
+  );
+  return lines;
+}

--- a/tools/citations-context.test.mjs
+++ b/tools/citations-context.test.mjs
@@ -1,0 +1,124 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { contextLines, extractIndexUrl, refMutability } from './citations-context.mjs';
+
+const REAL = 'https://raw.githubusercontent.com/jrmoulckers/engineering/main/principles/index.json';
+const PINNED =
+  'https://raw.githubusercontent.com/jrmoulckers/engineering/8d4f2a1c9b0e7d6f5a4c3b2e1d0f9a8b7c6d5e4f/principles/index.json';
+
+test('extractIndexUrl returns the URL when exactly one candidate exists', () => {
+  const { url, matches } = extractIndexUrl(`const INDEX =\n  '${REAL}';\n`);
+  assert.equal(url, REAL);
+  assert.equal(matches, 1);
+});
+
+test('extractIndexUrl refuses to guess when two distinct candidates exist', () => {
+  const { url, matches } = extractIndexUrl(`'${REAL}' '${PINNED}'`);
+  assert.equal(url, null, 'two candidates must not resolve to one of them');
+  assert.equal(matches, 2);
+});
+
+test('extractIndexUrl collapses repeats of the same URL to one candidate', () => {
+  const { url, matches } = extractIndexUrl(`'${REAL}' and again '${REAL}'`);
+  assert.equal(url, REAL);
+  assert.equal(matches, 1, 'the same literal twice is still one authority');
+});
+
+test('extractIndexUrl reports zero rather than throwing when the constant is gone', () => {
+  const { url, matches } = extractIndexUrl('const INDEX = process.env.INDEX_URL;');
+  assert.equal(url, null);
+  assert.equal(matches, 0);
+});
+
+test('extractIndexUrl is not left stateful by a previous call', () => {
+  extractIndexUrl(`'${REAL}' '${PINNED}'`);
+  const second = extractIndexUrl(`'${REAL}'`);
+  assert.equal(second.matches, 1, 'a global regex must be reset between calls');
+});
+
+test('extractIndexUrl stops at the quote, not at the end of the line', () => {
+  const { url } = extractIndexUrl(`const INDEX = '${REAL}';`);
+  assert.equal(url, REAL, 'trailing quote and semicolon must not be captured');
+});
+
+test('refMutability calls a branch ref mutable', () => {
+  assert.deepEqual(refMutability(REAL), { ref: 'main', mutable: true });
+});
+
+test('refMutability calls a 40-char sha immutable', () => {
+  const { ref, mutable } = refMutability(PINNED);
+  assert.equal(ref.length, 40);
+  assert.equal(mutable, false);
+});
+
+test('refMutability treats a 39-char hex ref as mutable', () => {
+  const short = PINNED.replace(/[0-9a-f]{40}/, 'a'.repeat(39));
+  assert.equal(refMutability(short).mutable, true, 'anchored length check must reject 39');
+});
+
+test('refMutability treats a branch named like a sha prefix as mutable', () => {
+  const branchy = PINNED.replace(/[0-9a-f]{40}/, `backup-${'a'.repeat(40)}`);
+  assert.equal(
+    refMutability(branchy).mutable,
+    true,
+    'an unanchored test would read this as a commit',
+  );
+});
+
+test('refMutability fails safe when there is no URL', () => {
+  assert.deepEqual(refMutability(null), { ref: null, mutable: true });
+});
+
+test('contextLines names the version, the pin and the index', () => {
+  const out = contextLines({ version: '10', url: REAL, matches: 1, pin: 'v0.134.0' }).join('\n');
+  assert.match(out, /checker: v10/);
+  assert.match(out, /v0\.134\.0/);
+  assert.match(out, /principles\/index\.json/);
+});
+
+test('contextLines states the stale-index alternative the checker suppresses', () => {
+  const out = contextLines({ version: '10', url: REAL, matches: 1, pin: 'v0.134.0' }).join('\n');
+  assert.match(out, /stale index/i, 'the suppressed alternative must be named, not implied');
+});
+
+test('contextLines warns that a branch-read index moves', () => {
+  const out = contextLines({ version: '10', url: REAL, matches: 1, pin: 'v0.134.0' }).join('\n');
+  assert.match(out, /which moves/);
+  assert.match(out, /"main"/);
+});
+
+test('contextLines drops the moves-warning once the index is pinned by sha', () => {
+  const out = contextLines({ version: '10', url: PINNED, matches: 1, pin: 'v0.134.0' }).join('\n');
+  assert.doesNotMatch(
+    out,
+    /which moves/,
+    'a repo that fixed the problem must stop being told it has it',
+  );
+  assert.match(out, /principles\/index\.json/, 'the index is still reported');
+});
+
+test('contextLines reports the candidate count when the URL could not be determined', () => {
+  const out = contextLines({ version: '10', url: null, matches: 3, pin: 'v0.134.0' }).join('\n');
+  assert.match(out, /3 URL candidate\(s\)/);
+  assert.match(out, /expected exactly 1/);
+});
+
+test('contextLines says so plainly when the version lookup failed', () => {
+  const out = contextLines({ version: null, url: REAL, matches: 1, pin: 'v0.134.0' }).join('\n');
+  assert.match(out, /vunknown/, 'a failed lookup must not be rendered as a real version');
+});
+
+test('contextLines says so plainly when no pin is recorded', () => {
+  const out = contextLines({ version: '10', url: REAL, matches: 1, pin: null }).join('\n');
+  assert.match(out, /unrecorded pin/);
+});
+
+test('contextLines always points at the control that measures staleness', () => {
+  for (const pin of ['v0.134.0', null]) {
+    for (const url of [REAL, PINNED, null]) {
+      const out = contextLines({ version: '10', url, matches: 1, pin }).join('\n');
+      assert.match(out, /eng:vendor:check/, `missing on pin=${pin} url=${url}`);
+    }
+  }
+});

--- a/tools/run-citations-check.mjs
+++ b/tools/run-citations-check.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+/**
+ * Run the vendored citation checker and, on failure, append the resolution context it
+ * omits: which checker version ran, which index it resolved against, whether that index
+ * is pinned, and how to find out if a newer one exists.
+ *
+ * The wrapper adds no checks and changes no verdict. It passes every argument through,
+ * streams the checker's own output unmodified, and exits with the checker's exit code.
+ */
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+import { contextLines, extractIndexUrl } from './citations-context.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const CHECKER = path.join(repoRoot, 'config', 'engineering', 'citations', 'check-citations.mjs');
+const LOCK = path.join(repoRoot, 'engineering-configs.lock.json');
+
+/** Ask the checker its version rather than reading it out of the source. */
+function checkerVersion() {
+  const probe = spawnSync(process.execPath, [CHECKER, '--version'], { encoding: 'utf8' });
+  if (probe.status !== 0) return null;
+  return (probe.stdout ?? '').trim() || null;
+}
+
+/** Read the recorded vendor pin, which is the version of the authority this repo agreed to. */
+function vendorPin() {
+  try {
+    return JSON.parse(readFileSync(LOCK, 'utf8')).ref ?? null;
+  } catch {
+    return null;
+  }
+}
+
+const result = spawnSync(process.execPath, [CHECKER, ...process.argv.slice(2)], {
+  stdio: 'inherit',
+});
+
+if (result.status !== 0) {
+  let source;
+  try {
+    source = readFileSync(CHECKER, 'utf8');
+  } catch {
+    source = '';
+  }
+  const { url, matches } = extractIndexUrl(source);
+  const lines = contextLines({
+    version: checkerVersion(),
+    url,
+    matches,
+    pin: vendorPin(),
+  });
+  console.error('');
+  for (const line of lines) console.error(line);
+}
+
+process.exit(result.status ?? 1);


### PR DESCRIPTION
## Summary

The vendored citation checker prints its version and the index URL it resolved against on the **passing** path, and prints neither on the **failing** path. So an unknown-ID failure is ambiguous between "the ID is wrong" and "the index this repository resolves against is stale", and the output supports only the first. The suppressed reading accuses the instrument — one of the two suspects every time.

Three facts, looked up rather than assumed:

- vendored checker `--version` reports **10**; current upstream release reports **11**
- `engineering-configs.lock.json` pins at **v0.134.0**; newest release is **v0.145.0**
- of the six vendored files, the **one** that differs between those releases is `check-citations.mjs` itself

The index URL also points at `.../engineering/main/principles/index.json` — a branch. Two runs over an identical tree can legitimately disagree.

`npm run eng:vendor:check` already prints the pin, the newest release and the differing file, unconditionally. The defect was never missing knowledge; it was knowledge printed by a control the reader chasing a citation failure has no reason to run.

## Changes

- **NEW** `tools/run-citations-check.mjs` — wraps the vendored checker without diverging it. Arguments pass through, output streams unmodified, exit status is the checker's, and a non-zero exit appends the resolution context. Adds no check, changes no verdict.
- **NEW** `tools/citations-context.mjs` — `extractIndexUrl()`, `refMutability()`, `contextLines()`.
- **NEW** `tools/citations-context.test.mjs` — 19 tests.
- `package.json` — `eng:citations` / `eng:citations:review` route through the wrapper; new `citations:context:test`.
- `docs/guides/engineering-practice-adoption.md` — one new section.

Two deliberate constraints: the version comes from `--version` (a lookup) rather than a regex over source (a name); and the URL scraper returns a value only when it finds **exactly one** candidate, reporting zero-or-many as an instrument fault rather than resolving it silently. The mutable-ref warning is emitted only while the ref is mutable, so a repository that pins the index by SHA stops being told about a problem it fixed.

## Two things that went wrong, both already-known failures

The first probe of two other gates reported them **green**, and the probes had not fired — `upstream:refs:check` reads *tracked* markdown and the probe file was untracked; the undeclared-import probe named an already-declared package. A control that never ran, reported as a control that passed. Re-probed with tampers that bite: both gates do print scope on the failing path, and that is now a measurement rather than a recollection.

`refMutability` read the ref from the wrong URL segment and the test covering the real branch URL **passed anyway**, because the segment it wrongly read (`principles`) is also not a 40-char SHA. Only the pinned-SHA case discriminates. The test that failed was the one asserting the warning *disappears* — an assertion with no reason to exist except that a repo which fixed the problem should stop being told it has it.

## Issues

Closes #4257

## Testing

- [x] 19/19 `citations-context` tests; 2/2 mutants killed (`^…$` anchor removal; `segments[5]` → `[4]`)
- [x] Green path byte-identical and exit 0; red path verified to carry the context
- [x] The gate fired on the prose documenting the gate — fixed the text, not the checker
- [x] All eight gates exit 0; `format:check`, `eslint . --max-warnings 0`, `type-check` clean