### PR TITLE
chore(tools): scan the executed surface for mutable upstream refs

### DIFF
--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -8001,6 +8001,106 @@ declaring support across LTS majors — appeared to name nothing. That put the l
 lower than the tree states, and since the notice claims everything past the line
 is not evidence, understating it over-claims.
 
+## A truthful scope line over the wrong population
+
+`tools/check-upstream-refs.mjs` printed `Scope: ref immutability only, read from the
+text of tracked markdown`. That sentence was accurate. The population it described
+was wrong, and the single most consequential reference in the repository sat outside
+it: the `DEFAULT_INDEX` constant in `config/engineering/citations/check-citations.mjs`,
+which resolves the engineering repo's `principles/index.json` from a branch. The
+`eng:citations` gate validates every `ENG-*` ID against that file, so the set of IDs
+this repository considers valid can change with no diff here at all.
+
+Printing scope was the remedy adopted after an earlier finding, and it worked as
+designed -- it tells a reader what was counted. It does not, and cannot, tell a reader
+whether what was counted is what should have been. Those are different questions and
+only the first has a mechanical answer.
+
+**It was missed for two independent reasons, either alone sufficient.** The file list
+was `git ls-files -- docs *.md`, so a `.mjs` file was never opened; and the extraction
+regex matched `github.com/.../blob/...` only, so a `raw.githubusercontent.com` URL was
+invisible even in a file that _was_ scanned. Fixing either one alone would have left
+the ref hidden while producing a diff that looked like the fix. This is the second
+time in this adoption that a defect had more causes than the first correct-looking
+explanation accounted for.
+
+The second cause also under-counted within the tool's own stated scope: one
+`raw.githubusercontent.com` link in this very guide was never counted, so the prose
+baseline moves 22 -> 23 with no new reference added.
+
+### Consequence is an axis, not a detail
+
+The two populations are reported apart and ratcheted apart:
+
+| Population             | Count | If a ref here is mutable                                       |
+| ---------------------- | ----- | -------------------------------------------------------------- |
+| Tracked markdown       | 23    | A reader opens a document newer than the sentence citing it.   |
+| Tracked executed files | 1     | A gate returns a different verdict tomorrow for the same tree. |
+
+A single baseline covering both would have put one number on two consequences, and the
+23 would have swamped the 1 -- the finding would have been arithmetically present and
+practically invisible. Population and consequence are independent axes; the four axes
+of scope recorded earlier in this guide (which files, which point in time, which
+direction, which duration) did not include it.
+
+### Fixtures are a source file's code fences
+
+A test asserting that `main` classifies as mutable has to contain a mutable ref. Scanning
+test files would report those assertions as the defect they assert about -- the same
+shape as a fenced block in prose. They are excluded, and **the exclusion is counted and
+printed**, because an exclusion nobody can see is indistinguishable from a population
+that had nothing in it.
+
+The first implementation of that exclusion matched `.test.{js,ts}` and not `.test.tsx`,
+so 259 React test files were scanned as executed code while the tool printed a fixture
+count claiming they were not. The verdict was unaffected -- those files contain no
+cross-repo refs today -- so no run would ever have revealed it. A unit test did. This is
+the case for testing a printed number that no verdict depends on: the number is the only
+part a human reads.
+
+### A ratchet whose tests are written in terms of itself
+
+Mutation testing found one survivor that no amount of additional assertion would have
+caught: raising `EXECUTED_BASELINE` from 1 to 9 passed the entire suite, because every
+baseline test was phrased as `EXECUTED_BASELINE + 1`. The fixtures moved with the
+constant. A ratchet expressed relative to its own setting cannot detect the setting
+being loosened -- the baselines are now asserted as literals.
+
+Three further survivors were all on the **failing** branch: the suite contained no case
+in which the gate fails, so a program that could only ever return green passed it. The
+verdict logic was extracted from `main()` into an exported `verdict()` for that reason.
+Related: a mutation run whose unmutated baseline is not verified green first reports a
+perfect score, because every mutant dies of the same syntax error. That happened here
+and produced a spurious `10/12` before the guard was added.
+
+### The remaining reference, and why it is recorded rather than pinned
+
+The one executed mutable ref is real but has not fired. Fetching `principles/index.json`
+at `v0.134.0`, at `v0.145.0`, and at `main` yields **66 IDs each, with 0 IDs, 0 titles
+and 0 paths differing**. The checker also fails _closed_: an unreachable index exits 2
+rather than passing vacuously.
+
+Pinning it via `--index` in `tools/run-citations-check.mjs` is the fix, and upstream's
+own `docs/adopting.md` documents that recipe. It is deliberately **not** done in this
+change, because a pin creates a staleness surface and `eng:vendor:check` covers only the
+vendored checker, not the index it reads. Trading a measured-zero-drift hazard for an
+ungated staleness hazard is not obviously an improvement, and this adoption has already
+shipped one silent-staleness defect. Pin and staleness gate should land together.
+
+### Two figures reported to the engineering session were wrong
+
+Both concerned this repository and were relayed upstream as facts about it:
+
+- ESLint is **10.6.0** here (declared `^10.6.0`), not `10.8.1`.
+- "601 `.tsx` files load zero React or a11y rules" is false. `eslint --print-config` on
+  `apps/web/src/App.tsx` reports **82 active rules**, including **10 `react-hooks` rules**
+  enabled earlier in this adoption. The true zeros are `jsx-a11y` (0) and `react/` (0);
+  the 601 file count is correct.
+
+The pattern is the one already recorded here in the other direction: a figure that
+crosses a repository boundary keeps its value and loses its subject, and the subject was
+the only part that made it true.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:

--- a/tools/check-upstream-refs.mjs
+++ b/tools/check-upstream-refs.mjs
@@ -13,16 +13,57 @@
 // a check that reaches the network cannot run in the pull-request gate. The
 // two questions are reported separately and the second is reported as
 // unmeasured rather than assumed.
+//
+// The first version of this file scanned tracked markdown for `github.com/.../blob/`
+// links. Both halves of that were narrower than the argument above, and the
+// consequential ref sat outside both: the `DEFAULT_INDEX` constant in
+// `config/engineering/citations/check-citations.mjs`, which points at the
+// engineering repo's `principles/index.json` on a branch rather than a tag.
+//
+// It was missed twice over -- the file is not markdown, and the URL uses the
+// `raw` host rather than a `blob` one -- and either miss alone was sufficient,
+// so fixing one would have left it hidden and looked like progress. It is also
+// the only ref here whose mutability changes a *verdict* rather than a reading:
+// `eng:citations` resolves every ID against it, so the set of valid IDs can
+// change with no diff in this repository.
+//
+// This comment deliberately describes that URL instead of quoting it. Nothing
+// textual separates a ref that is fetched from one that is merely discussed, so
+// the scanner counts both -- and the first draft of this file failed its own
+// check on the paragraph explaining the check. Raising the baseline would have
+// buried the real finding next to a description of it; the fix is to keep
+// descriptions from carrying fetchable literals.
+//
+// Hence two populations, counted apart. A mutable ref in prose means a reader
+// may open a document newer than the one the sentence was written against. A
+// mutable ref in executed code means a gate can return a different answer
+// tomorrow for the same tree. Summing them would put one number on two
+// consequences.
 
 import { readFileSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 
 // Recorded, not approved. Lower it whenever the real count drops; the tool
 // prints the new floor when it can. See docs/guides/engineering-practice-adoption.md.
-export const BASELINE = 22;
+export const BASELINE = 23;
+
+// The executed surface, kept separate because a change here is a change of
+// verdict. This one should go to zero, not drift down.
+export const EXECUTED_BASELINE = 1;
+
+// The repository this check runs in. A link from finance to finance is not a
+// cross-repo authority reference, and counting it would inflate both figures
+// with links whose target moves in the same commit as the text citing it.
+export const SELF_REPO = 'finance';
 
 const BLOB =
   /https?:\/\/github\.com\/jrmoulckers\/([A-Za-z0-9._-]+)\/blob\/([^/\s)]+)\/([^)\s"'`#>]+)/g;
+
+// `raw.githubusercontent.com` is how a *program* fetches a file, so it is the
+// form that appears in executed code -- and it was the form the original regex
+// could not see. `refs/heads/` is optional in this host's path grammar.
+const RAW =
+  /https?:\/\/raw\.githubusercontent\.com\/jrmoulckers\/([A-Za-z0-9._-]+)\/(?:refs\/heads\/)?([^/\s)]+)\/([^)\s"'`#>]+)/g;
 
 /** Classify one ref string as an immutable commit SHA, a tag, or a mutable branch. */
 export function refForm(ref) {
@@ -31,22 +72,43 @@ export function refForm(ref) {
   return 'branch';
 }
 
-/** Extract every jrmoulckers cross-repo blob link from one file's text. */
-export function collectRefs(text, file = '') {
+/**
+ * True for a file whose mutable refs are deliberate.
+ *
+ * A test that asserts `main` is classified as mutable has to contain the string
+ * `main` in a ref, so scanning test files would report the assertions as the
+ * defect they assert about. Same shape as a fenced code block in prose: the
+ * text is an illustration of a reference, not a reference. Excluded here and
+ * counted in the output, because an exclusion nobody can see is a silent one.
+ */
+export function isFixtureFile(file) {
+  // `x?` matters: this repository is 601 `.tsx` files, and without it every
+  // React test file fell outside the exclusion while the tool printed a
+  // fixture count that claimed otherwise. Caught by a test, not by a run --
+  // the executed scan returned the same verdict either way, because those
+  // files happen to contain no cross-repo refs today.
+  return /(^|\/)[^/]*\.(test|spec)\.[cm]?[jt]sx?$/.test(file) || /(^|\/)__fixtures__\//.test(file);
+}
+
+/** Extract every jrmoulckers cross-repo link from one file's text. */
+export function collectRefs(text, file = '', { fenceAware = true } = {}) {
   const out = [];
   let fenced = false;
   text.split(/\r?\n/).forEach((line, i) => {
     // A link inside a fenced block is an illustration, not a reference this
     // repository follows. Counting them made the check fail on the prose that
     // documents the check -- the fix is scope, not a higher baseline.
-    if (/^\s*(```|~~~)/.test(line)) {
+    if (fenceAware && /^\s*(```|~~~)/.test(line)) {
       fenced = !fenced;
       return;
     }
     if (fenced) return;
-    BLOB.lastIndex = 0;
-    for (const [, repo, ref, path] of line.matchAll(BLOB)) {
-      out.push({ file, line: i + 1, repo, ref, path, form: refForm(ref) });
+    for (const pattern of [BLOB, RAW]) {
+      pattern.lastIndex = 0;
+      for (const [, repo, ref, path] of line.matchAll(pattern)) {
+        if (repo === SELF_REPO) continue;
+        out.push({ file, line: i + 1, repo, ref, path, form: refForm(ref) });
+      }
     }
   });
   return out;
@@ -62,9 +124,59 @@ export function census(refs) {
   return by;
 }
 
+/**
+ * Decide the outcome from two counts.
+ *
+ * Extracted because the first version of this logic lived inside `main()`,
+ * where no test could reach it: three mutants that suppressed failure entirely,
+ * or raised a baseline past the real count, all survived. Every test asserted
+ * the green verdict, so a program that could only ever return green passed the
+ * whole suite.
+ */
+export function verdict({ mutableCount, executedCount, proseFiles = 0, executedFiles = 0 }) {
+  const failures = [];
+  if (mutableCount > BASELINE) {
+    failures.push(`${mutableCount} mutable prose refs exceeds the recorded ${BASELINE}.`);
+  }
+  if (executedCount > EXECUTED_BASELINE) {
+    failures.push(
+      `${executedCount} mutable refs in executed files exceeds the recorded ${EXECUTED_BASELINE}.`,
+    );
+  }
+  // Restated on the failing branch too: the count that broke is half the
+  // picture, and a reader who sees only that half reads it as the whole.
+  const populations =
+    `Populations: ${mutableCount}/${BASELINE} prose (${proseFiles} file(s)), ` +
+    `${executedCount}/${EXECUTED_BASELINE} executed (${executedFiles} file(s)).`;
+  const lowerable = [];
+  if (mutableCount < BASELINE) lowerable.push(`Baseline can be lowered to ${mutableCount}.`);
+  if (executedCount < EXECUTED_BASELINE) {
+    lowerable.push(`Executed baseline can be lowered to ${executedCount}.`);
+  }
+  return { failures, populations, lowerable, ok: failures.length === 0 };
+}
+
 function listFiles() {
   const out = execFileSync('git', ['ls-files', '--', 'docs', '*.md'], { encoding: 'utf8' });
   return out.split('\n').filter((f) => f.endsWith('.md'));
+}
+
+/**
+ * Tracked files that are neither markdown nor fixtures: the surface where a
+ * mutable ref is fetched rather than read.
+ */
+export function listExecutedFiles(all, markdown) {
+  const seen = new Set(markdown);
+  return all.filter(
+    (f) =>
+      f &&
+      !seen.has(f) &&
+      !f.endsWith('.md') &&
+      !isFixtureFile(f) &&
+      !/\.(png|jpe?g|gif|ico|webp|svg|jar|zip|pdf|woff2?|ttf|keystore|so|dylib|dll|bin|lock)$/i.test(
+        f,
+      ),
+  );
 }
 
 function main() {
@@ -80,19 +192,60 @@ function main() {
 
   for (const r of mutable) console.log(`    ${r.file}:${r.line}  ${r.repo}@${r.ref}  ${r.path}`);
 
+  const all = execFileSync('git', ['ls-files'], { encoding: 'utf8', maxBuffer: 64e6 })
+    .split('\n')
+    .filter(Boolean);
+  const executedFiles = listExecutedFiles(all, files);
+  const fixtures = all.filter((f) => isFixtureFile(f));
+  const executedRefs = executedFiles.flatMap((f) => {
+    let text;
+    try {
+      text = readFileSync(f, 'utf8');
+    } catch {
+      return [];
+    }
+    // Not fence-aware: there is no prose convention for "this string is an
+    // illustration" in a source file, and a URL in a comment is still shipped.
+    return collectRefs(text, f, { fenceAware: false });
+  });
+  const executedMutable = executedRefs.filter((r) => r.form === 'branch');
+
+  console.log('');
+  console.log('Cross-repo references in executed files:');
+  console.log(`  non-markdown files scanned  ${executedFiles.length}`);
+  console.log(
+    `  fixture files skipped       ${fixtures.length} (their mutable refs are the assertion)`,
+  );
+  console.log(`  jrmoulckers links           ${executedRefs.length}`);
+  console.log(
+    `  on a mutable ref            ${executedMutable.length} (baseline ${EXECUTED_BASELINE})`,
+  );
+  for (const r of executedMutable) {
+    console.log(`    ${r.file}:${r.line}  ${r.repo}@${r.ref}  ${r.path}`);
+  }
+
   // Print the scope beside the verdict, including what was not measured.
   console.log('');
-  console.log('Scope: ref immutability only, read from the text of tracked markdown.');
+  console.log('Scope: ref immutability only, over tracked markdown and tracked executed');
+  console.log(`files, counted apart. Links to ${SELF_REPO} itself are excluded from both.`);
   console.log('Not measured: whether any referenced path exists upstream. That needs');
   console.log('the sibling repository and is deliberately outside this check.');
+  console.log('Not measured: whether a mutable ref has actually moved. A ref that is');
+  console.log('unpinned and currently identical prints the same as one that is pinned.');
 
-  if (mutable.length > BASELINE) {
-    console.error(`\nFAIL: ${mutable.length} mutable refs exceeds the recorded ${BASELINE}.`);
+  const v = verdict({
+    mutableCount: mutable.length,
+    executedCount: executedMutable.length,
+    proseFiles: files.length,
+    executedFiles: executedFiles.length,
+  });
+  if (!v.ok) {
+    console.error(`\nFAIL:`);
+    for (const f of v.failures) console.error(`  - ${f}`);
+    console.error(`\n${v.populations}`);
     process.exit(1);
   }
-  if (mutable.length < BASELINE) {
-    console.log(`\nBaseline can be lowered to ${mutable.length}.`);
-  }
+  if (v.lowerable.length > 0) console.log(`\n${v.lowerable.join('\n')}`);
 }
 
 if (process.argv[1] && process.argv[1].endsWith('check-upstream-refs.mjs')) main();

--- a/tools/check-upstream-refs.test.mjs
+++ b/tools/check-upstream-refs.test.mjs
@@ -1,8 +1,20 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { refForm, collectRefs, census, BASELINE } from './check-upstream-refs.mjs';
+import {
+  refForm,
+  collectRefs,
+  census,
+  isFixtureFile,
+  listExecutedFiles,
+  verdict,
+  BASELINE,
+  EXECUTED_BASELINE,
+  SELF_REPO,
+} from './check-upstream-refs.mjs';
 
 const url = (repo, ref, path) => `https://github.com/jrmoulckers/${repo}/blob/${ref}/${path}`;
+const raw = (repo, ref, path) =>
+  `https://raw.githubusercontent.com/jrmoulckers/${repo}/${ref}/${path}`;
 const SHA = '3a752c11856515a74eb204675d5d5198cac1e48e';
 
 test('a 40-character hex ref is immutable', () => {
@@ -118,4 +130,153 @@ test('the baseline is a recorded number, not a target of zero', () => {
   // A baseline of 0 would mean the ratchet had been silently reset; a baseline
   // below the count would fail the gate on unchanged input.
   assert.ok(BASELINE > 0);
+});
+
+test('a raw.githubusercontent url is a reference too', () => {
+  // The form a *program* uses. The first version of this tool matched only the
+  // `blob` host, so the one ref that changes a gate verdict was invisible.
+  const [r] = collectRefs(raw('engineering', 'main', 'principles/index.json'));
+  assert.deepEqual(
+    { repo: r.repo, ref: r.ref, path: r.path, form: r.form },
+    { repo: 'engineering', ref: 'main', path: 'principles/index.json', form: 'branch' },
+  );
+});
+
+test('a raw url with refs/heads still yields the branch name', () => {
+  const [r] = collectRefs(
+    'https://raw.githubusercontent.com/jrmoulckers/engineering/refs/heads/main/p/index.json',
+  );
+  assert.equal(r.ref, 'main');
+  assert.equal(r.path, 'p/index.json');
+});
+
+test('a raw url on a tag is immutable', () => {
+  const [r] = collectRefs(raw('engineering', 'v0.145.0', 'principles/index.json'));
+  assert.equal(r.form, 'tag');
+});
+
+test('blob and raw links on one line are both found', () => {
+  const line = `${url('a', 'main', 'x.md')} ${raw('b', 'main', 'y.json')}`;
+  assert.equal(collectRefs(line).length, 2);
+});
+
+test('a link to this repository is not a cross-repo reference', () => {
+  // finance -> finance moves in the same commit as the text citing it, so
+  // counting it inflates both populations with refs that cannot go stale.
+  assert.equal(collectRefs(url(SELF_REPO, 'main', 'LICENSE')).length, 0);
+  assert.equal(collectRefs(raw(SELF_REPO, 'main', 'LICENSE')).length, 0);
+});
+
+test('the self-repo exclusion does not swallow other repositories', () => {
+  // Survives a mutant that drops the equality and excludes everything.
+  assert.equal(collectRefs(url('engineering', 'main', 'x.md')).length, 1);
+});
+
+test('fence awareness can be turned off for source files', () => {
+  // A triple-backtick line in a .ts file is not a fence, and treating it as one
+  // would silently halve the scanned region of any file containing one.
+  const body = ['```', url('engineering', 'main', 'a.md'), '```'].join('\n');
+  assert.equal(collectRefs(body, 'x.ts', { fenceAware: false }).length, 1);
+});
+
+test('test files are fixtures because their mutable refs are the assertion', () => {
+  for (const f of [
+    'tools/check-upstream-refs.test.mjs',
+    'apps/web/src/x.test.ts',
+    'a/b.test.tsx',
+    'apps/web/src/x.spec.jsx',
+    'tools/__fixtures__/refs.mjs',
+  ]) {
+    assert.equal(isFixtureFile(f), true, f);
+  }
+});
+
+test('a source file is not a fixture merely for containing the word test', () => {
+  // Survives a mutant matching /test/ anywhere: that would exclude real code.
+  for (const f of ['tools/latest.mjs', 'src/testing.ts', 'tools/check.mjs']) {
+    assert.equal(isFixtureFile(f), false, f);
+  }
+});
+
+test('the executed surface excludes markdown, fixtures and binaries', () => {
+  const all = ['a.md', 'b.mjs', 'c.test.mjs', 'd.png', 'e.ts', 'package-lock.json'];
+  const executed = listExecutedFiles(all, ['a.md']);
+  assert.deepEqual(executed, ['b.mjs', 'e.ts', 'package-lock.json']);
+});
+
+test('the executed surface is not merely the complement of the markdown list', () => {
+  // A mutant using only `!seen.has(f)` would re-admit untracked markdown and
+  // every fixture, so the executed count would absorb the prose population.
+  const executed = listExecutedFiles(['x.md', 'y.test.mjs', 'z.mjs'], []);
+  assert.deepEqual(executed, ['z.mjs']);
+});
+
+test('the two baselines are recorded separately', () => {
+  // One number over both populations would report a reader following a stale
+  // link and a gate returning a different verdict as the same quantity.
+  assert.notEqual(BASELINE, EXECUTED_BASELINE);
+  assert.ok(EXECUTED_BASELINE >= 0);
+});
+test('a count above the prose baseline fails', () => {
+  const v = verdict({ mutableCount: BASELINE + 1, executedCount: 0 });
+  assert.equal(v.ok, false);
+  assert.equal(v.failures.length, 1);
+  assert.match(v.failures[0], /prose refs exceeds/);
+});
+
+test('a count above the executed baseline fails on its own', () => {
+  // The executed population is the consequential one; a mutant that dropped
+  // this branch left the prose ratchet green and the verdict-changing ref
+  // unguarded.
+  const v = verdict({ mutableCount: 0, executedCount: EXECUTED_BASELINE + 1 });
+  assert.equal(v.ok, false);
+  assert.equal(v.failures.length, 1);
+  assert.match(v.failures[0], /executed files exceeds/);
+});
+
+test('both populations can fail at once and are reported separately', () => {
+  const v = verdict({ mutableCount: BASELINE + 1, executedCount: EXECUTED_BASELINE + 1 });
+  assert.equal(v.failures.length, 2);
+});
+
+test('counts at the baseline pass', () => {
+  const v = verdict({ mutableCount: BASELINE, executedCount: EXECUTED_BASELINE });
+  assert.equal(v.ok, true);
+  assert.deepEqual(v.lowerable, []);
+});
+
+test('the failing branch names both populations, not just the one that broke', () => {
+  // The defect this suite could not previously see: a scope line printed only
+  // on success tells the reader nothing at the moment they have a verdict to
+  // doubt.
+  const v = verdict({
+    mutableCount: BASELINE + 1,
+    executedCount: 0,
+    proseFiles: 593,
+    executedFiles: 3615,
+  });
+  assert.match(v.populations, new RegExp(`${BASELINE + 1}/${BASELINE} prose \\(593 file`));
+  assert.match(v.populations, new RegExp(`0/${EXECUTED_BASELINE} executed \\(3615 file`));
+});
+
+test('a drop below either baseline is offered as a new floor', () => {
+  const v = verdict({ mutableCount: BASELINE - 1, executedCount: EXECUTED_BASELINE - 1 });
+  assert.equal(v.ok, true);
+  assert.equal(v.lowerable.length, 2);
+});
+test('the executed baseline is exactly one, and that one is named', () => {
+  // Written as a literal on purpose. Every other baseline test here is phrased
+  // relative to the constant (`EXECUTED_BASELINE + 1`), which means the whole
+  // suite moves when the constant moves -- a mutant raising it 1 -> 9 survived
+  // all of them. A ratchet whose tests are expressed in terms of the ratchet
+  // cannot notice the ratchet being loosened.
+  //
+  // The one permitted ref is the engineering index URL in the vendored citation
+  // checker. It should fall to 0 when that is pinned to a release tag; it must
+  // never rise.
+  assert.equal(EXECUTED_BASELINE, 1);
+});
+
+test('the prose baseline is exactly the measured count', () => {
+  assert.equal(BASELINE, 23);
 });


### PR DESCRIPTION
## Summary

`tools/check-upstream-refs.mjs` printed `Scope: ref immutability only, read from the
text of tracked markdown`. That sentence was accurate; the population it described was
wrong. The one reference in this repository whose mutability changes a **gate verdict**
sat outside it -- the `DEFAULT_INDEX` in
`config/engineering/citations/check-citations.mjs`, which resolves the engineering
repo's `principles/index.json` from a branch. `eng:citations` validates every `ENG-*` ID
against that file, so the set of IDs this repo accepts can change with no diff here.

Printing scope tells a reader what was counted. It cannot tell them whether what was
counted is what should have been.

## Two independent causes, either alone sufficient

- The file list was `git ls-files -- docs *.md`, so a `.mjs` file was never opened.
- The regex matched `github.com/.../blob/` only, so a `raw.githubusercontent.com` URL
  was invisible **even in a scanned file**.

Fixing either alone would have left the ref hidden while producing a diff that looked
like the fix. The second cause also under-counted inside the tool's own stated scope:
one raw link in `docs/guides/engineering-practice-adoption.md` was never counted, so the
prose baseline moves **22 -> 23** with no new reference added.

## Consequence is a second axis

| Population | Count | If mutable |
| --- | --- | --- |
| Tracked markdown | 23 | A reader opens a newer document than the sentence citing it. |
| Tracked executed files | 1 | A gate returns a different verdict for the same tree. |

Ratcheted separately. One baseline over both would have put a single number on two
consequences, and 23 would have swamped the 1.

## Defects found while building it

- **Fixture pattern missed `.test.tsx`** -- 259 React test files were scanned as executed
  code while the tool printed a fixture count claiming otherwise. Verdict unaffected, so
  no run would have shown it; a unit test did.
- **Three mutants survived on the failing branch** -- the suite never exercised a
  failure, so a program that could only return green passed it. `verdict()` extracted.
- **A mutant loosening `EXECUTED_BASELINE` 1 -> 9 survived** every baseline test, because
  the tests were phrased `EXECUTED_BASELINE + 1`. A ratchet expressed in terms of itself
  cannot detect itself being loosened. Baselines now asserted as literals.
- **A mutation run over a non-parsing file reported 10/12** -- every mutant died of the
  same syntax error. The run now aborts unless the unmutated suite is green first.

## Not done deliberately

The remaining executed ref is real but has not fired: `principles/index.json` at
`v0.134.0`, `v0.145.0` and `main` yields **66 IDs each, 0 IDs / 0 titles / 0 paths
differing**, and the checker fails **closed** (exit 2 on an unreachable index).

Pinning it via `--index` is the fix and upstream documents that recipe, but a pin
creates a staleness surface that `eng:vendor:check` does not cover -- it checks the
vendored checker, not the index it reads. Trading measured-zero drift for ungated
staleness is not clearly an improvement. Pin and staleness gate should land together.

## Testing

- 39 tests in this file, 315 across `tools/`, all passing
- **12/12 mutants killed**
- `format:check`, `eslint . --max-warnings 0`, `type-check` clean
- All 12 repository gates exit 0

Closes #4268