### PR TITLE
fix(tools): cite each direction's own population, not the dependency count (#4266)

### DIFF
--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -7918,6 +7918,89 @@ against a nine-entry baseline, because three targets are linked from two places 
 reporting occurrences under a name that says distinct targets — the same conflation this
 guide has documented twice, in output written to describe it.
 
+## The number beside a verdict was from the wrong vocabulary
+
+Both directions of the `engines.node` check printed the same figure:
+
+```
+admits no version rejected by any of 452 dependency declaration(s).
+excludes no version that all 452 dependency declaration(s) accept.
+```
+
+`452` decides neither. The probe set is 52 versions; the declared range admits
+8 of them and excludes 44. So one verdict rests on 8 points, the other on 44,
+and the number offered as the scope of both is a count of a different thing
+entirely — declarations, not probes. Two verdicts, two populations, one number,
+and it is neither of them.
+
+This was written to satisfy the rule that a verdict must print its scope. It
+prints _a_ number, in a sentence that reads as a denominator, and the check
+passes a reader's eye precisely because 452 is large and real. A wrong
+denominator is worse than a missing one: absence prompts the question, and a
+plausible figure closes it.
+
+Both lines now name the population that decided them, and the scope line states
+a partition that sums:
+
+```
+admits no version rejected by any dependency, over the 8 probe version(s) it admits.
+excludes no version that every dependency accepts, over the 44 probe version(s) it excludes.
+scope: both directions checked over 52 probe version(s) (8 admitted, 44 excluded)
+       drawn from 452 dependency declaration(s).
+```
+
+### A direction that fires without consulting evidence
+
+All 452 installed declarations are unbounded above — none rejects Node 9999.
+That makes the over-restrictive direction degenerate past the highest major any
+dependency names, but not in the way it first appears. "Every dependency accepts
+this version" is _unanimous by construction_ up there, so the check reports every
+version the declared range excludes, without the tree contributing anything. It
+has stopped testing the range and started handing the range's own upper bound
+back.
+
+The mirror is where a clean reading becomes worthless: a range left open above
+excludes nothing up there, so it has no population and returns empty whatever
+the tree looks like. That is this repository's case — `>=22.22.1 <23 || >=24` is
+open above 24, the highest major the tree names, so **0** probe versions sit in
+the region, and the clean verdict there is guaranteed rather than earned.
+
+Either way the upper end of an `engines.node` range is unfalsifiable from
+`engines` data. The only evidence for it is having run it, which is why the
+marked CI job that actually executes Node 24 carries more weight than any number
+of probe points. The check now says so on every run.
+
+### The first draft of that reasoning was backwards, and a test caught it
+
+The initial notice claimed nothing above the line _could ever_ be flagged. A
+fixture returned 3, not 0. The direction is not silenced up there; it is made
+unanimous, which is the opposite failure and produces the opposite output. The
+assertion that caught it was a literal `0` transplanted from this repository's
+real tree into a fixture that does not have that shape — so a value carried
+across contexts failed for the right reason, which is the more useful half.
+
+Two further mutants survived the first pass and both were real:
+
+- Reverting the interpolation to `populations.declarations` left every unit test
+  green, because they all tested the computation and none read the sentence. The
+  defect being fixed is _which number appears in the text_, and no test looked at
+  text. The notice builder is now a separate exported function so the strings are
+  assertable.
+- `highestNamedMajor` used `Math.max`, and replacing it with plain assignment
+  passed everything — every fixture happened to list its literals in ascending
+  order. A fixture is realistic and discriminating for unrelated reasons.
+
+A third: asserting only that the partition _sums_ let a mutant printing the
+admitted count in both slots survive, because the natural two-dependency fixture
+splits 7/7. It now uses one that splits 7/9 and asserts each half against the
+population it names.
+
+One correctness fix fell out of the same pass. `highestNamedMajor` read only full
+`x.y.z` triples, so a range like `18 || 20 || >=22` — the canonical form for
+declaring support across LTS majors — appeared to name nothing. That put the line
+lower than the tree states, and since the notice claims everything past the line
+is not evidence, understating it over-claims.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:

--- a/tools/check-node-version-consistency.mjs
+++ b/tools/check-node-version-consistency.mjs
@@ -24,6 +24,14 @@ import semver from 'semver';
 const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const workflowDirectory = join(repositoryRoot, '.github', 'workflows');
 
+/**
+ * A version far beyond any real release, used to ask whether a range bounds
+ * above at all. Any range that accepts this one accepts every version that will
+ * ever exist, which is the property that makes the over-restrictive direction
+ * unfalsifiable past the highest bound anyone states.
+ */
+export const UNREACHABLE_FUTURE_VERSION = '9999.0.0';
+
 /** Reads the major version declared by `.nvmrc` text, or null when absent. */
 export function parseNvmrc(text) {
   const match = String(text ?? '')
@@ -263,6 +271,65 @@ export function findExcludedCompatibilities(declared, dependencies) {
   }
   return excluded.sort((a, b) => semver.compare(a.version, b.version));
 }
+/**
+ * The population each direction was actually decided over, and whether the
+ * second one could have fired at all.
+ *
+ * Both verdicts above previously printed the *dependency count* beside them.
+ * That number decides neither: the probe set is 52 versions, of which the
+ * declared range admits 8 and excludes 44, so one verdict rests on 8 points and
+ * the other on 44 while both cite 452. A count is only a denominator for the
+ * question it enumerates, and `dependencies.length` enumerates declarations.
+ *
+ * The second field matters more, and its consequence is the opposite of the
+ * intuitive one. `findExcludedCompatibilities` reports versions every
+ * dependency accepts, and a dependency stating no upper bound accepts every
+ * version there will ever be -- so once all of them are open above, "every
+ * dependency accepts it" is automatically true past the highest bound anyone
+ * names. The direction does not go quiet up there; it fires for *anything* the
+ * declared range excludes, without consulting evidence, because the evidence is
+ * unanimous by construction. It has stopped testing the range against the tree
+ * and started restating the range's own upper bound back at you.
+ *
+ * The mirror of that is where a clean reading becomes worthless: a declared
+ * range left open above excludes nothing up there, so it has no population to
+ * test and returns empty whatever the tree looks like. Either way the upper end
+ * of `engines.node` is unfalsifiable from `engines` data; the only evidence for
+ * it is having run the thing.
+ */
+export function directionPopulations(declared, dependencies) {
+  const usable = dependencies.filter((dep) => dep.range && semver.validRange(dep.range));
+  const probes = probeVersions(usable.map((dep) => dep.range));
+  const valid = declared && semver.validRange(declared);
+  const admitted = valid ? probes.filter((version) => semver.satisfies(version, declared)) : [];
+  const excluded = valid ? probes.filter((version) => !semver.satisfies(version, declared)) : [];
+  const unboundedAbove = usable.filter((dep) =>
+    semver.satisfies(UNREACHABLE_FUTURE_VERSION, dep.range, { includePrerelease: true }),
+  );
+  let highestNamedMajor = 0;
+  for (const dep of usable) {
+    // Bare majors count. A range of `18 || 20 || >=22` names three majors and
+    // not one full `x.y.z`, so a triple-only regex reads it as naming nothing
+    // and puts the line lower than the tree actually states. That direction is
+    // not safe: the notice below claims everything past this line is
+    // unmeasurable, so understating it over-claims.
+    for (const match of String(dep.range).matchAll(/(\d+)(?:\.\d+(?:\.\d+)?)?/g)) {
+      highestNamedMajor = Math.max(highestNamedMajor, Number(match[1]));
+    }
+  }
+  return {
+    probes: probes.length,
+    admitted: admitted.length,
+    excluded: excluded.length,
+    unboundedAbove: unboundedAbove.length,
+    declarations: usable.length,
+    highestNamedMajor,
+    excludedAboveHighestNamed: excluded.filter(
+      (version) => semver.major(version) > highestNamedMajor,
+    ).length,
+  };
+}
+
 /** Every installed dependency that states an `engines.node`, walked from disk. */
 export function collectDependencyEngines(root, depth = 0) {
   const found = [];
@@ -295,6 +362,58 @@ export function collectDependencyEngines(root, depth = 0) {
   }
   return found;
 }
+/**
+ * The notices describing what each direction was decided over.
+ *
+ * Extracted from `main` so the rendered strings are testable. That matters more
+ * than it looks: the whole point of this change is *which number appears beside
+ * a verdict*, and a test of `directionPopulations` alone cannot see the text.
+ * Reverting the interpolation to the dependency count survived every unit test
+ * of the computation, because nothing read the sentence.
+ */
+export function directionNotices(declared, populations, admittedFindings, excludedFindings) {
+  const notices = [];
+  if (admittedFindings.length === 0) {
+    notices.push(
+      `engines.node "${declared}" admits no version rejected by any dependency, ` +
+        `over the ${populations.admitted} probe version(s) it admits.`,
+    );
+  }
+  if (excludedFindings.length > 0) {
+    notices.push(
+      `engines.node "${declared}" excludes Node ${excludedFindings
+        .map((entry) => entry.version)
+        .join(
+          ', ',
+        )}, which every one of ${populations.declarations} dependency declaration(s) accepts.`,
+    );
+  } else {
+    notices.push(
+      `engines.node excludes no version that every dependency accepts, ` +
+        `over the ${populations.excluded} probe version(s) it excludes.`,
+    );
+  }
+  // Both directions are named even when both are clean, because "admits no bad
+  // version" reads as "the range is right" and is only half the claim. Each
+  // verdict cites the population that decided it rather than the dependency
+  // count, which decided neither.
+  notices.push(
+    `scope: both directions checked over ${populations.probes} probe version(s) ` +
+      `(${populations.admitted} admitted, ${populations.excluded} excluded) ` +
+      `drawn from ${populations.declarations} dependency declaration(s).`,
+  );
+  if (populations.declarations > 0 && populations.unboundedAbove === populations.declarations) {
+    notices.push(
+      `not evidence: all ${populations.declarations} declaration(s) are unbounded above, so past Node ` +
+        `${populations.highestNamedMajor} "every dependency accepts it" is true by construction. ` +
+        `${populations.excludedAboveHighestNamed} probe version(s) sit there, and the verdict on them ` +
+        `restates engines.node's own upper bound rather than testing it. The upper end is ` +
+        `unfalsifiable from engines data; only running it is evidence.`,
+    );
+  }
+  return notices;
+}
+
 function main() {
   const expectedMajor = parseNvmrc(readFileSync(join(repositoryRoot, '.nvmrc'), 'utf8'));
   if (!expectedMajor) {
@@ -338,6 +457,7 @@ function main() {
     notices.push('node_modules is absent, so engines.node was not checked against dependencies.');
   } else {
     const dependencies = collectDependencyEngines(modules);
+    const populations = directionPopulations(engines?.node, dependencies);
     const admitted = findAdmittedIncompatibilities(engines?.node, dependencies);
     if (admitted.length > 0) {
       const worst = admitted[0];
@@ -347,33 +467,12 @@ function main() {
           `(e.g. ${worst.ranges.join(', ')}). ${admitted.length} admitted version(s) fail this way. ` +
           `Narrow engines.node to what the dependency tree actually supports.`,
       );
-    } else {
-      notices.push(
-        `engines.node "${engines?.node}" admits no version rejected by any of ${dependencies.length} dependency declaration(s).`,
-      );
     }
-    // The other direction. Reported as a notice because a dependency relaxing
-    // its own floor widens what is admissible without any local edit, and this
-    // check only fails on disagreements a local edit causes.
+    // The other direction is a notice because a dependency relaxing its own
+    // floor widens what is admissible without any local edit, and this check
+    // only fails on disagreements a local edit causes.
     const excluded = findExcludedCompatibilities(engines?.node, dependencies);
-    if (excluded.length > 0) {
-      notices.push(
-        `engines.node "${engines?.node}" excludes Node ${excluded
-          .map((entry) => entry.version)
-          .join(
-            ', ',
-          )}, which every one of ${dependencies.length} dependency declaration(s) accepts.`,
-      );
-    } else {
-      notices.push(
-        `engines.node excludes no version that all ${dependencies.length} dependency declaration(s) accept.`,
-      );
-    }
-    // Both directions are named even when both are clean, because "admits no
-    // bad version" reads as "the range is right" and is only half the claim.
-    notices.push(
-      'scope: both directions were checked, over versions named by some dependency range.',
-    );
+    notices.push(...directionNotices(engines?.node, populations, admitted, excluded));
   }
   const runningMajor = process.versions.node.split('.')[0];
   if (runningMajor !== expectedMajor) {

--- a/tools/check-node-version-consistency.test.mjs
+++ b/tools/check-node-version-consistency.test.mjs
@@ -15,8 +15,11 @@ import {
   majorSatisfiesEngines,
   parseNvmrc,
   pinMajor,
+  directionNotices,
+  directionPopulations,
   probeVersions,
   RANGE_MARKER,
+  UNREACHABLE_FUTURE_VERSION,
 } from './check-node-version-consistency.mjs';
 
 const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
@@ -334,4 +337,166 @@ test('a deliberately excluded odd major is reported when nothing rejects it', ()
   const permissive = [{ range: '>=20' }];
   const found = findExcludedCompatibilities('>=22.22.1 <23 || >=24', permissive);
   assert.ok(found.some((f) => f.version === '23.0.0'));
+});
+
+test('each direction reports the population that decided it, not the dependency count', () => {
+  // The defect this replaces: both verdicts printed `dependencies.length`, a
+  // number that decides neither. Asserting the three are distinct is what makes
+  // reintroducing the shared count fail here rather than read plausibly.
+  const dependencies = [{ range: '>=18' }, { range: '>=20.9.0' }, { range: '^18 || >=20' }];
+  const populations = directionPopulations('>=22.22.1 <23 || >=24', dependencies);
+  assert.equal(populations.probes, populations.admitted + populations.excluded);
+  assert.notEqual(populations.admitted, populations.declarations);
+  assert.notEqual(populations.excluded, populations.declarations);
+  assert.equal(populations.declarations, dependencies.length);
+});
+
+test('the partition sums even when the declared range admits nothing probed', () => {
+  const dependencies = [{ range: '>=18' }];
+  const populations = directionPopulations('>=90', dependencies);
+  assert.equal(populations.probes, populations.admitted + populations.excluded);
+  assert.equal(populations.admitted, 0);
+});
+
+test('a tree that is entirely unbounded above is reported as such', () => {
+  const dependencies = [{ range: '>=18' }, { range: '^18 || >=20' }, { range: '>=20.9.0' }];
+  const populations = directionPopulations('>=22.22.1 <23 || >=24', dependencies);
+  assert.equal(populations.unboundedAbove, dependencies.length);
+  // The consequence, which is the point of measuring it: nothing above the
+  // highest bound anyone names can ever be flagged as wrongly excluded, so a
+  // clean reading up there is vacuous rather than reassuring. Stated as a
+  // comparison between two measurements of this fixture -- an earlier draft
+  // asserted the literal 0, which was the real tree's value carried into a
+  // fixture that does not have it, and the test caught the transplant.
+  assert.ok(populations.excludedAboveHighestNamed > 0);
+  // And every one of them is reported, without the tree being consulted --
+  // which is the actual defect. Above the line "every dependency accepts it" is
+  // unanimous by construction, so the finding is the declared range's own upper
+  // bound handed back, not a measurement of it. An earlier draft asserted 0
+  // here on the theory that the direction goes quiet up there; it does the
+  // opposite, and only running it distinguished the two.
+  const aboveLine = findExcludedCompatibilities('>=22.22.1 <23 || >=24', dependencies).filter(
+    (entry) => Number(entry.version.split('.')[0]) > populations.highestNamedMajor,
+  );
+  assert.equal(aboveLine.length, populations.excludedAboveHighestNamed);
+});
+
+test('an open-ended declared range has no population above the line at all', () => {
+  // The mirror case, and the one this repository is in: nothing is excluded up
+  // there, so the clean verdict is guaranteed rather than earned.
+  // Shaped like this repository: the tree names a major the declared range is
+  // open above. A first draft put the declared floor *above* every major the
+  // deps name, which leaves a real excluded population and is the other case.
+  const dependencies = [{ range: '>=18' }, { range: '>=24.1.0' }];
+  const populations = directionPopulations('>=22.22.1 <23 || >=24', dependencies);
+  assert.equal(populations.unboundedAbove, dependencies.length);
+  assert.equal(populations.highestNamedMajor, 24);
+  assert.equal(populations.excludedAboveHighestNamed, 0);
+  assert.ok(populations.excluded > 0);
+});
+
+test('a bounded-above dependency is counted as bounded', () => {
+  // Discriminates the unbounded count from a constant: this range rejects the
+  // probe, so the tally must fall below the declaration count.
+  const dependencies = [{ range: '>=18' }, { range: '>=18 <24' }];
+  const populations = directionPopulations('>=22.22.1', dependencies);
+  assert.equal(populations.declarations, 2);
+  assert.equal(populations.unboundedAbove, 1);
+});
+
+test('the unreachable probe is above every major the tree names', () => {
+  // If this constant ever drifts below a real release, `unboundedAbove` starts
+  // undercounting silently and the vacuity notice stops appearing.
+  const dependencies = [{ range: '>=18' }, { range: '>=20.9.0 <21 || >=22' }];
+  const populations = directionPopulations('>=22', dependencies);
+  assert.ok(Number(UNREACHABLE_FUTURE_VERSION.split('.')[0]) > populations.highestNamedMajor);
+  assert.equal(populations.highestNamedMajor, 22);
+  // >=22 is a bare major with no minor or patch. A triple-only regex reads
+  // it as naming nothing, which puts the line at 20 and over-claims the
+  // unmeasurable region above it.
+});
+
+test('highestNamedMajor reads every literal in a range, not just the first', () => {
+  const dependencies = [{ range: '^18.18.0 || ^20.9.0 || >=21.1.0' }];
+  const populations = directionPopulations('>=22', dependencies);
+  assert.equal(populations.highestNamedMajor, 21);
+});
+test('the rendered notice cites the direction population, not the dependency count', () => {
+  // The unit test of directionPopulations cannot see this: swapping the
+  // interpolation back to the dependency count leaves every computation test
+  // green, because none of them read the sentence. This asserts against the
+  // measured populations rather than literals, so it tracks the fixture.
+  const dependencies = [{ range: '>=18' }, { range: '>=20.9.0' }, { range: '^18 || >=20' }];
+  const declared = '>=22.22.1 <23 || >=24';
+  const populations = directionPopulations(declared, dependencies);
+  const lines = directionNotices(declared, populations, [], []).join('\n');
+  assert.match(
+    lines,
+    new RegExp(`over the ${populations.admitted} probe version\\(s\\) it admits`),
+  );
+  assert.match(
+    lines,
+    new RegExp(`over the ${populations.excluded} probe version\\(s\\) it excludes`),
+  );
+  // And the two must be distinguishable from the count they used to print.
+  assert.notEqual(populations.admitted, populations.declarations);
+  assert.notEqual(populations.excluded, populations.declarations);
+});
+
+test('the scope line states a partition that sums to the probe set', () => {
+  // This fixture splits 7/9. The obvious two-dependency fixture splits 7/7,
+  // where printing the admitted count in both slots still sums to the probe
+  // set -- a fixture chosen for realism rather than for discriminating power.
+  const dependencies = [{ range: '^18.18.0 || ^20.9.0 || >=21.1.0' }, { range: '>=18' }];
+  const declared = '>=22.22.1 <23 || >=24';
+  const populations = directionPopulations(declared, dependencies);
+  const scope = directionNotices(declared, populations, [], []).find((line) =>
+    line.startsWith('scope:'),
+  );
+  const [, probes, admitted, excluded] = scope.match(
+    /over (\d+) probe version\(s\) \((\d+) admitted, (\d+) excluded\)/,
+  );
+  assert.equal(Number(admitted) + Number(excluded), Number(probes));
+  // Summing is not enough on its own: printing the admitted count in both
+  // slots still sums correctly whenever a fixture happens to split in half,
+  // and the first draft of this test used exactly such a fixture. Each half is
+  // therefore checked against the population it names, and the two are asserted
+  // to differ so the mutant cannot hide behind a symmetric split.
+  assert.equal(Number(admitted), populations.admitted);
+  assert.equal(Number(excluded), populations.excluded);
+  assert.notEqual(populations.admitted, populations.excluded);
+});
+
+test('the unfalsifiable-upper-end notice appears only when the tree is all open above', () => {
+  const declared = '>=22.22.1 <23 || >=24';
+  const open = [{ range: '>=18' }, { range: '>=24.1.0' }];
+  const closed = [{ range: '>=18' }, { range: '>=18 <26' }];
+  const marker = /not evidence: all \d+ declaration\(s\) are unbounded above/;
+  assert.match(
+    directionNotices(declared, directionPopulations(declared, open), [], []).join('\n'),
+    marker,
+  );
+  assert.doesNotMatch(
+    directionNotices(declared, directionPopulations(declared, closed), [], []).join('\n'),
+    marker,
+  );
+});
+
+test('an empty tree does not claim its zero declarations are all unbounded', () => {
+  // 0 === 0 would satisfy a naive equality and print the notice over nothing.
+  const declared = '>=22.22.1 <23 || >=24';
+  const populations = directionPopulations(declared, []);
+  assert.equal(populations.declarations, 0);
+  assert.equal(populations.unboundedAbove, 0);
+  assert.doesNotMatch(
+    directionNotices(declared, populations, [], []).join('\n'),
+    /not evidence: all \d+ declaration\(s\) are unbounded above/,
+  );
+});
+
+test('highestNamedMajor is the maximum, not the last literal read', () => {
+  // Every other fixture happens to list its literals in ascending order, so
+  // replacing Math.max with plain assignment passes all of them.
+  const populations = directionPopulations('>=22', [{ range: '>=24.0.0 || ^18.1.0' }]);
+  assert.equal(populations.highestNamedMajor, 24);
 });


### PR DESCRIPTION
## Summary

Both directions of the `engines.node` check printed the same figure beside their verdicts:

```
admits no version rejected by any of 452 dependency declaration(s).
excludes no version that all 452 dependency declaration(s) accept.
```

`452` decided neither. The probe set is 52 versions; the declared range admits **8** and excludes **44**. So one verdict rested on 8 points, the other on 44, and the number offered as the scope of both counted a different thing — declarations, not probes.

This code was written to satisfy the rule that a verdict must print its scope. It printed *a* number, in a sentence that reads as a denominator. A wrong denominator is worse than a missing one: absence prompts the question, and a plausible figure closes it.

## After

```
admits no version rejected by any dependency, over the 8 probe version(s) it admits.
excludes no version that every dependency accepts, over the 44 probe version(s) it excludes.
scope: both directions checked over 52 probe version(s) (8 admitted, 44 excluded)
       drawn from 452 dependency declaration(s).
not evidence: all 452 declaration(s) are unbounded above, so past Node 24 "every
       dependency accepts it" is true by construction. 0 probe version(s) sit there…
```

## A direction that fires without consulting evidence

All 452 installed declarations accept Node 9999. Past the highest major any dependency names, "every dependency accepts it" is unanimous *by construction*, so the over-restrictive direction reports whatever the declared range excludes with the tree contributing nothing — it restates the range's own upper bound rather than testing it. The mirror is this repository's case: `>=22.22.1 <23 || >=24` is open above 24, so it has **0** probe versions there and the clean verdict is guaranteed rather than earned.

Either way the upper end of an `engines.node` range is unfalsifiable from `engines` data. Only running it is evidence — which is why the one marked CI job that executes Node 24 outweighs any number of probe points.

## Correctness fix

`highestNamedMajor` matched only full `x.y.z` triples, so `18 || 20 || >=22` — the canonical form for declaring LTS support — appeared to name no majors. That put the line below what the tree states, and since the notice claims everything past the line is not evidence, understating it over-claims.

## Testing

- [x] 51 tests, **11/11 mutants killed**
- [x] `format:check`, `eslint --max-warnings 0`, `type-check`, all 12 repo gates green

Three mutants survived a first pass and each was a real gap: the notice **text** was untested (every test read the computation, none read the sentence — so reverting the interpolation stayed green); `Math.max` was undiscriminated because every fixture listed literals in ascending order; and asserting only that the partition *sums* passed a fixture that splits 7/7. The first draft of the unfalsifiability reasoning was also backwards, and a fixture returning 3 where I had asserted a literal `0` — a value transplanted from the real tree — is what corrected it.

## Issues

Closes #4266