### PR TITLE
fix(tools): pin corpus breadth in production, not in an inline premise (#4256)

### DIFF
--- a/tools/check-ai-manifest.js
+++ b/tools/check-ai-manifest.js
@@ -396,9 +396,12 @@ function validateActivationDoc() {
   return findings;
 }
 
-function validateSyncLock() {
+// `lockOverride` exists only so a test can construct a degenerate corpus and observe that this
+// function still reports it. Without a seam, the breadth guard could be unwired from here and
+// no test would notice: the recorded lock is healthy, so the wiring is invisible against it.
+function validateSyncLock(lockOverride = null) {
   const findings = [];
-  const lock = readJson(SYNC_LOCK, findings);
+  const lock = lockOverride ?? readJson(SYNC_LOCK, findings);
   if (!lock) return findings;
   if (lock.version !== 1) findings.push(`sync lock version is ${lock.version}; expected 1`);
   if (lock.backbone !== 'jrmoulckers/.github') {
@@ -498,6 +501,7 @@ function validateSyncLock() {
   for (const line of sourceDisclosureLines(source.knownUnreproduced)) {
     process.stdout.write(`${line}\n`);
   }
+  findings.push(...corpusBreadth(lock));
   return findings;
 }
 
@@ -943,6 +947,49 @@ function commentFamily(entryPath) {
   return null;
 }
 
+// The suite's family-switch assertions certify `unstampSource` across comment families, and its
+// coverage assertions certify the walk across nesting depths. Both are only as strong as the
+// corpus that happens to be recorded: an assertion over one family certifies the switch on a
+// third of it, and an inline `assert.ok(x.length > 0)` premise cannot pin that, because
+// weakening the premise is invisible to the same suite that contains it (measured: five such
+// premises, all surviving `> 0` -> `>= 0` at 0 failures — #4256).
+//
+// So the judgement lives here, in production, where a mutation is observable by a named test
+// and the degenerate states can be constructed rather than waited for. It reports rather than
+// throws: a narrowed corpus is a real change in what the green check means, not a broken tool.
+const BREADTH_FLOOR = { families: 2, rootLevel: 1 };
+
+/**
+ * Report when the recorded corpus is too narrow for the suite's per-family and per-depth
+ * assertions to mean what they appear to mean.
+ *
+ * @param {object} lock Parsed sync lock.
+ * @returns {string[]} Findings; empty when the corpus supports the assertions made about it.
+ */
+function corpusBreadth(lock) {
+  const entries = Object.keys(lock?.entries ?? {});
+  if (entries.length === 0) return ['lock records no entries; every corpus assertion is vacuous'];
+
+  const families = new Set(entries.map(commentFamily).filter((family) => family !== null));
+  const rootLevel = entries.filter((entry) => !entry.includes('/'));
+  const findings = [];
+
+  if (families.size < BREADTH_FLOOR.families) {
+    findings.push(
+      `corpus exercises ${families.size} comment family/families ` +
+        `(${[...families].sort().join(', ') || 'none'}); the unstamp switch has ` +
+        `${HASH_EXTENSIONS.size + BLOCK_EXTENSIONS.size + HTML_EXTENSIONS.size} extensions across 3, ` +
+        'so a passing family assertion would certify a fraction of it',
+    );
+  }
+  if (rootLevel.length < BREADTH_FLOOR.rootLevel) {
+    findings.push(
+      'corpus records no root-level entries; the walk-reaches-root assertion would hold vacuously',
+    );
+  }
+  return findings;
+}
+
 // Returns { status: 'no-stamp' } for a file the engine never stamped, { status: 'unknown' }
 // for a stamped file whose extension is unclassified, and { status: 'ok', body } otherwise.
 //
@@ -1371,6 +1418,9 @@ module.exports = {
   ENFORCEMENT_WORKFLOW,
   driftEnforcement,
   enforcementFindings,
+  BREADTH_FLOOR,
+  corpusBreadth,
+  validateSyncLock,
   SYNC_LOCK,
   triggerPaths,
   triggerCovers,

--- a/tools/check-ai-manifest.test.mjs
+++ b/tools/check-ai-manifest.test.mjs
@@ -32,6 +32,9 @@ const {
   ENFORCEMENT_WORKFLOW,
   driftEnforcement,
   enforcementFindings,
+  BREADTH_FLOOR,
+  corpusBreadth,
+  validateSyncLock,
   SYNC_LOCK,
   triggerPaths,
   triggerCovers,
@@ -999,4 +1002,66 @@ test('uncovered managed entries are counted against the whole population (#4251)
   assert.match(findings[0], /2 of 3 managed entries/);
   assert.match(findings[0], /vendor\/@jrm/);
   assert.deepEqual(triggerFindings(globs, ['.github/agents/a.md']), []);
+});
+
+// --- #4256: a premise guard must live where a mutation can be seen -------------------------
+//
+// The suite asserts `unstampSource` across comment families and the walk across nesting depths.
+// Both are only as strong as the recorded corpus, and the inline `assert.ok(x.length > 0)`
+// premises that were supposed to protect them cannot: weakening `> 0` to `>= 0` is invisible to
+// the same suite that contains the assertion. Measured on df65452a -- five such premises, all
+// surviving at 0 failures. So the judgement moved into production, where these tests can
+// construct the degenerate states instead of waiting for them.
+
+test('an empty corpus is reported rather than passing vacuously (#4256)', () => {
+  assert.deepEqual(corpusBreadth({}), [
+    'lock records no entries; every corpus assertion is vacuous',
+  ]);
+  assert.equal(corpusBreadth({ entries: {} }).length, 1);
+  assert.equal(corpusBreadth(null).length, 1, 'a missing lock is not a broad corpus');
+});
+
+test('a single-family corpus cannot certify the unstamp switch (#4256)', () => {
+  const oneFamily = corpusBreadth({ entries: { 'AGENTS.md': {}, 'docs/x.md': {} } });
+  assert.equal(oneFamily.length, 1);
+  assert.match(oneFamily[0], /1 comment family/);
+  // Two families clears the floor; the root-level arm is satisfied by AGENTS.md.
+  assert.deepEqual(corpusBreadth({ entries: { 'AGENTS.md': {}, 'agency.toml': {} } }), []);
+});
+
+test('a corpus with no root-level entry is reported (#4256)', () => {
+  const nested = corpusBreadth({ entries: { 'x/a.md': {}, 'x/b.toml': {} } });
+  assert.equal(nested.length, 1);
+  assert.match(nested[0], /no root-level entries/);
+});
+
+test('the real corpus clears the floor, and the floor is not zero (#4256)', () => {
+  const lock = JSON.parse(fs.readFileSync(path.join(ROOT, SYNC_LOCK), 'utf8'));
+  assert.deepEqual(
+    corpusBreadth(lock),
+    [],
+    'the recorded corpus should support its own assertions',
+  );
+  // A floor of zero would make the guard unfalsifiable -- the defect it exists to prevent.
+  assert.ok(BREADTH_FLOOR.families >= 2, 'one family cannot certify a three-way switch');
+  assert.ok(BREADTH_FLOOR.rootLevel >= 1);
+});
+
+test('validateSyncLock still reports a degenerate corpus (#4256)', () => {
+  // Pins the wiring, not the guard: with the recorded lock the guard is silent, so unwiring it
+  // from validateSyncLock is invisible unless a test supplies a corpus that should be reported.
+  const nested = validateSyncLock({
+    version: 1,
+    backbone: 'jrmoulckers/.github',
+    entries: { 'x/a.md': {} },
+  });
+  assert.ok(
+    nested.some((finding) => /no root-level entries/.test(finding)),
+    'the breadth guard must reach the verdict, not just exist',
+  );
+  assert.ok(
+    validateSyncLock({ version: 1, backbone: 'jrmoulckers/.github', entries: {} }).some((finding) =>
+      /every corpus assertion is vacuous/.test(finding),
+    ),
+  );
 });


### PR DESCRIPTION
## Summary

Five inline test premise guards all survived mutation at 0 failures. A premise asserted inside a
suite cannot be pinned by that suite — weakening it is exactly the change the suite would have to
detect in itself. The judgement moves into production, where the degenerate states can be
constructed by a named test.

## Measurement

`> 0` -> `>= 0` on `df65452a`, one at a time, source restored byte-identical:

| premise | line | result |
| --- | --- | --- |
| `nonMarkdown` | 93 | SURVIVED |
| `stamped` | 104 | SURVIVED |
| `CANON_CITATIONS` | 553 | SURVIVED |
| `scan.claims` | 748 | SURVIVED |
| `rootLevel` | 846 | SURVIVED |

## Changes

- `BREADTH_FLOOR = { families: 2, rootLevel: 1 }` and `corpusBreadth(lock)` in
  `tools/check-ai-manifest.js` — reports (never throws) an empty lock, a corpus exercising fewer
  than two of the three comment families, and a corpus with no root-level entry.
- Wired into `validateSyncLock()`'s findings so it reaches the verdict.
- `validateSyncLock(lockOverride)` test seam. Load-bearing: with the recorded lock the guard is
  silent, so **unwiring it was itself a surviving mutant** until a test could supply a corpus that
  should be reported.
- A structural floor rather than an exact cardinality — an exact pin breaks on legitimate corpus
  growth, `> 0` is invisible to weakening.

## Controls

```
BASELINE                                62 pass  0 fail
MUT A  families floor -> < 0            1 FAIL   a single-family corpus cannot certify the unstamp switch
MUT B  root-level arm -> < 0            2 FAIL   a corpus with no root-level entry is reported
MUT C  empty-lock early return removed  2 FAIL   an empty corpus is reported rather than passing vacuously
MUT D  corpusBreadth unwired            1 FAIL   validateSyncLock still reports a degenerate corpus
```

Each killed by failing test name; each anchor verified unique before application.

## Disclosure

The first run reported MUT A, C and D as `SURVIVED` at 0 failures. They were not — the harness's
kill detector matched TAP `not ok` while `node --test` emitted spec-reporter `✖`. A control
reporting a clean result from a channel it never read: the same defect, inside the instrument
measuring it. Full detail in the issue. MUT C's first anchor also failed to apply (prettier had
reflowed the early return) and was retried rather than scored.

## Issues

Closes #4256

## Testing

- [x] `node --test tools/check-ai-manifest.test.mjs` — 62/62
- [x] `npx eslint tools/check-ai-manifest.js tools/check-ai-manifest.test.mjs --max-warnings 0` — exit 0
- [x] `npx prettier --check` on both touched files — clean
- [x] `node tools/check-ai-manifest.js` — exit 0, no new findings (the 3 pre-existing #4251 trigger-gap warnings only)
- [x] 4 mutants, 4 kills by distinct failing test name

## Scope

Tooling only. `packages/design-tokens/` untouched, no workflow modified, `.studio-sync.lock.json`
never hand-edited, `vendor/@jrm/tokens/css/default/tokens.css` untouched.