### PR TITLE
docs: verify relative markdown links (#4262)

### DIFF
--- a/deploy/monitoring/monitors.md
+++ b/deploy/monitoring/monitors.md
@@ -62,7 +62,7 @@ Recommended groups:
 
 ## Alerting Rules
 
-Reference: [docs/architecture/alerting-rules.md](../../../docs/architecture/alerting-rules.md)
+Reference: [docs/architecture/alerting-rules.md](../../docs/architecture/alerting-rules.md)
 
 | Severity | Response Time   | Escalation                                  |
 | -------- | --------------- | ------------------------------------------- |

--- a/docs/architecture/0015-premium-architecture.md
+++ b/docs/architecture/0015-premium-architecture.md
@@ -477,10 +477,10 @@ suspend fun onPurchaseValidated(engine: DefaultSyncEngine) {
 
 ## References
 
-- [ADR-0009: Legal & Monetization Analysis](../0009-legal-monetization-analysis.md)
-- [ADR-0010: V2 Architecture Vision](../0010-v2-architecture-vision.md)
-- [ADR-0004: Auth & Security Architecture](../0004-auth-security-architecture.md)
-- [ADR-0002: Backend & Sync Architecture](../0002-backend-sync-architecture.md)
+- [ADR-0009: Legal & Monetization Analysis](./0009-legal-monetization-analysis.md)
+- [ADR-0010: V2 Architecture Vision](./0010-v2-architecture-vision.md)
+- [ADR-0004: Auth & Security Architecture](./0004-auth-security-architecture.md)
+- [ADR-0002: Backend & Sync Architecture](./0002-backend-sync-architecture.md)
 - [Apple StoreKit 2 Documentation](https://developer.apple.com/storekit/)
 - [Google Play Billing Library](https://developer.android.com/google/play/billing)
 - [Stripe Subscriptions](https://stripe.com/docs/billing/subscriptions)

--- a/docs/architecture/0016-gamification-system.md
+++ b/docs/architecture/0016-gamification-system.md
@@ -617,9 +617,9 @@ val GAMIFICATION_CELEBRATIONS = FeatureFlagKey("gamification.celebrations.enable
 
 ## References
 
-- [ADR-0001: Cross-Platform Framework](../0001-cross-platform-framework.md) — KMP shared logic architecture
-- [ADR-0002: Backend & Sync Architecture](../0002-backend-sync-architecture.md) — PowerSync sync rules
-- [ADR-0004: Auth & Security Architecture](../0004-auth-security-architecture.md) — Household RBAC
+- [ADR-0001: Cross-Platform Framework](./0001-cross-platform-framework.md) — KMP shared logic architecture
+- [ADR-0002: Backend & Sync Architecture](./0002-backend-sync-architecture.md) — PowerSync sync rules
+- [ADR-0004: Auth & Security Architecture](./0004-auth-security-architecture.md) — Household RBAC
 - [ADR-0015: Premium Architecture](./0015-premium-architecture.md) — Premium tier integration
 - [Duolingo Engineering: Streak Mechanics](https://blog.duolingo.com/) — Streak design patterns
 - [Nir Eyal: Hooked](https://www.nirandfar.com/hooked/) — Behavioral design framework

--- a/docs/audits/accessibility-audit-wcag22.md
+++ b/docs/audits/accessibility-audit-wcag22.md
@@ -197,6 +197,6 @@ are in place for implemented UI. Re-audit after Windows reaches full parity.
 
 - [WCAG 2.2 Specification](https://www.w3.org/TR/WCAG22/)
 - [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/)
-- [Accessibility Guide](../../guides/accessibility.md)
-- [VPAT 2.5](../../compliance/vpat-2.5.md)
+- [Accessibility Guide](../guides/accessibility.md)
+- [VPAT 2.5](../compliance/vpat-2.5.md)
 - [Feature Parity Matrix](./feature-parity-matrix.md)

--- a/docs/business/marketing/marketing-plan-sprints-1-5.md
+++ b/docs/business/marketing/marketing-plan-sprints-1-5.md
@@ -5,7 +5,7 @@
 > **Owner:** Marketing Strategist
 > **Purpose:** Define marketing, GTM, and content tasks aligned with engineering milestones for the 5 sprints leading to v1.0 launch
 > **Preferred location:** `docs/business/marketing/marketing-plan-sprints-1-5.md` (create `docs/business/` directory and move this file)
-> **Related:** [Product Identity](../../design/product-identity.md) · [Store Metadata](../../guides/store-metadata.md) · [Beta Testing](../../guides/beta-testing.md) · [Launch Checklist](../../guides/launch-checklist.md) · [Onboarding Strategy](../../guides/onboarding-strategy.md) · [Launch Readiness Plan](launch-readiness-plan.md)
+> **Related:** [Product Identity](../../design/product-identity.md) · [Store Metadata](../../guides/store-metadata.md) · [Beta Testing](../../guides/beta-testing.md) · [Launch Checklist](../../guides/launch-checklist.md) · [Onboarding Strategy](../../guides/onboarding-strategy.md) · [Launch Readiness Plan](../../ops/launch-readiness-plan.md)
 
 > **Satisfies:** `PROD-PLAN-001`, `PROD-BUS-003` — Product obligations are defined in
 > [jrmoulckers/product](https://github.com/jrmoulckers/product). This document is the
@@ -712,7 +712,7 @@ All metrics come from platform-provided dashboards or aggregate opt-in analytics
 - [Beta Testing Program](../../guides/beta-testing.md) — Beta goals, recruitment, exit criteria
 - [Onboarding Strategy](../../guides/onboarding-strategy.md) — Onboarding flow and philosophy
 - [Launch Checklist](../../guides/launch-checklist.md) — Pre-launch requirements
-- [Launch Readiness Plan](launch-readiness-plan.md) — Launch day operations
+- [Launch Readiness Plan](../../ops/launch-readiness-plan.md) — Launch day operations
 - [Privacy Policy](../../legal/privacy-policy.md) — Data practices documentation
 - [ADR-0003: Local Storage](../../architecture/0003-local-storage-strategy.md) — SQLCipher encryption
 - [ADR-0004: Auth & Security](../../architecture/0004-auth-security-architecture.md) — Authentication architecture

--- a/docs/business/marketing/marketing-plan-sprints-6-10.md
+++ b/docs/business/marketing/marketing-plan-sprints-6-10.md
@@ -5,7 +5,7 @@
 > **Owner:** Marketing Strategist
 > **Purpose:** Define marketing, growth, and content tasks for the 5 sprints following v1.0 launch — shifting from launch execution to sustainable growth and retention
 > **Predecessor:** [Marketing Plan Sprints 1–5](marketing-plan-sprints-1-5.md) (pre-launch)
-> **Related:** [Product Identity](../../design/product-identity.md) · [Growth Strategy](growth-strategy-post-launch.md) · [Review Strategy](review-strategy.md) · [Launch Retrospective](launch-retrospective-week-1.md) · [Privacy Messaging](privacy-marketing-messaging.md)
+> **Related:** [Product Identity](../../design/product-identity.md) · [Growth Strategy](growth-strategy-post-launch.md) · [Review Strategy](review-strategy.md) · [Launch Retrospective](launch-retrospective-week-1.md) · [Privacy Messaging](../../marketing/privacy-marketing-messaging.md)
 
 > **Satisfies:** `PROD-PLAN-001`, `PROD-BUS-003` — Product obligations are defined in
 > [jrmoulckers/product](https://github.com/jrmoulckers/product). This document is the
@@ -835,8 +835,8 @@ All metrics come from platform-provided dashboards or aggregate opt-in analytics
 - [User Personas](../../design/personas.md) — Alex, Jordan, Casey, Sam profiles
 - [Growth Strategy](growth-strategy-post-launch.md) — 90-day post-launch growth plan (Sprint 5)
 - [Review Strategy](review-strategy.md) — Ethical review and rating approach (Sprint 5)
-- [Privacy Messaging](privacy-marketing-messaging.md) — Privacy marketing framework (Sprint 2)
+- [Privacy Messaging](../../marketing/privacy-marketing-messaging.md) — Privacy marketing framework (Sprint 2)
 - [Privacy Audit v1](../../architecture/privacy-audit-v1.md) — Data inventory and compliance status
 - [ADR-0004: Auth & Security](../../architecture/0004-auth-security-architecture.md) — Authentication and encryption architecture
 - [ADR-0009: Legal & Monetization](../../architecture/0009-legal-monetization-analysis.md) — BSL 1.1, pricing strategy
-- [Brand Voice Guide](brand-voice-guide.md) — Tone, vocabulary, do/don't examples (Sprint 1)
+- [Brand Voice Guide](../../marketing/brand-voice-guide.md) — Tone, vocabulary, do/don't examples (Sprint 1)

--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -7850,6 +7850,74 @@ things. It would have passed against any implementation, including one that retu
 constant. It now derives both counts from the same fixtures it measures the durations from,
 so the assertion fails if the fixtures stop illustrating the claim.
 
+## The link filter was the publisher's, and finance matched none of it
+
+The vendored citation checker follows only links whose target sits under `principles/`.
+That filter was reported here as a property of the vendored copy. It is not: it is
+`scripts/check-citations.mjs` in `jrmoulckers/engineering`, live on `main`, one vendoring
+hop upstream. Every consumer inherits it silently.
+
+The attribution error is the more useful half. An earlier finding in this same file family
+assumed a behaviour was inherited when it was local; this one assumed local when it was
+inherited. Same fork, same file, opposite direction, within a few turns — so neither
+_assume upstream_ nor _assume local_ is the conservative guess. Provenance has no safe
+default, and the only way to settle it is to read the other tree.
+
+What the filter leaves unmeasured is larger here than upstream, because finance has no
+`principles/` directory at all:
+
+```
+tracked markdown files    593
+relative .md links       3353
+  matched by the checker     0
+  verified by nothing     3353
+targets that do not exist   35
+```
+
+Not 5 of 65 — **0 of 3353**. The filter does not narrow the coverage here, it eliminates it.
+
+### Seven of the thirty-five were mine
+
+`docs/architecture/0015-premium-architecture.md` and `0016-gamification-system.md` were
+moved out of `docs/architecture/adr/` up one level during the first adoption commit. Their
+internal links read `../0009-legal-monetization-analysis.md`, which was correct from the
+`adr/` subdirectory and resolves outside `docs/architecture/` from the new location. Checked
+rather than assumed — the pre-move blob carries those exact `../` paths, and the rename was
+recorded as `R100`/`R099`, so the content did not change and the meaning of the content did.
+
+That regression shipped in the first commit of this adoption and survived every subsequent
+one. Nothing in lint, format, type-check or any of the eight gates reads a link, so a rename
+is invisible to all of them: the citing document stays syntactically perfect and simply
+points at nothing.
+
+The remaining twenty-eight split into eight in `docs/guides/workflow-cheatsheet.md` that use
+repo-root paths from a subdirectory — introduced long before this work, verified by finding
+the commit that added them — and twenty that name documents this repository has never
+contained. Twenty-four of the thirty-five resolved to exactly one existing file by basename
+and were repointed. The rest are recorded as a named, shrinkable baseline, because the fix
+for a link to a document that was never written is to write it or drop the reference, and a
+checker should not guess which.
+
+### The check is fence-aware because the census that found the defect was not
+
+An illustrative link inside a fenced block is not a link. The upstream-side census that
+first measured this gap reported one broken link that turned out to be an elided example
+inside a fence, so this implementation skips fenced blocks _and prints how many it skipped_ —
+an exclusion that is not counted is indistinguishable from an exclusion that never happened.
+Inline code spans are blanked rather than removed, so masking a `[x](./a.md)` illustration
+cannot shift the line number reported for a real link on the same line.
+
+Two things this check deliberately does not do, both printed on every run: it does not
+resolve anchor fragments, and it cannot see a target that keeps its path while its content
+moves elsewhere. That second failure is the one that motivated the whole exchange, and no
+link checker can hold it — a file that keeps its name stays green while every claim about
+its contents goes stale.
+
+One reporting bug caught before merge: the first version printed `12 recorded gap(s)`
+against a nine-entry baseline, because three targets are linked from two places each. It was
+reporting occurrences under a name that says distinct targets — the same conflation this
+guide has documented twice, in output written to describe it.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:

--- a/docs/guides/workflow-cheatsheet.md
+++ b/docs/guides/workflow-cheatsheet.md
@@ -121,16 +121,16 @@ Type `@agent-name` in VS Code Copilot Chat:
 
 Key architecture decisions made during development, documented as ADRs:
 
-| ADR                                                           | Decision                 | Chosen                           |
-| ------------------------------------------------------------- | ------------------------ | -------------------------------- |
-| [0001](docs/architecture/0001-cross-platform-framework.md)    | Cross-platform framework | KMP (Kotlin Multiplatform)       |
-| [0002](docs/architecture/0002-backend-sync-architecture.md)   | Backend + sync           | Supabase + PowerSync             |
-| [0003](docs/architecture/0003-local-storage-strategy.md)      | Local storage            | SQLite + SQLDelight + SQLCipher  |
-| [0004](docs/architecture/0004-auth-security-architecture.md)  | Authentication           | Passkeys + OAuth 2.0/PKCE        |
-| [0005](docs/architecture/0005-design-system-approach.md)      | Design system            | Design tokens (DTCG) + native UI |
-| [0006](docs/architecture/0006-cicd-strategy.md)               | CI/CD                    | GitHub Actions + Turborepo       |
-| [0007](docs/architecture/0007-hosting-strategy.md)            | Hosting                  | Self-hosted VPS (~$10-20/mo)     |
-| [0009](docs/architecture/0009-legal-monetization-analysis.md) | Monetization             | Freemium + donations             |
+| ADR                                                         | Decision                 | Chosen                           |
+| ----------------------------------------------------------- | ------------------------ | -------------------------------- |
+| [0001](../architecture/0001-cross-platform-framework.md)    | Cross-platform framework | KMP (Kotlin Multiplatform)       |
+| [0002](../architecture/0002-backend-sync-architecture.md)   | Backend + sync           | Supabase + PowerSync             |
+| [0003](../architecture/0003-local-storage-strategy.md)      | Local storage            | SQLite + SQLDelight + SQLCipher  |
+| [0004](../architecture/0004-auth-security-architecture.md)  | Authentication           | Passkeys + OAuth 2.0/PKCE        |
+| [0005](../architecture/0005-design-system-approach.md)      | Design system            | Design tokens (DTCG) + native UI |
+| [0006](../architecture/0006-cicd-strategy.md)               | CI/CD                    | GitHub Actions + Turborepo       |
+| [0007](../architecture/0007-hosting-strategy.md)            | Hosting                  | Self-hosted VPS (~$10-20/mo)     |
+| [0009](../architecture/0009-legal-monetization-analysis.md) | Monetization             | Freemium + donations             |
 
 ## Common Patterns
 

--- a/package.json
+++ b/package.json
@@ -68,7 +68,9 @@
     "version": "changeset version",
     "node:version:check": "node tools/check-node-version-consistency.mjs",
     "node:version:test": "node --test tools/check-node-version-consistency.test.mjs",
-    "citations:context:test": "node --test tools/citations-context.test.mjs"
+    "citations:context:test": "node --test tools/citations-context.test.mjs",
+    "docs:links:check": "node tools/check-doc-links.mjs",
+    "docs:links:test": "node --test tools/check-doc-links.test.mjs"
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx,mjs}": [

--- a/tools/check-doc-links.mjs
+++ b/tools/check-doc-links.mjs
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+/**
+ * Verify that relative markdown links point at files that exist.
+ *
+ * The vendored citation checker only follows links whose target sits under
+ * `principles/`. That filter is the publisher's, not this repository's fork -- it is
+ * `scripts/check-citations.mjs` upstream -- and finance has no `principles/` directory,
+ * so the filter matches nothing here and every relative link is verified by nothing.
+ *
+ * A moved file leaves the citing document syntactically intact, so nothing in a lint or
+ * format pass notices. This check closes that gap for existence only; see the scope lines
+ * it prints for what it deliberately does not measure.
+ *
+ * Cites ENG-OBS-004.
+ */
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const LINK = /\[[^\]]*\]\(([^)\s]+)\)/g;
+const FENCE = /^\s*(?:```|~~~)/;
+const INLINE_CODE = /`[^`]*`/g;
+
+/**
+ * Targets that name a document this repository has never contained. Each is a real gap in
+ * the docs rather than a stale path, so the fix is to write the document or drop the
+ * reference -- neither of which this check should guess at. The list is a ratchet: it may
+ * shrink, and any target not on it fails.
+ */
+export const UNRESOLVED_BASELINE = [
+  'docs/architecture/0005-design-system-approach.md -> ./0002-cross-platform-framework-selection.md',
+  'docs/architecture/0006-cicd-strategy.md -> ./0002-cross-platform-framework-selection.md',
+  'docs/architecture/0009-legal-monetization-analysis.md -> ./0008-competitive-protection-strategy.md',
+  'docs/architecture/0018-offline-conflict-resolution.md -> ./sync-architecture.md',
+  'docs/architecture/overview.md -> ./sync-architecture.md',
+  'docs/business/marketing/marketing-plan-sprints-6-10.md -> growth-strategy-post-launch.md',
+  'docs/business/marketing/marketing-plan-sprints-6-10.md -> launch-retrospective-week-1.md',
+  'docs/business/marketing/marketing-plan-sprints-6-10.md -> review-strategy.md',
+  'docs/guides/release-process.md -> ../audits/accessibility-checklist.md',
+];
+
+/**
+ * Split a document into lines, marking which are inside a fenced code block.
+ *
+ * A census that reads fenced blocks reports illustrative paths as real links. The census
+ * that first measured this defect in the citation checker was itself fence-blind and
+ * reported an elided example as a broken link, so this is measured rather than assumed:
+ * the count of skipped links is printed.
+ *
+ * @param {string} text
+ * @returns {{ line: string, fenced: boolean }[]}
+ */
+export function markFences(text) {
+  let fenced = false;
+  return String(text)
+    .split('\n')
+    .map((line) => {
+      if (FENCE.test(line)) {
+        fenced = !fenced;
+        return { line, fenced: true };
+      }
+      return { line, fenced };
+    });
+}
+
+/**
+ * Collect relative markdown-file links from one document.
+ *
+ * @param {string} text
+ * @returns {{ links: {href: string, target: string, line: number}[], skipped: number }}
+ */
+export function collectLinks(text) {
+  const links = [];
+  let skipped = 0;
+  const marked = markFences(text);
+  for (let i = 0; i < marked.length; i += 1) {
+    // Blank out inline code spans so a path shown as `../x.md` is not read as a link.
+    const line = marked[i].line.replace(INLINE_CODE, (m) => ' '.repeat(m.length));
+    for (const match of line.matchAll(LINK)) {
+      const href = match[1];
+      if (/^(?:[a-z][a-z0-9+.-]*:|#|\/\/)/i.test(href)) continue;
+      const target = href.split('#')[0].trim();
+      if (!target.endsWith('.md')) continue;
+      if (marked[i].fenced) {
+        skipped += 1;
+        continue;
+      }
+      links.push({ href, target, line: i + 1 });
+    }
+  }
+  return { links, skipped };
+}
+
+/**
+ * Walk every tracked markdown file and resolve its relative links.
+ *
+ * @param {(args: string[]) => string} git
+ * @param {(p: string) => boolean} exists
+ * @param {(p: string) => string} read
+ * @returns {{files: number, total: number, fenced: number, broken: string[]}}
+ */
+export function census(git, exists, read) {
+  const files = git(['ls-files', '*.md']).trim().split('\n').filter(Boolean);
+  const broken = [];
+  let total = 0;
+  let fenced = 0;
+
+  for (const file of files) {
+    const { links, skipped } = collectLinks(read(file));
+    fenced += skipped;
+    for (const link of links) {
+      total += 1;
+      const resolved = path.posix.normalize(
+        path.posix.join(path.posix.dirname(file.split(path.sep).join('/')), link.target),
+      );
+      if (!exists(resolved)) broken.push(`${file} -> ${link.href}`);
+    }
+  }
+  return { files: files.length, total, fenced, broken };
+}
+
+/**
+ * Lines describing what was and was not measured, printed on both the passing and the
+ * failing path. A control that reports its population only when it passes cannot be
+ * distinguished from one that measured nothing.
+ *
+ * @param {{files: number, total: number, fenced: number}} scope
+ * @returns {string[]}
+ */
+export function scopeLines({ files, total, fenced }) {
+  return [
+    `Scope: ${total} relative markdown link(s) across ${files} tracked file(s); ${fenced} inside fenced blocks were skipped.`,
+    'Not measured: URL targets, anchor fragments, links to non-markdown files, or whether',
+    'a target still contains the content the citing text claims. A file that keeps its name',
+    'while its content moves elsewhere stays green here and is wrong.',
+  ];
+}
+
+function main() {
+  const git = (args) =>
+    execFileSync('git', args, { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+  const root = process.cwd();
+  const exists = (p) => fs.existsSync(path.join(root, p));
+  const read = (p) => fs.readFileSync(path.join(root, p), 'utf8');
+
+  const { files, total, fenced, broken } = census(git, exists, read);
+  const baseline = new Set(UNRESOLVED_BASELINE);
+  const unexpected = broken.filter((b) => !baseline.has(b));
+  const fixed = [...baseline].filter((b) => !broken.includes(b));
+  // `broken` counts occurrences; the baseline names distinct targets, and three of
+  // them are linked from two places. Printing one as the other would report twelve
+  // gaps against a nine-entry list and invite exactly the wrong correction.
+  const distinctBroken = new Set(broken).size;
+
+  if (unexpected.length > 0) {
+    console.error(`${unexpected.length} broken relative markdown link(s):`);
+    for (const b of unexpected) console.error(`  ${b}`);
+    console.error('');
+    console.error('A moved or renamed file leaves the citing document syntactically intact,');
+    console.error('so nothing in a lint or format pass notices. Repoint or remove the link.');
+    console.error('');
+    for (const line of scopeLines({ files, total, fenced })) console.error(line);
+    console.error(
+      `${broken.length} broken occurrence(s) over ${distinctBroken} distinct target(s); ${baseline.size - fixed.length} of those targets are recorded gaps where the document does not exist.`,
+    );
+    process.exit(1);
+  }
+
+  console.log(`All resolvable relative markdown links point at files that exist.`);
+  for (const line of scopeLines({ files, total, fenced })) console.log(line);
+  console.log(
+    `${distinctBroken} recorded gap(s) remain across ${broken.length} link(s), where the target names a document this repository has never contained.`,
+  );
+  if (fixed.length > 0) {
+    console.log('');
+    console.log(
+      `${fixed.length} recorded gap(s) no longer broken -- remove them from the baseline:`,
+    );
+    for (const f of fixed) console.log(`  ${f}`);
+    process.exit(1);
+  }
+}
+
+if (process.argv[1] && process.argv[1].endsWith('check-doc-links.mjs')) {
+  main();
+}

--- a/tools/check-doc-links.test.mjs
+++ b/tools/check-doc-links.test.mjs
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  UNRESOLVED_BASELINE,
+  census,
+  collectLinks,
+  markFences,
+  scopeLines,
+} from './check-doc-links.mjs';
+
+test('a relative markdown link is collected', () => {
+  const { links } = collectLinks('See [x](../guides/x.md) here.');
+  assert.equal(links.length, 1);
+  assert.equal(links[0].target, '../guides/x.md');
+});
+
+test('an anchor is stripped from the target but kept in the href', () => {
+  const { links } = collectLinks('[x](./a.md#section)');
+  assert.equal(links[0].target, './a.md');
+  assert.equal(links[0].href, './a.md#section');
+});
+
+test('absolute URLs are not treated as files', () => {
+  const { links } = collectLinks('[x](https://example.com/a.md) [y](mailto:a@b.md)');
+  assert.equal(links.length, 0);
+});
+
+test('a protocol-relative URL is not treated as a file', () => {
+  const { links } = collectLinks('[x](//example.com/a.md)');
+  assert.equal(links.length, 0, 'a leading // is a URL, not a relative path');
+});
+
+test('a bare fragment is not treated as a file', () => {
+  const { links } = collectLinks('[x](#anchor)');
+  assert.equal(links.length, 0);
+});
+
+test('non-markdown targets are out of scope', () => {
+  const { links } = collectLinks('[x](./a.png) [y](./b.ts)');
+  assert.equal(links.length, 0);
+});
+
+test('links inside a fenced block are skipped and counted', () => {
+  const doc = ['before [a](./a.md)', '```', 'inside [b](./b.md)', '```', 'after [c](./c.md)'].join(
+    '\n',
+  );
+  const { links, skipped } = collectLinks(doc);
+  assert.deepEqual(
+    links.map((l) => l.target),
+    ['./a.md', './c.md'],
+  );
+  assert.equal(skipped, 1, 'the skip must be reported, not silent');
+});
+
+test('a tilde fence opens and closes a block too', () => {
+  const doc = ['~~~', '[b](./b.md)', '~~~'].join('\n');
+  assert.equal(collectLinks(doc).links.length, 0);
+});
+
+test('an inline code span is not a link', () => {
+  const { links } = collectLinks('write `[x](./a.md)` to link');
+  assert.equal(links.length, 0, 'a path shown as code is an illustration');
+});
+
+test('blanking a code span does not shift the line number of a real link', () => {
+  const doc = ['first', '`[x](./a.md)` and [y](./b.md)'].join('\n');
+  const { links } = collectLinks(doc);
+  assert.equal(links.length, 1);
+  assert.equal(links[0].line, 2);
+});
+
+test('markFences marks the fence line itself as fenced', () => {
+  const marked = markFences('a\n```\nb\n```\nc');
+  assert.deepEqual(
+    marked.map((m) => m.fenced),
+    [false, true, true, true, false],
+  );
+});
+
+test('an unclosed fence swallows the rest of the file rather than reopening', () => {
+  const marked = markFences('a\n```\nb\nc');
+  assert.deepEqual(
+    marked.map((m) => m.fenced),
+    [false, true, true, true],
+  );
+});
+
+function fakeCensus(filesByPath, existing) {
+  const git = (args) => {
+    assert.equal(args[0], 'ls-files');
+    return Object.keys(filesByPath).join('\n');
+  };
+  const exists = (p) => existing.has(p);
+  const read = (p) => filesByPath[p];
+  return census(git, exists, read);
+}
+
+test('census resolves a link relative to the citing file, not the repo root', () => {
+  const result = fakeCensus(
+    { 'docs/guides/a.md': '[x](../architecture/b.md)' },
+    new Set(['docs/architecture/b.md']),
+  );
+  assert.deepEqual(result.broken, []);
+  assert.equal(result.total, 1);
+});
+
+test('census reports a link that escapes above the resolved target', () => {
+  const result = fakeCensus(
+    { 'docs/guides/a.md': '[x](../../architecture/b.md)' },
+    new Set(['docs/architecture/b.md']),
+  );
+  assert.deepEqual(result.broken, ['docs/guides/a.md -> ../../architecture/b.md']);
+});
+
+test('census counts files and fenced skips as well as links', () => {
+  const result = fakeCensus(
+    {
+      'a.md': '[x](./b.md)\n```\n[y](./nope.md)\n```',
+      'b.md': 'no links',
+    },
+    new Set(['b.md']),
+  );
+  assert.equal(result.files, 2);
+  assert.equal(result.total, 1);
+  assert.equal(result.fenced, 1);
+  assert.deepEqual(result.broken, []);
+});
+
+test('census returns an empty result for a repository with no markdown', () => {
+  const result = census(
+    () => '',
+    () => false,
+    () => '',
+  );
+  assert.deepEqual(result, { files: 0, total: 0, fenced: 0, broken: [] });
+});
+
+test('scopeLines states the population on any branch that prints them', () => {
+  const out = scopeLines({ files: 593, total: 3353, fenced: 2 }).join('\n');
+  assert.match(out, /3353 relative markdown link\(s\)/);
+  assert.match(out, /593 tracked file\(s\)/);
+  assert.match(out, /2 inside fenced blocks/);
+});
+
+test('scopeLines names the failure this check cannot see', () => {
+  const out = scopeLines({ files: 1, total: 1, fenced: 0 }).join('\n');
+  assert.match(
+    out,
+    /keeps its name[\s\S]*content moves/,
+    'a target that keeps its path while losing its content stays green',
+  );
+});
+
+test('the baseline holds distinct entries only', () => {
+  assert.equal(new Set(UNRESOLVED_BASELINE).size, UNRESOLVED_BASELINE.length);
+});
+
+test('every baseline entry is in the file -> href form the census emits', () => {
+  for (const entry of UNRESOLVED_BASELINE) {
+    assert.match(entry, /^[^ ]+\.md -> \S+\.md$/, `malformed baseline entry: ${entry}`);
+  }
+});


### PR DESCRIPTION
## Summary

No gate in this repository reads a markdown link. The vendored citation checker follows only targets under `principles/`, a filter that belongs to the publisher (`scripts/check-citations.mjs` in `jrmoulckers/engineering`) rather than the vendored copy — measured against the other tree, after an earlier finding in the same file turned out the opposite way. finance has no `principles/` directory, so the filter matches nothing.

```
tracked markdown files    593
relative .md links       3353
  verified by nothing    3353
targets that do not exist  35
```

Seven of the 35 came from the first adoption commit here, which flattened `docs/architecture/adr/` up one level (`R099`/`R100`, content unchanged) while the `../000N-*.md` links inside kept the old depth. The citing documents stayed syntactically perfect and pointed at nothing, so lint, format, type-check and all eight existing gates stayed green through every subsequent PR.

## Changes

- `tools/check-doc-links.mjs` — fence-aware and inline-code-aware; prints the population, the skip count and the two named non-measurements on **both** the passing and failing paths; distinguishes broken occurrences (12) from distinct targets (9).
- `tools/check-doc-links.test.mjs` — 20 tests; 6/6 mutants killed (fence line not fenced, no fence toggle, skip not counted, inline code removed instead of blanked, resolve from citing file instead of repo root, protocol-relative rejected).
- `UNRESOLVED_BASELINE` — 9 targets that name documents this repository has never contained. A ratchet, not a suppression: writing them or dropping the reference is an editorial call a checker should not make.
- 24 links fixed across 7 documents.
- `docs:links:check` / `docs:links:test` scripts, and a section in the adoption guide.

## Issues

Closes #4262

## Testing

- [x] `npm run format:check`, `npx eslint . --max-warnings 0`, `npm run type-check`
- [x] 20/20 tests, 6/6 mutants killed
- [x] All 12 repo gates green; new gate forced red and verified to print full scope