### PR TITLE
chore(tools): report episode shape in workflow pin history

### DIFF
--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -8101,6 +8101,85 @@ The pattern is the one already recorded here in the other direction: a figure th
 crosses a repository boundary keeps its value and loses its subject, and the subject was
 the only part that made it true.
 
+## A duration is silent about shape
+
+The workflow pin history reported 89 non-compliant commits of 209 (42.6%), then --
+after an earlier finding that a count cannot distinguish seven minutes from four days
+-- 62d 19h of 160d 6h (39.2%). Both figures are correct and both are silent about the
+same thing.
+
+**finance has three non-compliant episodes, not 89.** Five state transitions, and one
+episode holding 83% of all exposure:
+
+| Episode                  | Duration   | Share of exposure |
+| ------------------------ | ---------- | ----------------- |
+| 2026-03-05 -> 2026-03-08 | 2d 10h     | 3.8%              |
+| 2026-06-10 -> 2026-06-16 | 6d 0h      | 9.6%              |
+| 2026-06-17 -> 2026-08-09 | **52d 6h** | **83.2%**         |
+
+Ninety regressions and three episodes have opposite implications for the decision the
+number is consulted for -- whether a gate is warranted, or whether one already worked --
+and neither the count nor the duration separates them. The episode count does.
+
+This was reported to the engineering session as "89 scattered across 209". The word
+_scattered_ was a claim about shape, made by an instrument that measured only count and
+time. It was wrong: the distribution is the opposite of scattered. Nothing in the
+existing output would have contradicted it, which is the whole problem -- **an
+instrument may only accuse in the vocabulary it actually measured**, and _scattered_ was
+not in its vocabulary.
+
+The compliant streak is now printed for a related reason: a low transition count invites
+"the practice stuck", and finance's streak is 4d 0h against a 52d lapse. The tool also
+states what it cannot see -- whether a streak reflects enforcement or habit. Here it is
+enforcement (`workflow:security:check` gates every pull request), but the tool has no
+way to know that and does not infer it.
+
+### Two latent regex defects, one masking the other
+
+Reconciling a scratch probe against the shipped tool produced a one-commit disagreement
+-- 90 against 89 -- and both programs turned out to be wrong:
+
+- The probe over-matched **`statuses: read`**, because `statuses:` ends in the literal
+  `uses:` and the pattern had no word boundary.
+- The shipped tool had the _same_ missing boundary, and was protected from it only
+  because it also required an `@`. That requirement was itself a defect: a `uses:` with
+  no ref at all resolves to the action's default branch and is the **most** unpinned form
+  there is, and the tool could not report it at any severity.
+
+Neither defect had ever produced a wrong answer, because each was masking the other.
+There are 0 real ref-less `uses:` entries in this repository's history, so closing both
+changes no count -- 89 and 62d 19h are unchanged after the fix, which is the evidence
+that the fix was to the instrument and not to the verdict.
+
+### Dead code is dead relative to the checks around it
+
+This file already carried a note that the `./` guard for local reusable workflows was
+removed after mutation testing showed nothing failed without it. That finding was sound:
+those paths carry no `@`, so the old pattern skipped them anyway.
+
+Counting a missing `@` **revived the guard**. There are 8 local reusable calls at HEAD,
+and without the exclusion every one would now be reported as an unpinned action. A
+mutation result is evidence about the suite and the surrounding logic _as they stood_,
+not a permanent property of the line -- so a later change in strictness can turn dead
+code live again, and nothing re-runs the old reasoning to notice.
+
+### The same illustration-versus-test failure, twice in one function
+
+The new boundary was first written `[\s-]`, to admit the `- uses:` form, with a test
+that looked like it covered the dash. Mutation testing removed the `-` and the test
+still passed: there is always a space between the dash and the keyword, so `\s` had been
+doing the work. That is precisely the failure the file already documents about the `./`
+guard, recurring in the same function two revisions later. The test now says explicitly
+what it does _not_ establish.
+
+### A retracted probe's figures survived in prose
+
+Both numbers in this section's first draft came from the over-matching probe -- "ninety
+non-compliant commits" and "86% of all exposure" -- and stayed in the tool's own
+docstring and printed output after the probe had been retracted and its defect
+identified. The summary is the artifact with no checker; that has been recorded here
+before, and it recurred inside the change that recorded it.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:

--- a/tools/check-workflow-pin-history.mjs
+++ b/tools/check-workflow-pin-history.mjs
@@ -17,7 +17,21 @@
 import { execFileSync } from 'node:child_process';
 
 const SHA_RE = /^[0-9a-f]{40}$/;
-const USES_RE = /uses:\s*['"]?([^\s'"@]+)@([^\s'"#]+)/;
+// The `(?:^|\s)` boundary is load-bearing: `statuses: read` ends in `uses:`
+// and matched a boundary-free pattern. It never produced a wrong answer here,
+// because an earlier form of this regex also required an `@` and that line has
+// none -- one latent defect was masking another. A scratch probe written
+// without the `@` requirement reported 90 dirty commits against this tool's 89,
+// and the extra commit was a `permissions:` block.
+//
+// The boundary was first written `[\s-]`, to admit the `- uses:` form at the
+// start of a YAML step, with a test that appeared to cover it. Mutation testing
+// removed the `-` and the test still passed: there is always a space between
+// the dash and the keyword, so `\s` had been doing the work all along. Exactly
+// the failure recorded below about the `./` guard, in the same function, two
+// revisions apart -- an assertion written to illustrate a token rather than to
+// test it.
+const USES_RE = /(?:^|\s)uses:\s*['"]?([^\s'"#]+)/;
 
 /**
  * Extract unpinned `uses:` refs from raw workflow text.
@@ -28,12 +42,21 @@ const USES_RE = /uses:\s*['"]?([^\s'"@]+)@([^\s'"#]+)/;
  * passes -- an instrument defect pointing in the accusatory direction, which is
  * the one direction an instrument must not fail in.
  *
- * Local reusable workflows (`uses: ./.github/workflows/x.yml`) need no
- * exclusion: they carry no `@ref`, so the pattern never matches them. An
- * explicit `startsWith('./')` guard was removed after mutation testing showed
- * it could be deleted without failing anything -- the test that appeared to
- * cover it was passing because the fixture had no `@` either, not because the
- * guard did any work.
+ * A `uses:` with no `@ref` at all is the *most* unpinned form there is -- it
+ * resolves to the action's default branch -- and an earlier version of this
+ * function could not report it, because the pattern required an `@` in order to
+ * match. There are 0 such entries in this repository's history, so the gap was
+ * latent rather than live, and no count changes by closing it.
+ *
+ * Closing it revives a guard that mutation testing had correctly called dead.
+ * The `./` exclusion for local reusable workflows was removed once, on the
+ * sound finding that nothing failed without it: those paths carry no `@`, so
+ * the old pattern skipped them anyway. Now that a missing `@` is itself a
+ * finding, the guard does real work again -- there are 8 such calls at HEAD,
+ * and without it every one would be reported as an unpinned action. Dead code
+ * is only dead relative to the strictness of the checks around it, and a
+ * mutation result is evidence about the suite as it stood, not a permanent
+ * property of the line.
  *
  * @param {string} text Raw lines containing candidate `uses:` entries.
  * @returns {Set<string>} Distinct `action@ref` strings that are not SHA-pinned.
@@ -44,7 +67,15 @@ export function unpinnedRefs(text) {
     if (/^\s*#/.test(line)) continue;
     const match = line.match(USES_RE);
     if (!match) continue;
-    const [, action, ref] = match;
+    const target = match[1];
+    if (target.startsWith('./') || target.startsWith('docker://')) continue;
+    const at = target.indexOf('@');
+    if (at === -1) {
+      found.add(`${target}@<no ref>`);
+      continue;
+    }
+    const action = target.slice(0, at);
+    const ref = target.slice(at + 1);
     if (!SHA_RE.test(ref)) found.add(`${action}@${ref}`);
   }
   return found;
@@ -109,8 +140,18 @@ export function censusHistory(
   }
 
   const { dirtySeconds, spanSeconds } = exposure(states, nowSeconds);
+  const shape = episodes(states, nowSeconds);
 
-  return { examined: commits.length, dirty, refs, lastDirty, headClean, dirtySeconds, spanSeconds };
+  return {
+    examined: commits.length,
+    dirty,
+    refs,
+    lastDirty,
+    headClean,
+    dirtySeconds,
+    spanSeconds,
+    shape,
+  };
 }
 
 /**
@@ -138,6 +179,77 @@ export function exposure(states, nowSeconds) {
 }
 
 /**
+ * Split a state series into contiguous non-compliant episodes.
+ *
+ * A count is complete over commits and silent about duration; a duration is
+ * complete over time and silent about *shape*. Eighty-nine non-compliant commits
+ * may be eighty-nine independent regressions or three episodes nobody noticed,
+ * and those have opposite implications for the decision the number is consulted
+ * for -- whether a gate is warranted, or whether one already worked.
+ *
+ * This repository reads as "89 of 209" and is in fact **three** episodes, one of
+ * which holds 83% of all exposure. The scattered reading was asserted in a
+ * report before it was measured; nothing in the count supported it either way.
+ * Both figures in this paragraph were briefly wrong here too -- 90 and 86% --
+ * carried in from a scratch probe that over-matched `statuses: read`, and left
+ * in the prose after the probe itself had been retracted.
+ *
+ * @param {{at: number, bad: boolean}[]} states Newest first.
+ * @param {number} nowSeconds
+ * @returns {{episodes: {from: number, to: number, seconds: number}[], transitions: number,
+ *   bornCompliant: boolean, currentStreakSeconds: number, longestSeconds: number}}
+ */
+export function episodes(states, nowSeconds) {
+  if (states.length === 0) {
+    return {
+      episodes: [],
+      transitions: 0,
+      bornCompliant: true,
+      currentStreakSeconds: 0,
+      longestSeconds: 0,
+    };
+  }
+  const found = [];
+  let open = null;
+  // Walk oldest -> newest so an episode is built forward in time.
+  for (let i = states.length - 1; i >= 0; i -= 1) {
+    const until = i === 0 ? nowSeconds : states[i - 1].at;
+    if (states[i].bad) {
+      if (open) open.to = until;
+      else open = { from: states[i].at, to: until };
+    } else if (open) {
+      found.push(open);
+      open = null;
+    }
+  }
+  if (open) found.push(open);
+  for (const e of found) e.seconds = Math.max(0, e.to - e.from);
+
+  let transitions = 0;
+  for (let i = states.length - 1; i > 0; i -= 1) {
+    if (states[i].bad !== states[i - 1].bad) transitions += 1;
+  }
+
+  // How long the branch has been clean, counted back from now. A single
+  // transition invites "the practice stuck"; the streak is what says whether
+  // there is enough elapsed time for that reading to mean anything.
+  let streakFrom = nowSeconds;
+  for (const s of states) {
+    if (s.bad) break;
+    streakFrom = s.at;
+  }
+  const currentStreakSeconds = states[0].bad ? 0 : Math.max(0, nowSeconds - streakFrom);
+
+  return {
+    episodes: found,
+    transitions,
+    bornCompliant: !states[states.length - 1].bad,
+    currentStreakSeconds,
+    longestSeconds: found.reduce((m, e) => Math.max(m, e.seconds), 0),
+  };
+}
+
+/**
  * Render a duration in whole days and hours, so a report never implies a
  * precision it does not have.
  *
@@ -157,10 +269,8 @@ function main() {
   const git = (args) =>
     execFileSync('git', args, { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
 
-  const { examined, dirty, refs, lastDirty, headClean, dirtySeconds, spanSeconds } = censusHistory(
-    git,
-    ref,
-  );
+  const { examined, dirty, refs, lastDirty, headClean, dirtySeconds, spanSeconds, shape } =
+    censusHistory(git, ref);
 
   if (examined === 0) {
     console.log(`No commits touching .github/workflows found on ${ref}.`);
@@ -177,6 +287,21 @@ function main() {
     `  time in a non-compliant state ${humanDuration(dirtySeconds)} of ${humanDuration(spanSeconds)} (${timePercent}%)`,
   );
   console.log(`  working tree at ${ref}      ${headClean ? 'clean' : 'UNPINNED REFS PRESENT'}`);
+  console.log(`  non-compliant episodes      ${shape.episodes.length}`);
+  console.log(`  state transitions           ${shape.transitions}`);
+  console.log(`  born compliant              ${shape.bornCompliant ? 'yes' : 'no'}`);
+  if (shape.episodes.length > 0 && dirtySeconds > 0) {
+    const share = ((shape.longestSeconds / dirtySeconds) * 100).toFixed(1);
+    console.log(
+      `  longest episode             ${humanDuration(shape.longestSeconds)} (${share}% of all exposure)`,
+    );
+    for (const e of shape.episodes) {
+      const from = new Date(e.from * 1000).toISOString().slice(0, 10);
+      const to = new Date(e.to * 1000).toISOString().slice(0, 10);
+      console.log(`    ${from} -> ${to}  ${humanDuration(e.seconds)}`);
+    }
+  }
+  console.log(`  current compliant streak    ${humanDuration(shape.currentStreakSeconds)}`);
   if (lastDirty) {
     console.log(`  most recent occurrence      ${lastDirty.sha} ${lastDirty.date}`);
     console.log(`    ${lastDirty.refs.slice(0, 4).join(', ')}`);
@@ -190,6 +315,18 @@ function main() {
   console.log('the same seven lapses may be seven minutes or four days of exposure. The');
   console.log('time figures close that gap, and are measured against wall-clock now, so');
   console.log('the final interval grows until the next commit touching this directory.');
+  console.log('');
+  console.log('A duration is in turn silent about shape. Eighty-nine non-compliant');
+  console.log('commits may be eighty-nine regressions or three episodes, and only the');
+  console.log('separates "we keep regressing" from "we fixed it once" -- which is the');
+  console.log('question a reader is actually asking when they consult this number.');
+  console.log('');
+  console.log('The compliant streak is reported because a low transition count invites');
+  console.log('"the practice stuck", and a streak shorter than the lapse it followed');
+  console.log('cannot support that reading. Not measured: whether the streak reflects');
+  console.log('enforcement or habit. Here it is enforcement -- workflow:security:check');
+  console.log('gates every pull request -- but this tool cannot see that and does not');
+  console.log('infer it.');
 }
 
 if (process.argv[1] && process.argv[1].endsWith('check-workflow-pin-history.mjs')) {

--- a/tools/check-workflow-pin-history.test.mjs
+++ b/tools/check-workflow-pin-history.test.mjs
@@ -8,6 +8,7 @@ import {
   exposure,
   humanDuration,
   unpinnedRefs,
+  episodes,
 } from './check-workflow-pin-history.mjs';
 
 const SHA = 'a'.repeat(40);
@@ -275,4 +276,132 @@ test('a commit declaring no actions holds a clean state rather than vanishing', 
   assert.equal(result.dirty, 1);
   assert.equal(result.dirtySeconds, DAY, 'the unmatched commit ended the exposure');
   assert.equal(result.spanSeconds, 2 * DAY);
+});
+
+// --- shape: episodes, transitions, streak -----------------------------------
+
+const S = (...pairs) => pairs.map(([at, bad]) => ({ at, bad }));
+
+test('a permissions key ending in uses: is not a step', () => {
+  // `statuses: read` ends with the literal `uses:`. A boundary-free pattern
+  // matched it; a scratch probe without the `@` requirement then reported 90
+  // dirty commits against this tool's 89, and the extra one was this line.
+  assert.equal(unpinnedRefs('  statuses: read').size, 0);
+  assert.equal(unpinnedRefs('  statuses: read@v1').size, 0);
+});
+
+test('a uses: with no ref at all is the most unpinned form there is', () => {
+  // Resolves to the action's default branch. The earlier pattern required an
+  // `@` in order to match, so it could not report this at any severity.
+  assert.deepEqual(
+    [...unpinnedRefs('      uses: actions/checkout')],
+    ['actions/checkout@<no ref>'],
+  );
+});
+
+test('a local reusable workflow is not an unpinned action', () => {
+  // Load-bearing again. This guard was correctly removed once -- nothing failed
+  // without it, because the old pattern needed an `@` these paths do not have.
+  // Counting a missing `@` revived it: there are 8 such calls at HEAD.
+  assert.equal(unpinnedRefs('      uses: ./.github/workflows/reusable-detect-changes.yml').size, 0);
+  assert.equal(unpinnedRefs('      uses: docker://alpine').size, 0);
+});
+
+test('a list-item uses: is still a step', () => {
+  // The boundary must admit the `- uses:` form at the start of a YAML step.
+  // Note what this does NOT establish: the dash. A first version of the pattern
+  // put `-` in the boundary character class for this case, and mutation testing
+  // removed it without failing here -- the space after the dash was matching.
+  assert.deepEqual([...unpinnedRefs('    - uses: actions/checkout@v4')], ['actions/checkout@v4']);
+  assert.deepEqual([...unpinnedRefs('- uses: actions/checkout@v4')], ['actions/checkout@v4']);
+});
+
+test('a sha-pinned action is still clean under the new pattern', () => {
+  const sha = 'a'.repeat(40);
+  assert.equal(unpinnedRefs(`      uses: actions/checkout@${sha}`).size, 0);
+});
+
+test('three lapses in a row are one episode, not three', () => {
+  // The whole point: contiguity, not count.
+  const states = S([400, false], [300, true], [200, true], [100, true]);
+  const r = episodes(states, 500);
+  assert.equal(r.episodes.length, 1);
+});
+
+test('lapses separated by a clean commit are separate episodes', () => {
+  const states = S([500, false], [400, true], [300, false], [200, true]);
+  const r = episodes(states, 600);
+  assert.equal(r.episodes.length, 2);
+});
+
+test('an episode spans from its first bad commit to the next clean one', () => {
+  const states = S([500, false], [400, true], [300, true]);
+  const [e] = episodes(states, 600).episodes;
+  assert.equal(e.from, 300);
+  assert.equal(e.to, 500);
+  assert.equal(e.seconds, 200);
+});
+
+test('an episode still open at HEAD runs to now, not to the last commit', () => {
+  // Otherwise a currently-broken branch reports its exposure as ending when it
+  // was last touched, which is the flattering direction.
+  const states = S([400, true], [300, false]);
+  const [e] = episodes(states, 1000).episodes;
+  assert.equal(e.to, 1000);
+});
+
+test('transitions count edges, not bad commits', () => {
+  // Three bad commits in a row is one transition in and one out.
+  const states = S([500, false], [400, true], [300, true], [200, true], [100, false]);
+  assert.equal(episodes(states, 600).transitions, 2);
+});
+
+test('a branch that was never clean has no transitions and one episode', () => {
+  const states = S([300, true], [200, true], [100, true]);
+  const r = episodes(states, 400);
+  assert.equal(r.transitions, 0);
+  assert.equal(r.episodes.length, 1);
+  assert.equal(r.bornCompliant, false);
+});
+
+test('born compliant reads the oldest commit, not the newest', () => {
+  // Survives a mutant reading states[0]: the newest commit here is clean and
+  // the oldest is not, so an index error inverts the answer.
+  assert.equal(episodes(S([300, false], [200, true], [100, true]), 400).bornCompliant, false);
+  assert.equal(episodes(S([300, true], [200, false], [100, false]), 400).bornCompliant, true);
+});
+
+test('the compliant streak measures back from now to the first clean commit', () => {
+  const r = episodes(S([300, false], [250, false], [200, true]), 400);
+  assert.equal(r.currentStreakSeconds, 400 - 250);
+});
+
+test('a branch dirty at HEAD has no compliant streak', () => {
+  // Not "a very short streak" -- zero. Reporting the gap since the last commit
+  // as a streak would credit a broken branch for the time it stayed broken.
+  assert.equal(episodes(S([300, true], [200, false]), 400).currentStreakSeconds, 0);
+});
+
+test('the longest episode is the maximum, not the most recent', () => {
+  // Survives a mutant taking the last element: the fixture is ordered so the
+  // newest episode is the shorter one.
+  const states = S([900, false], [850, true], [800, false], [400, true], [100, false]);
+  const r = episodes(states, 1000);
+  assert.equal(r.longestSeconds, 400);
+});
+
+test('an empty history has no shape rather than a zero-length one', () => {
+  const r = episodes([], 100);
+  assert.deepEqual(r.episodes, []);
+  assert.equal(r.transitions, 0);
+  assert.equal(r.bornCompliant, true);
+});
+
+test('episode seconds sum to the exposure measured independently', () => {
+  // Cross-check between the two functions. Asymmetric on purpose: an even
+  // split would pass a mutant that duplicated one half.
+  const states = S([1000, false], [900, true], [700, false], [400, true], [100, false]);
+  const total = episodes(states, 1100).episodes.reduce((s, e) => s + e.seconds, 0);
+  assert.equal(total, exposure(states, 1100).dirtySeconds);
+  assert.equal(total, 400);
 });


### PR DESCRIPTION
## Summary

An earlier change established that a **count** of non-compliant commits is silent about
**duration**. This one establishes that a duration is silent about **shape**.

finance reports 89 non-compliant commits of 209 (42.6%) and 62d 19h of 160d 6h (39.2%).
Both correct. Neither says this:

| Episode | Duration | Share of exposure |
| --- | --- | --- |
| 2026-03-05 → 2026-03-08 | 2d 10h | 3.8% |
| 2026-06-10 → 2026-06-16 | 6d 0h | 9.6% |
| 2026-06-17 → 2026-08-09 | **52d 6h** | **83.2%** |

**Three episodes, five transitions** — not 89 regressions. Those imply opposite answers
to the question the number is consulted for: *is a gate warranted*, or *did one already
work*.

I reported this repository to a sibling session as "**89 scattered** across 209".
*Scattered* was a claim about shape made by an instrument that measured only count and
time, and the distribution is the opposite of scattered. An instrument may only accuse
in the vocabulary it actually measured.

## Also reported

- **Compliant streak** — a low transition count invites "the practice stuck"; finance's
  streak is **4d 0h against a 52d lapse**.
- **What it cannot see** — whether a streak reflects enforcement or habit. Here it is
  enforcement (`workflow:security:check` gates every PR), but the tool has no way to
  know and does not infer it.

## Two latent regex defects, each masking the other

Reconciling a scratch probe against the shipped tool gave 90 vs 89. Both were wrong:

- The probe over-matched **`statuses: read`** — `statuses:` ends in the literal `uses:`
  and the pattern had no word boundary.
- The shipped tool had the **same** missing boundary, and was shielded only because it
  also required an `@`. That requirement was itself a defect: a `uses:` with **no ref at
  all** resolves to the action's default branch — the most unpinned form there is — and
  could not be reported at any severity.

Zero real occurrences of either in 209 commits, so **89 and 62d 19h are unchanged** after
the fix. That is the evidence the fix was to the instrument and not to the verdict.

## Dead code is dead relative to the checks around it

This file already documented that the `./` guard for local reusable workflows was
removed after mutation testing showed nothing failed without it. Sound at the time —
those paths carry no `@`, so the old pattern skipped them.

Counting a missing `@` **revived it**: there are 8 local reusable calls at HEAD, and
without the guard every one would now be reported as unpinned. A mutation result is
evidence about the suite *as it stood*, not a permanent property of the line.

## The same illustration-vs-test failure, twice in one function

The new boundary was written `[\s-]` to admit `- uses:`, with a test that looked like it
covered the dash. Mutation testing removed the `-` and the test still passed — there is
always a space after the dash, so `\s` was doing the work. Precisely the failure this
file already records about the `./` guard, two revisions later. The test now states what
it does *not* establish.

## And a retracted probe's figures survived in prose

"Ninety" and "86%" came from the over-matching probe and remained in the tool's docstring
and printed output after the probe was retracted. Caught before merge. The summary is the
artifact with no checker — recorded here previously, and it recurred inside the change
recording it.

## Testing

- 45 tests in this file, **332 across `tools/`**, all passing
- **12/12 mutants killed** (one survivor fixed: the dead `-` in the boundary)
- `format:check`, `eslint . --max-warnings 0`, `type-check` clean
- All 12 repository gates exit 0

Closes #4272