### PR TITLE
fix(tools): derive the citation rule's population from the surface it governs (#4270)

### DIFF
--- a/tools/check-ai-manifest.js
+++ b/tools/check-ai-manifest.js
@@ -597,6 +597,7 @@ function citationFindings(text, citations = CANON_CITATIONS, isLocal = () => fal
 const BACKBONE_CLAIM =
   /(sync\/lib\/|copier\.mjs|provenance\.mjs|basemerge\.mjs|lock\.mjs|jrmoulckers\/\.github)/;
 const CITATION_TEXT = /\.(?:md|js|mjs|cjs|ts|json|ya?ml|toml)$/;
+const MAX_CITATION_BYTES = 400000;
 
 /**
  * Files whose prose makes a claim about the backbone, and which are therefore subject to the
@@ -610,11 +611,17 @@ function citationCorpus() {
     const relPath = path.relative(ROOT, file).split(path.sep).join('/');
     if (!CITATION_TEXT.test(relPath) && relPath !== '.gitattributes') continue;
     let text;
+    let fd;
     try {
-      if (fs.statSync(file).size > 400000) continue;
-      text = fs.readFileSync(file, 'utf8');
+      // One descriptor serves both the size guard and the read. stat-then-read is a genuine
+      // TOCTOU race (CodeQL js/file-system-race) and the guard exists only to skip large blobs.
+      fd = fs.openSync(file, 'r');
+      if (fs.fstatSync(fd).size > MAX_CITATION_BYTES) continue;
+      text = fs.readFileSync(fd, 'utf8');
     } catch {
       continue;
+    } finally {
+      if (fd !== undefined) fs.closeSync(fd);
     }
     if (BACKBONE_CLAIM.test(text)) corpus.push({ path: relPath, text });
   }
@@ -1537,6 +1544,7 @@ module.exports = {
   validateCitationCoverage,
   BACKBONE_CLAIM,
   CITATION_TEXT,
+  MAX_CITATION_BYTES,
   COORDINATE,
   exemptionMatches,
   sourceDisclosureLines,

--- a/tools/check-ai-manifest.js
+++ b/tools/check-ai-manifest.js
@@ -539,17 +539,39 @@ const CANON_CITATIONS = [
   { file: 'sync/lib/provenance.mjs', symbol: 'inject', verifiedAt: '79faef3a' },
 ];
 
-// A bare `<file>.mjs:<line>` reference to engine source. Scoped to .mjs because this repo's own
-// files are .js/.ts and self-references are stable -- they move with the edit that moves them.
-const BARE_COORDINATE = /\b[a-z][a-z0-9-]*\.mjs:\d+/g;
+// The rule was `\b[a-z][a-z0-9-]*\.mjs:\d+`, justified as "scoped to .mjs because this repo's own
+// files are .js/.ts". That reasoning covers the ENGINE half of the backbone and none of the CANON
+// half, and canon is the half this repo actually receives. Measured against the delivered surface:
+//
+//   delivered from the backbone   81 entries
+//   extensions                    .md=57 .css=7 .ts=6 .js=6 .gitattributes .toml .kt .swift .cjs
+//   detector covered              .mjs
+//   overlap                       NONE
+//
+// So `AGENTS.md:120` or `agency.toml:14` -- a coordinate into a file this repo is SENT, and which
+// therefore moves under it without warning -- was invisible, twice over: the extension was not
+// listed, and the leading `[a-z]` also excluded every capitalised basename.
+//
+// The expected count of this rule is zero, which is what hid it. A detector that matches nothing
+// and a corpus that contains nothing print the identical clean line, and on a prohibition that
+// zero reads as compliance rather than as a question about the population (#4270).
+const COORDINATE = /\b[A-Za-z0-9_][A-Za-z0-9_./-]*\.[A-Za-z][A-Za-z0-9]{0,9}:\d+(?:-\d+)?/g;
 
-// Pure so the rule is assertable over arbitrary text rather than only over the file that
-// happens to be on disk.
-function citationFindings(text, citations = CANON_CITATIONS) {
+/**
+ * Report coordinate citations of files this repository does not contain.
+ *
+ * @param {string} text Prose to inspect.
+ * @param {object[]} citations Registry rows to validate.
+ * @param {(p: string) => boolean} isLocal True when the cited path exists here. A self-reference
+ *   moves with the edit that moves it, so only cross-repo coordinates decay unnoticed.
+ * @returns {string[]} Findings; empty when no coordinate cites another repository.
+ */
+function citationFindings(text, citations = CANON_CITATIONS, isLocal = () => false) {
   const findings = [];
-  for (const match of text.match(BARE_COORDINATE) || []) {
+  for (const match of text.match(COORDINATE) || []) {
+    if (isLocal(match.split(':')[0].replace(/^\.\//, ''))) continue;
     findings.push(
-      `cites engine source by line number, which decays unnoticed: ${match} — ` +
+      `cites another repository by line number, which decays unnoticed: ${match} — ` +
         `name the symbol and register it in CANON_CITATIONS instead`,
     );
   }
@@ -564,6 +586,60 @@ function citationFindings(text, citations = CANON_CITATIONS) {
   return findings;
 }
 
+// The pattern was one narrowing; the CORPUS was the other, and it was the larger one. The rule
+// was applied to exactly one file -- `tools/check-ai-manifest.js`, named as a literal inside a
+// test. Measured across tracked prose: 72 files make claims about the backbone engine or repo,
+// so the rule observed 1 of 72, about 1.4%, while reporting a clean result for all of it.
+//
+// So the population is DERIVED from the same property that makes a file subject to the rule --
+// mentioning the backbone -- rather than written down beside it. A file that starts citing the
+// backbone tomorrow is scanned tomorrow, with nothing to update (#4270).
+const BACKBONE_CLAIM =
+  /(sync\/lib\/|copier\.mjs|provenance\.mjs|basemerge\.mjs|lock\.mjs|jrmoulckers\/\.github)/;
+const CITATION_TEXT = /\.(?:md|js|mjs|cjs|ts|json|ya?ml|toml)$/;
+
+/**
+ * Files whose prose makes a claim about the backbone, and which are therefore subject to the
+ * coordinate rule. Derived by walking, so the population cannot drift from the rule.
+ *
+ * @returns {{path: string, text: string}[]} Claimant files with their contents.
+ */
+function citationCorpus() {
+  const corpus = [];
+  for (const file of walkFiles(ROOT)) {
+    const relPath = path.relative(ROOT, file).split(path.sep).join('/');
+    if (!CITATION_TEXT.test(relPath) && relPath !== '.gitattributes') continue;
+    let text;
+    try {
+      if (fs.statSync(file).size > 400000) continue;
+      text = fs.readFileSync(file, 'utf8');
+    } catch {
+      continue;
+    }
+    if (BACKBONE_CLAIM.test(text)) corpus.push({ path: relPath, text });
+  }
+  return corpus;
+}
+
+/**
+ * Apply the coordinate rule across every claimant file, and state the population it covered.
+ *
+ * @param {{path: string, text: string}[]} corpus Claimant files.
+ * @param {(p: string) => boolean} isLocal True when a cited path exists in this repository.
+ * @returns {{findings: string[], scanned: number}} Findings, and how many files were read.
+ */
+function citationCoverage(corpus, isLocal) {
+  const findings = [];
+  for (const { path: relPath, text } of corpus) {
+    for (const finding of citationFindings(text, CANON_CITATIONS, isLocal)) {
+      if (finding.startsWith('cites another repository')) findings.push(`${relPath}: ${finding}`);
+    }
+  }
+  // A zero here is only meaningful beside the number of files it was computed from. Emitted by
+  // the caller unconditionally, for the same reason the enforcement mode is (#4233).
+  return { findings, scanned: corpus.length };
+}
+
 // A green "AI Manifest Check" in the PR list does NOT mean drift is absent. The drift step runs
 // with STRICT: '0', so it prints findings and exits 0; only the digest rule tests block. The
 // workflow says so plainly in its own comments -- but the reader deciding whether to merge sees
@@ -576,6 +652,20 @@ function citationFindings(text, citations = CANON_CITATIONS) {
 const ENFORCEMENT_WORKFLOW = '.github/workflows/ai-manifest-check.yml';
 const ENFORCEMENT_STEP = 'Check for drift';
 const SYNC_LOCK = '.studio-sync.lock.json';
+
+/**
+ * Run the coordinate rule over every claimant file, resolving locality against the walk.
+ *
+ * @returns {{findings: string[], scanned: number}} Findings and the population they came from.
+ */
+function validateCitationCoverage() {
+  const present = new Set(
+    walkFiles(ROOT).map((file) => path.relative(ROOT, file).split(path.sep).join('/')),
+  );
+  const byBase = new Set([...present].map((relPath) => relPath.split('/').pop()));
+  const isLocal = (cited) => present.has(cited) || byBase.has(cited.split('/').pop());
+  return citationCoverage(citationCorpus(), isLocal);
+}
 
 /**
  * Determine whether the drift step blocks, by reading the workflow rather than believing prose.
@@ -1281,6 +1371,15 @@ function main() {
     `CI drift enforcement (${ENFORCEMENT_WORKFLOW}): ${readEnforcementMode()}\n\n`,
   );
 
+  // The coordinate rule's verdict is a zero by design, so it is printed WITH its population.
+  // A detector matching nothing and a corpus containing nothing print the same clean line; only
+  // the count of files scanned distinguishes them (#4270).
+  const citations = validateCitationCoverage();
+  process.stdout.write(
+    `Cross-repo citations: ${citations.findings.length} coordinate(s) in ` +
+      `${citations.scanned} file(s) making backbone claims\n\n`,
+  );
+
   const scan = scanDocs(counts);
   const countFindings = scan.claims;
   const driftedCounts = countFindings.filter((finding) => finding.drift);
@@ -1291,6 +1390,7 @@ function main() {
     ...validateSyncLock(),
     ...validateEnforcementDoc(),
     ...validateTriggerCoverage(),
+    ...citations.findings,
   ];
   for (const doc of scan.missing) process.stdout.write(`- ${doc}: not found\n`);
   // Printed unconditionally, in both the passing and the failing branch. The old report emitted
@@ -1432,7 +1532,12 @@ module.exports = {
   EXPECTED_AGENTS,
   MANAGED_COUNTS,
   citationFindings,
-  BARE_COORDINATE,
+  citationCorpus,
+  citationCoverage,
+  validateCitationCoverage,
+  BACKBONE_CLAIM,
+  CITATION_TEXT,
+  COORDINATE,
   exemptionMatches,
   sourceDisclosureLines,
 };

--- a/tools/check-ai-manifest.test.mjs
+++ b/tools/check-ai-manifest.test.mjs
@@ -51,6 +51,7 @@ const {
   validateCitationCoverage,
   BACKBONE_CLAIM,
   CITATION_TEXT,
+  MAX_CITATION_BYTES,
   exemptionMatches,
   sourceDisclosureLines,
   DOC_FILES,
@@ -1190,15 +1191,18 @@ test('the scanned population is derived from the surface, not narrowed to a samp
     .filter(Boolean);
   const expected = tracked.filter((relPath) => {
     if (!CITATION_TEXT.test(relPath) && relPath !== '.gitattributes') return false;
-    const abs = path.join(ROOT, relPath);
-    let stat;
+    // Same single-descriptor discipline as the production walk: stat-then-read is a TOCTOU race.
+    let fd;
     try {
-      stat = fs.statSync(abs);
+      fd = fs.openSync(path.join(ROOT, relPath), 'r');
+      const stat = fs.fstatSync(fd);
+      if (!stat.isFile() || stat.size > MAX_CITATION_BYTES) return false;
+      return BACKBONE_CLAIM.test(fs.readFileSync(fd, 'utf8'));
     } catch {
       return false;
+    } finally {
+      if (fd !== undefined) fs.closeSync(fd);
     }
-    if (!stat.isFile() || stat.size > 400000) return false;
-    return BACKBONE_CLAIM.test(fs.readFileSync(abs, 'utf8'));
   });
   const scanned = new Set(citationCorpus().map((entry) => entry.path));
   assert.ok(expected.length > 5, 'PREMISE: git sees a non-trivial claimant population');
@@ -1211,7 +1215,7 @@ test('a constructed cross-repo coordinate reaches the report, not just the funct
   // Constructs the state the guard exists for, rather than asserting the premise inline. This
   // pins the whole chain at once: derivation, pattern, locality, the disclosure count, and the
   // wiring into the activation findings -- each of which is silent against the healthy tree.
-  const probe = path.join(ROOT, 'PROBE-4271.md');
+  const probe = path.join(ROOT, 'PROBE-4270.md');
   fs.writeFileSync(probe, `The engine at ${at('sync/lib/copier.mjs', 410)} does the hashing.\n`);
   try {
     let out;
@@ -1221,7 +1225,7 @@ test('a constructed cross-repo coordinate reaches the report, not just the funct
       out = String(error.stdout || '');
     }
     assert.match(out, /Cross-repo citations: 1 coordinate\(s\) in \d+ file\(s\)/);
-    assert.match(out, /\[DRIFT\] PROBE-4271\.md: cites another repository by line number/);
+    assert.match(out, /\[DRIFT\] PROBE-4270\.md: cites another repository by line number/);
   } finally {
     fs.unlinkSync(probe);
   }

--- a/tools/check-ai-manifest.test.mjs
+++ b/tools/check-ai-manifest.test.mjs
@@ -47,6 +47,10 @@ const {
   EXPECTED_AGENTS,
   MANAGED_COUNTS,
   citationFindings,
+  citationCorpus,
+  validateCitationCoverage,
+  BACKBONE_CLAIM,
+  CITATION_TEXT,
   exemptionMatches,
   sourceDisclosureLines,
   DOC_FILES,
@@ -530,10 +534,13 @@ test('the disclosure names every path and never collapses to a count', () => {
 // described needs the network at check time (#4141, owner-gated). What is checkable offline is
 // that no citation reverts to a coordinate and that every registered row is complete.
 
-test('this file cites engine symbols, never engine line numbers', () => {
-  const source = fs.readFileSync(path.join(ROOT, 'tools', 'check-ai-manifest.js'), 'utf8');
+test('no tracked file cites another repository by line number', () => {
+  // Was: this one file. The rule now runs over every file that makes a backbone claim, with
+  // locality resolved against the walk, so a self-reference is exempt and a cross-repo
+  // coordinate is not (#4270).
+  const { findings } = validateCitationCoverage();
   assert.deepEqual(
-    citationFindings(source),
+    findings,
     [],
     'a line number in another repo decays silently; cite the symbol instead',
   );
@@ -542,9 +549,13 @@ test('this file cites engine symbols, never engine line numbers', () => {
 test('the coordinate rule catches a citation, including in its own historical record', () => {
   // PREMISE: the pattern must actually fire, or the test above passes vacuously over a rule
   // that matches nothing -- the failure mode this whole exchange keeps producing.
-  const findings = citationFindings('see lock.mjs:57 for the hashing rule');
+  // The needle is ASSEMBLED rather than written, so this control is not itself a violation once
+  // the rule scans every claimant file. The alternative was exempting this file by name, which
+  // would have put the rule's own corpus back under a hand-written list (#4270).
+  const needle = `lock.mjs:${57}`;
+  const findings = citationFindings(`see ${needle} for the hashing rule`);
   assert.equal(findings.length, 1, 'the rule must fire on a bare coordinate');
-  assert.ok(findings[0].includes('lock.mjs:57'), 'the finding must name the offending citation');
+  assert.ok(findings[0].includes(needle), 'the finding must name the offending citation');
   // And the SHA-pinned form the registry uses must NOT fire, because a measurement fixed at a
   // commit does not decay. This is the distinction the fix rests on, so it is asserted.
   assert.deepEqual(
@@ -1124,4 +1135,100 @@ test('every classified extension starts with a dot, which is why the first opera
       `${extension} is not dot-led; the dead operand is now live`,
     );
   }
+});
+
+// --- #4270: a prohibition whose expected answer is zero cannot report its own blindness ------
+//
+// The coordinate rule had two independent narrowings, and a clean zero from both:
+//
+//   pattern   /\b[a-z][a-z0-9-]*\.mjs:\d+/   vs. 81 delivered entries -- overlap NONE
+//   corpus    1 file, named as a literal here  vs. 72 files making backbone claims -- 1.4%
+//
+// Live violations found after widening both: ZERO. So the corpus was never stale and there is
+// nothing to correct. That is luck, not hygiene: the instrument that would have said otherwise
+// was blind in two directions at once, and on a prohibition a zero reads as compliance.
+
+// Needles are ASSEMBLED, never written: this file is itself in the scanned corpus now, so a
+// literal coordinate here would be a violation of the rule these tests pin (#4270).
+const at = (file, line) => `${file}:${line}`;
+
+test('the coordinate rule sees the extensions this repo is actually sent (#4270)', () => {
+  // Every one of these is a file type the backbone DELIVERS here, so it is exactly the class
+  // that moves under this repo without warning. The old `.mjs`-only pattern matched none.
+  for (const needle of [
+    at('AGENTS.md', 120),
+    at('agency.toml', '14'),
+    at('JrmTokens.kt', '12-34'),
+    at('a/b.css', 9),
+  ]) {
+    const findings = citationFindings(`see ${needle} for the rule`);
+    assert.equal(findings.length, 1, `the rule must fire on ${needle}`);
+    assert.ok(findings[0].includes(needle), 'the finding must name the offending citation');
+  }
+  // And the SHA-pinned form still must not fire, or widening bought coverage with false alarms.
+  assert.deepEqual(citationFindings('at 79faef3a, `hashText` sits at line 68'), []);
+  assert.deepEqual(citationFindings('bumped to 1.2.3 in the manifest'), []);
+});
+
+test('a self-reference is exempt because it moves with the edit that moves it (#4270)', () => {
+  const local = (cited) => cited === 'tools/check-ai-manifest.js';
+  assert.deepEqual(
+    citationFindings(`see ${at('tools/check-ai-manifest.js', 44)}`, CANON_CITATIONS, local),
+    [],
+    'a coordinate into this repo is refactored by the same commit; it does not decay',
+  );
+  const cross = citationFindings(`see ${at('sync/lib/copier.mjs', 410)}`, CANON_CITATIONS, local);
+  assert.equal(cross.length, 1, 'a coordinate into another repository must still be reported');
+});
+
+test('the scanned population is derived from the surface, not narrowed to a sample (#4270)', () => {
+  // The one-line fix -- widen the pattern -- leaves the corpus free to shrink to anything
+  // non-empty, which is the guard shape that is indistinguishable from no guard. So the
+  // population is cross-checked against an INDEPENDENT enumeration: git's index, not the walk.
+  const tracked = execFileSync('git', ['ls-files'], { cwd: ROOT, encoding: 'utf8' })
+    .split('\n')
+    .filter(Boolean);
+  const expected = tracked.filter((relPath) => {
+    if (!CITATION_TEXT.test(relPath) && relPath !== '.gitattributes') return false;
+    const abs = path.join(ROOT, relPath);
+    let stat;
+    try {
+      stat = fs.statSync(abs);
+    } catch {
+      return false;
+    }
+    if (!stat.isFile() || stat.size > 400000) return false;
+    return BACKBONE_CLAIM.test(fs.readFileSync(abs, 'utf8'));
+  });
+  const scanned = new Set(citationCorpus().map((entry) => entry.path));
+  assert.ok(expected.length > 5, 'PREMISE: git sees a non-trivial claimant population');
+  for (const relPath of expected) {
+    assert.ok(scanned.has(relPath), `citationCorpus omits a claimant file: ${relPath}`);
+  }
+});
+
+test('a constructed cross-repo coordinate reaches the report, not just the function (#4270)', () => {
+  // Constructs the state the guard exists for, rather than asserting the premise inline. This
+  // pins the whole chain at once: derivation, pattern, locality, the disclosure count, and the
+  // wiring into the activation findings -- each of which is silent against the healthy tree.
+  const probe = path.join(ROOT, 'PROBE-4271.md');
+  fs.writeFileSync(probe, `The engine at ${at('sync/lib/copier.mjs', 410)} does the hashing.\n`);
+  try {
+    let out;
+    try {
+      out = execFileSync(process.execPath, [TOOL], { encoding: 'utf8' });
+    } catch (error) {
+      out = String(error.stdout || '');
+    }
+    assert.match(out, /Cross-repo citations: 1 coordinate\(s\) in \d+ file\(s\)/);
+    assert.match(out, /\[DRIFT\] PROBE-4271\.md: cites another repository by line number/);
+  } finally {
+    fs.unlinkSync(probe);
+  }
+  const clean = execFileSync(process.execPath, [TOOL], { encoding: 'utf8' });
+  assert.match(clean, /Cross-repo citations: 0 coordinate\(s\) in \d+ file\(s\)/);
+  assert.ok(
+    clean.indexOf('Cross-repo citations:') < clean.indexOf('Canonical runtime activation:'),
+    'the population must be stated before the verdict it qualifies',
+  );
 });


### PR DESCRIPTION
## Summary

The coordinate-citation rule (#4226) reported a clean zero while narrowed twice over, independently. Neither narrowing could show up in the result: the expected count of a prohibition is zero, and a detector that matches nothing prints the same line as a corpus that contains nothing.

Class reported by the `jrmoulckers/.github` session, which found its instruction-integrity detector disjoint from its delivery surface (653 writes, 0 covered). Run against finance it found two narrowings rather than one.

## Measured

```
pattern   /\b[a-z][a-z0-9-]*\.mjs:\d+/  vs. 81 delivered entries   overlap NONE
          delivered: .md=57 .css=7 .ts=6 .js=6 .gitattributes .toml .kt .swift .cjs
corpus    1 file, named as a literal in a test  vs. 72 claimant files   1.4%
live violations after widening both                                 0
```

The null is real. There is no stale corpus to correct — which is luck, not hygiene, since the instrument that would have said otherwise was blind in two directions at once.

## Changes

- `COORDINATE` derived from the delivered surface: any extension, capitalised basenames, `:12-34` ranges. Still silent on SHA-pinned measurements and version strings.
- `citationCorpus()` derives the population from the property that makes a file subject to the rule — mentioning the backbone — so it widens on its own with nothing to update.
- `isLocal` exempts self-references: a coordinate into this repo is refactored by the commit that moves it.
- The count is printed **with its denominator**, unconditionally: `Cross-repo citations: N coordinate(s) in M file(s) making backbone claims`.
- The rule's control needle is assembled rather than written, so the control is not itself a violation once the corpus widens — chosen over exempting this file by name, which would have put the population back under a hand-written list.

## Controls

Seven mutants, all killed by distinct failing test name, no survivors.

| | mutant | result |
|---|---|---|
| A | `COORDINATE` reverted to `.mjs`-only | 1 FAIL |
| B | leading char class narrowed to `[a-z]` | 1 FAIL |
| C | corpus narrowed to a single file | 2 FAIL |
| D | corpus narrowed to `.toml` only | 2 FAIL |
| E | `isLocal` exemption disabled | 1 FAIL |
| F | `citations.findings` unwired from `activationFindings` | 1 FAIL |
| G | disclosure count hardcoded to `0` | 1 FAIL |

C and D are the shape the backbone reported surviving inside its own fix: widening the pattern leaves the corpus free to shrink to anything non-empty, and a `size > 0` guard is indistinguishable from no guard. Killed by cross-checking the derived population against an **independent enumeration** (`git ls-files`, not the walk), and by constructing the narrowed state rather than asserting the premise inline.

E, F and G are killed by one end-to-end test that writes a probe file carrying a cross-repo coordinate and asserts the CLI reports it — pinning derivation, pattern, locality, disclosure and wiring in a single constructed state, each silent against the healthy tree.

## Disclosed instrument error

An earlier scan reported 550 cross-repo hits. That was a weak on-disk resolver. Re-run resolving both full path and basename against `git ls-files`, the real number was 2, both fixtures inside the test file.

## Issues

Closes #4270

## Testing

- [x] `node --test tools/check-ai-manifest.test.mjs` — 69 pass, 0 fail (was 65)
- [x] `npx eslint tools/check-ai-manifest.js tools/check-ai-manifest.test.mjs --max-warnings 0` — exit 0
- [x] `npx prettier --check` on both files — clean
- [x] `node tools/check-ai-manifest.js` — exit 0, `Cross-repo citations: 0 coordinate(s) in 72 file(s)`

## Scope

`tools/check-ai-manifest.js` and its test only. No workflow, no lock, no vendored token file, no `packages/design-tokens`.