### PR TITLE
feat(tools): measure how long the branch held an unpinned action ref

### DIFF
--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -7803,6 +7803,53 @@ assertion that had no reason to exist except that a repository which fixed the p
 stop being told it has it. A test suite where every case expects the same verdict cannot
 distinguish a correct implementation from one that always returns that verdict.
 
+## A count of commits is complete over commits and silent about duration
+
+The pin-history census reported that 89 of 209 commits touching `.github/workflows`
+carried at least one unpinned action ref. That figure is complete over commits and says
+nothing about how long the branch actually sat in a non-compliant state. The same 89
+lapses could be 89 minutes or most of the repository's life, and no percentage of commits
+can tell those apart.
+
+Only commits touching the workflow directory change the branch's pinning state, so each
+one's state holds until the next newer such commit, and the newest holds until now. That
+makes duration computable from the same walk:
+
+```
+commits examined              209
+commits with >=1 unpinned     89 (42.6%)
+time in a non-compliant state 62d 19h of 160d 4h (39.2%)
+```
+
+The two figures nearly agree, which means the lapses were close to average length. That is
+worth stating precisely because it was **not** predictable: had a single long-lived lapse
+dominated, the same 42.6% would have sat beside a time figure two or three times larger.
+The count was a good proxy here, and the only way to learn that was to stop using it as one.
+
+Three decisions in `exposure()` were forced by cases the count never had to answer:
+
+- **The newest state runs to wall-clock now, not to its own timestamp.** An unrepaired HEAD
+  is still accruing exposure, and a report that ended the interval at the last commit would
+  show a currently-broken branch as having stopped being broken the moment nobody touched it.
+  The report says so, because that final interval grows between runs with no diff.
+- **A commit whose tree declares no actions holds a _clean_ state rather than vanishing.**
+  `git grep` exits non-zero when nothing matches, and the previous code treated that as a
+  commit to skip. Skipping it silently removed its interval from the span — the partition
+  stopped summing, in the one direction where the total is the denominator.
+- **Elapsed time is floored at zero per interval.** Git timestamps are author dates and can
+  run backwards; without the floor, one skewed commit subtracts exposure and the total
+  understates.
+
+The stub for the git runner was widened rather than rewritten. It now derives the new epoch
+field from the short date the existing cases already stated, so none of the sixteen prior
+tests silently changed meaning while the format changed underneath them.
+
+One test in the first draft asserted `notEqual(3, 1)` — two literals compared to each other,
+written directly beneath a comment explaining that counts and durations measure different
+things. It would have passed against any implementation, including one that returned a
+constant. It now derives both counts from the same fixtures it measures the durations from,
+so the assertion fails if the fixtures stop illustrating the claim.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:

--- a/tools/check-workflow-pin-history.mjs
+++ b/tools/check-workflow-pin-history.mjs
@@ -55,13 +55,18 @@ export function unpinnedRefs(text) {
  *
  * @param {(args: string[]) => string} git Runner returning git stdout.
  * @param {string} ref Git ref to walk.
- * @returns {{examined: number, dirty: number, refs: Map<string, string>, lastDirty: object | null, headClean: boolean}}
+ * @param {number} nowSeconds Unix seconds treated as "now" for the open interval at HEAD.
+ * @returns {{examined: number, dirty: number, refs: Map<string, string>, lastDirty: object | null, headClean: boolean, dirtySeconds: number, spanSeconds: number}}
  *   `refs` maps each unpinned `action@ref` to the oldest commit that carried it.
  */
-export function censusHistory(git, ref = 'origin/main') {
+export function censusHistory(
+  git,
+  ref = 'origin/main',
+  nowSeconds = Math.floor(Date.now() / 1000),
+) {
   const listed = git([
     'log',
-    '--format=%H %ad',
+    '--format=%H %at %ad',
     '--date=short',
     ref,
     '--',
@@ -73,15 +78,21 @@ export function censusHistory(git, ref = 'origin/main') {
   let dirty = 0;
   let lastDirty = null;
   let headClean = true;
+  /** @type {{at: number, bad: boolean}[]} */
+  const states = [];
 
-  for (const [sha, date] of commits) {
+  for (const [sha, at, date] of commits) {
     let text;
     try {
       text = git(['grep', '-h', '-E', 'uses:', sha, '--', '.github/workflows']);
     } catch {
-      continue;
+      // git grep exits non-zero when nothing matches, which means this tree
+      // declares no actions at all. That is a clean state, not an absent one --
+      // dropping it here would silently remove its interval from the span.
+      text = '';
     }
     const bad = unpinnedRefs(text);
+    states.push({ at: Number(at), bad: bad.size > 0 });
     if (bad.size === 0) continue;
     dirty += 1;
     if (lastDirty === null) lastDirty = { sha: sha.slice(0, 8), date, refs: [...bad] };
@@ -97,7 +108,48 @@ export function censusHistory(git, ref = 'origin/main') {
     }
   }
 
-  return { examined: commits.length, dirty, refs, lastDirty, headClean };
+  const { dirtySeconds, spanSeconds } = exposure(states, nowSeconds);
+
+  return { examined: commits.length, dirty, refs, lastDirty, headClean, dirtySeconds, spanSeconds };
+}
+
+/**
+ * Convert a reverse-chronological list of branch states into elapsed time.
+ *
+ * A count of non-compliant commits is complete over commits and silent about
+ * duration: seven of them may be seven minutes or four days. Only commits that
+ * touch the workflow directory change the branch's pinning state, so each one's
+ * state holds until the next newer such commit -- and the newest holds until now.
+ *
+ * @param {{at: number, bad: boolean}[]} states Newest first.
+ * @param {number} nowSeconds
+ * @returns {{dirtySeconds: number, spanSeconds: number}}
+ */
+export function exposure(states, nowSeconds) {
+  if (states.length === 0) return { dirtySeconds: 0, spanSeconds: 0 };
+  let dirtySeconds = 0;
+  for (let i = 0; i < states.length; i += 1) {
+    const until = i === 0 ? nowSeconds : states[i - 1].at;
+    const held = Math.max(0, until - states[i].at);
+    if (states[i].bad) dirtySeconds += held;
+  }
+  const spanSeconds = Math.max(0, nowSeconds - states[states.length - 1].at);
+  return { dirtySeconds, spanSeconds };
+}
+
+/**
+ * Render a duration in whole days and hours, so a report never implies a
+ * precision it does not have.
+ *
+ * @param {number} seconds
+ * @returns {string}
+ */
+export function humanDuration(seconds) {
+  if (!Number.isFinite(seconds) || seconds <= 0) return '0h';
+  const days = Math.floor(seconds / 86400);
+  const hours = Math.floor((seconds % 86400) / 3600);
+  if (days === 0) return `${hours}h`;
+  return `${days}d ${hours}h`;
 }
 
 function main() {
@@ -105,7 +157,10 @@ function main() {
   const git = (args) =>
     execFileSync('git', args, { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
 
-  const { examined, dirty, refs, lastDirty, headClean } = censusHistory(git, ref);
+  const { examined, dirty, refs, lastDirty, headClean, dirtySeconds, spanSeconds } = censusHistory(
+    git,
+    ref,
+  );
 
   if (examined === 0) {
     console.log(`No commits touching .github/workflows found on ${ref}.`);
@@ -113,10 +168,14 @@ function main() {
   }
 
   const percent = ((dirty / examined) * 100).toFixed(1);
+  const timePercent = spanSeconds > 0 ? ((dirtySeconds / spanSeconds) * 100).toFixed(1) : '0.0';
   console.log(`Workflow pin history for ${ref}:`);
   console.log(`  commits examined            ${examined}`);
   console.log(`  commits with >=1 unpinned   ${dirty} (${percent}%)`);
   console.log(`  distinct unpinned refs      ${refs.size}`);
+  console.log(
+    `  time in a non-compliant state ${humanDuration(dirtySeconds)} of ${humanDuration(spanSeconds)} (${timePercent}%)`,
+  );
   console.log(`  working tree at ${ref}      ${headClean ? 'clean' : 'UNPINNED REFS PRESENT'}`);
   if (lastDirty) {
     console.log(`  most recent occurrence      ${lastDirty.sha} ${lastDirty.date}`);
@@ -126,6 +185,11 @@ function main() {
   console.log('This is a history report, not a gate. A clean working tree means the');
   console.log('violations were repaired, not that they never happened; the pinning gate');
   console.log('cannot distinguish those two and does not claim to.');
+  console.log('');
+  console.log('A count of commits is complete over commits and silent about duration --');
+  console.log('the same seven lapses may be seven minutes or four days of exposure. The');
+  console.log('time figures close that gap, and are measured against wall-clock now, so');
+  console.log('the final interval grows until the next commit touching this directory.');
 }
 
 if (process.argv[1] && process.argv[1].endsWith('check-workflow-pin-history.mjs')) {

--- a/tools/check-workflow-pin-history.test.mjs
+++ b/tools/check-workflow-pin-history.test.mjs
@@ -3,7 +3,12 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { censusHistory, unpinnedRefs } from './check-workflow-pin-history.mjs';
+import {
+  censusHistory,
+  exposure,
+  humanDuration,
+  unpinnedRefs,
+} from './check-workflow-pin-history.mjs';
 
 const SHA = 'a'.repeat(40);
 
@@ -63,8 +68,23 @@ test('quoted refs are handled', () => {
 });
 
 function fakeGit(log, grepBySha) {
+  // git now emits "<sha> <unix> <short-date>". Stubs written against the older
+  // two-field form stay valid: the epoch is derived from the date they already
+  // state, so no existing case silently changes meaning.
+  const normalized =
+    log === ''
+      ? ''
+      : log
+          .split('\n')
+          .map((line) => {
+            const [sha, ...rest] = line.split(' ');
+            if (rest.length >= 2) return line;
+            const date = rest[0];
+            return `${sha} ${Math.floor(Date.parse(`${date}T00:00:00Z`) / 1000)} ${date}`;
+          })
+          .join('\n');
   return (args) => {
-    if (args[0] === 'log') return log;
+    if (args[0] === 'log') return normalized;
     if (args[0] === 'grep') {
       const sha = args[4];
       if (!(sha in grepBySha)) throw new Error('no match');
@@ -135,4 +155,124 @@ test('an empty history reports zero rather than throwing', () => {
   assert.equal(result.examined, 0);
   assert.equal(result.dirty, 0);
   assert.equal(result.lastDirty, null);
+});
+
+const DAY = 86400;
+const T0 = 1_800_000_000;
+
+test('exposure charges each state until the next newer commit', () => {
+  // newest first: b clean from T0+DAY to now(T0+2*DAY); a dirty for one day
+  const { dirtySeconds, spanSeconds } = exposure(
+    [
+      { at: T0 + DAY, bad: false },
+      { at: T0, bad: true },
+    ],
+    T0 + 2 * DAY,
+  );
+  assert.equal(dirtySeconds, DAY);
+  assert.equal(spanSeconds, 2 * DAY);
+});
+
+test('exposure runs the newest state to now, not to its own timestamp', () => {
+  const { dirtySeconds } = exposure([{ at: T0, bad: true }], T0 + 3 * DAY);
+  assert.equal(dirtySeconds, 3 * DAY, 'an unrepaired head is still accruing');
+});
+
+test('exposure charges nothing when the newest state is clean', () => {
+  const { dirtySeconds, spanSeconds } = exposure(
+    [
+      { at: T0 + DAY, bad: false },
+      { at: T0, bad: false },
+    ],
+    T0 + 2 * DAY,
+  );
+  assert.equal(dirtySeconds, 0);
+  assert.equal(spanSeconds, 2 * DAY);
+});
+
+test('exposure distinguishes many brief lapses from one long one', () => {
+  const briefStates = [
+    { at: T0 + 300, bad: false },
+    { at: T0 + 200, bad: true },
+    { at: T0 + 100, bad: true },
+    { at: T0, bad: true },
+  ];
+  const longStates = [
+    { at: T0 + 300, bad: false },
+    { at: T0, bad: true },
+  ];
+  const brief = exposure(briefStates, T0 + 400);
+  const long = exposure(longStates, T0 + 400);
+
+  assert.equal(brief.dirtySeconds, 300);
+  assert.equal(long.dirtySeconds, 300);
+
+  // Identical duration, different counts. Neither figure alone separates three
+  // short lapses from one sustained one, which is why the report prints both.
+  const briefCount = briefStates.filter((s) => s.bad).length;
+  const longCount = longStates.filter((s) => s.bad).length;
+  assert.equal(briefCount, 3);
+  assert.equal(longCount, 1);
+  assert.notEqual(briefCount, longCount);
+});
+
+test('exposure is zero over an empty history rather than NaN', () => {
+  assert.deepEqual(exposure([], T0), { dirtySeconds: 0, spanSeconds: 0 });
+});
+
+test('exposure never charges negative time for out-of-order timestamps', () => {
+  const { dirtySeconds } = exposure(
+    [
+      { at: T0, bad: true },
+      { at: T0 + DAY, bad: true },
+    ],
+    T0,
+  );
+  assert.ok(dirtySeconds >= 0, 'a clock skew must not subtract exposure');
+});
+
+test('humanDuration reports days and hours', () => {
+  assert.equal(humanDuration(2 * DAY + 3 * 3600), '2d 3h');
+});
+
+test('humanDuration drops the day field under a day', () => {
+  assert.equal(humanDuration(5 * 3600), '5h');
+});
+
+test('humanDuration floors rather than rounds up', () => {
+  assert.equal(humanDuration(3599), '0h', 'never imply an hour that did not elapse');
+});
+
+test('humanDuration handles zero and nonsense without inventing a number', () => {
+  assert.equal(humanDuration(0), '0h');
+  assert.equal(humanDuration(-1), '0h');
+  assert.equal(humanDuration(NaN), '0h');
+});
+
+test('census reports duration alongside the commit count', () => {
+  const git = fakeGit(
+    `aaa ${T0 + 2 * DAY} 2026-01-03\nbbb ${T0 + DAY} 2026-01-02\nccc ${T0} 2026-01-01`,
+    {
+      aaa: `      - uses: actions/checkout@${SHA}`,
+      bbb: '      - uses: actions/stale@v9',
+      ccc: `      - uses: actions/checkout@${SHA}`,
+    },
+  );
+  const result = censusHistory(git, 'origin/main', T0 + 3 * DAY);
+  assert.equal(result.dirty, 1, 'one commit');
+  assert.equal(result.dirtySeconds, DAY, 'held for exactly one day');
+  assert.equal(result.spanSeconds, 3 * DAY);
+});
+
+test('a commit declaring no actions holds a clean state rather than vanishing', () => {
+  // git grep exits non-zero with no matches. Treating that as "skip" would drop
+  // the interval from the span; treating it as clean keeps the partition summing.
+  const git = fakeGit(`aaa ${T0 + DAY} 2026-01-02\nbbb ${T0} 2026-01-01`, {
+    bbb: '      - uses: actions/stale@v9',
+  });
+  const result = censusHistory(git, 'origin/main', T0 + 2 * DAY);
+  assert.equal(result.examined, 2);
+  assert.equal(result.dirty, 1);
+  assert.equal(result.dirtySeconds, DAY, 'the unmatched commit ended the exposure');
+  assert.equal(result.spanSeconds, 2 * DAY);
 });


### PR DESCRIPTION
## Summary

`workflow:pin:history` reported **89 of 209** commits touching `.github/workflows` carried an unpinned action ref. That is complete over commits and **silent about duration** — the same 89 lapses could be 89 minutes or most of the repository's life, and no percentage of commits separates them.

Only commits touching the workflow directory change the branch's pinning state, so each one's state holds until the next newer such commit, and the newest holds until now. Duration is computable from the same walk already being done:

```
commits examined              209
commits with >=1 unpinned     89 (42.6%)
time in a non-compliant state 62d 19h of 160d 4h (39.2%)
```

The two figures nearly agree, so the lapses were close to average length. That was **not** predictable — a single long-lived lapse would have produced the same 42.6% beside a time figure two or three times larger. The count was a good proxy here, and the only way to learn that was to stop using it as one.

## Changes

- `tools/check-workflow-pin-history.mjs` — new exported `exposure()` and `humanDuration()`; `censusHistory()` now returns `dirtySeconds` / `spanSeconds` and accepts an injectable `nowSeconds`; log format widened to `%H %at %ad`.
- `tools/check-workflow-pin-history.test.mjs` — 16 → **28** tests.
- `docs/guides/engineering-practice-adoption.md` — one new section.

Three decisions forced by cases the count never had to answer:

- **The newest state runs to wall-clock now**, not to its own timestamp. An unrepaired HEAD is still accruing, and ending the interval at the last commit would show a currently-broken branch as having stopped being broken the moment nobody touched it. The report states that this interval grows between runs with no diff.
- **A commit declaring no actions holds a *clean* state rather than vanishing.** `git grep` exits non-zero when nothing matches, and the previous code treated that as a commit to skip — silently removing its interval from the span, so the partition stopped summing in the one direction where the total is the denominator. This is a pre-existing bug in code this PR touches.
- **Elapsed time is floored at zero per interval**, because git author dates can run backwards and one skewed commit would otherwise subtract exposure.

## One thing I got wrong in the first draft

A test asserted `notEqual(3, 1)` — two literals compared to each other, written directly beneath a comment explaining that counts and durations measure different things. It would have passed against any implementation, including one returning a constant. It now derives both counts from the same fixtures it measures the durations from, so it fails if the fixtures stop illustrating the claim. Same decorative-assertion shape this repository has criticised twice; writing it while writing about it is the point worth recording.

The git stub was widened rather than rewritten — it derives the new epoch field from the short date the existing cases already stated, so none of the sixteen prior tests silently changed meaning while the format changed underneath them.

## Issues

Closes #4260

## Testing

- [x] 28/28 tests; **5/5 mutants killed** — `until := own at`, dropped `Math.max` floor, head not run to now, grep-failure → `continue`, `humanDuration` ceil-instead-of-floor
- [x] All eight gates exit 0; `format:check`, `eslint . --max-warnings 0`, `type-check` clean
- [x] Run against real history: 209 commits, 62d 19h of 160d 4h