### PR TITLE
feat(tools): verify markdown anchors and publish link specificity

### DIFF
--- a/docs/ai/workflow-metrics.md
+++ b/docs/ai/workflow-metrics.md
@@ -106,7 +106,7 @@ Metrics are NOT used to evaluate individual agent "performance." They measure sy
 
 **Target:** < 5%
 
-**Why it matters:** Avoidable CI failures waste time and indicate agents are skipping the pre-push checklist. Directly related to [PP-0002](pain-points.md#pp-0002-agents-skip-npm-run-cicheck-before-pushing).
+**Why it matters:** Avoidable CI failures waste time and indicate agents are skipping the pre-push checklist. Directly related to [PP-0002](pain-points.md#pp-0002-agents-skip-pre-push-workflow-before-pushing).
 
 ---
 

--- a/docs/design/ios-dynamic-type-reflow-audit.md
+++ b/docs/design/ios-dynamic-type-reflow-audit.md
@@ -192,7 +192,7 @@ and the income/expense icon. Verify the reflowed layouts under Increase
 Contrast, Smart Invert, and Bold Text. This aligns with
 [Accessibility Patterns §5 Color & Contrast](./accessibility-patterns.md#5-color--contrast)
 and the larger-target guidance in
-[Cognitive Accessibility Mode](./cognitive-accessibility.md#7-touch-target-requirements).
+[Cognitive Accessibility Mode](./cognitive-accessibility.md#touch-target-requirements).
 
 ## 9. Privacy — balance hiding under reflow
 

--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -8180,6 +8180,73 @@ docstring and printed output after the probe had been retracted and its defect
 identified. The summary is the artifact with no checker; that has been recorded here
 before, and it recurred inside the change that recorded it.
 
+## Specificity is a property of the claim, not of the instrument
+
+A sibling session retracted its own claim that content moving between files -- while both
+paths stay valid -- is unreachable by any checker. An **anchor** check sees a subset of it:
+when the citing link names a section, renaming that heading breaks the fragment.
+
+That retraction exposes an axis distinct from the three used elsewhere in this guide. _Which
+files_, _which point in time_, and _which direction_ are all scope of **measurement**. This
+one is scope of the **claim**, and it sits upstream of all of them: a link naming only a file
+asserts "this file is relevant", which almost no content change falsifies. No improvement to
+any instrument reaches an assertion that vague -- the only fix is to write a more specific
+link.
+
+Measured over finance:
+
+|                                        | count | share     |
+| -------------------------------------- | ----- | --------- |
+| relative `.md` links                   | 3353  |           |
+| naming only a file                     | 3095  | **92.3%** |
+| naming a section                       | 246   | 7.3%      |
+| pointing at a file that does not exist | 12    | 0.4%      |
+
+finance is materially less specific than the sibling repository (92.3% fragmentless against
+81%), and before this change the 7.3% that was checkable-in-principle was checked by nothing.
+Three anchors were stale, each the exact case the sibling had called invisible:
+
+1. A heading renamed (`npm run ci:check` dropped from a pain-point title).
+2. A document dropping its section numbering.
+3. `docs/legal/ccpa-notice.md` pointing at `privacy-policy.md#10-data-retention` after
+   retention moved to section 8. Section 10 still exists -- it is now "Your privacy rights" --
+   so the link is not obviously wrong to a reader skimming the source, and a CCPA notice
+   directing someone to the wrong section of a privacy policy is the one instance here with
+   consequences outside the repository.
+
+### The instrument was wrong three times before the documents were wrong once
+
+The probe reported **95** stale anchors, then **6**, then **3**. Both corrections were to the
+slugger, not to the docs:
+
+- **`\s+` against `\s`.** GitHub replaces each space individually, so removing an em dash
+  leaves the two spaces around it and renders a _double_ hyphen. Collapsing runs mis-slugged
+  **89** valid links. This surfaced only because the first case checked by hand was linked
+  from its own target file's table of contents -- the target was asserting the anchor that the
+  probe called stale.
+- **U+FE0F.** GitHub strips a warning-sign glyph from a heading but keeps the variation
+  selector, so the real anchor begins with an invisible character. Stripping it cost a
+  further **3**.
+
+96.8% of the first number was instrument error. The general form is worth recording: **an
+anchor checker is exactly as good as its slugger's agreement with the renderer, and a wrong
+slugger does not look wrong.** It emits real file paths and plausible anchors, and every entry
+survives a skim. Both cases are now pinned by tests and killed as mutants, because neither is
+recoverable by reading the code.
+
+### What the check now prints
+
+`tools/check-doc-links.mjs` verifies anchors and prints the specificity split on both the
+passing and the failing path. The split is published deliberately: a green result that does
+not state that 92.3% of links assert nothing checkable reads as "the documentation is
+verified", which is a stronger claim than the evidence supports. `STALE_ANCHOR_BASELINE` is
+empty and asserted in tests as a literal rather than as its own length -- a ratchet phrased in
+terms of itself moves when the constant moves.
+
+Both failure axes are reported before the process exits, rather than the first one found.
+Failing on broken paths alone would let them mask every stale anchor; the reader would repoint
+the paths, see green, and conclude the anchors had been checked all along.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:

--- a/docs/legal/ccpa-notice.md
+++ b/docs/legal/ccpa-notice.md
@@ -144,7 +144,7 @@ We keep personal information only for as long as reasonably necessary for the pu
 | Optional analytics and crash reporting  | Collected only if you opt in; retention depends on the specific feature or provider; **final schedule: [TBD before publication]**                                      |
 | Web storage and browser caches          | May remain until cleared by you, the browser, or the app, subject to technical limits                                                                                  |
 
-For more detail, see [Data Retention](./privacy-policy.md#10-data-retention) in the main Privacy Policy.
+For more detail, see [Data Retention](./privacy-policy.md#8-data-retention) in the main Privacy Policy.
 
 ## 13. Contact for California Requests
 

--- a/tools/check-doc-links.mjs
+++ b/tools/check-doc-links.mjs
@@ -8,8 +8,13 @@
  * so the filter matches nothing here and every relative link is verified by nothing.
  *
  * A moved file leaves the citing document syntactically intact, so nothing in a lint or
- * format pass notices. This check closes that gap for existence only; see the scope lines
- * it prints for what it deliberately does not measure.
+ * format pass notices. This check closes that gap for existence, and for the one further
+ * case a link can express: when the link names a section, that the section still exists.
+ *
+ * The second case bounds itself. Only 7.3% of this repository's relative links name a
+ * section at all; the rest assert no more than "this file is relevant", which almost no
+ * content change falsifies. That limit is a property of the citing sentences, not of this
+ * check, so the specificity split is printed rather than left implicit -- see `scopeLines`.
  *
  * Cites ENG-OBS-004.
  */
@@ -20,6 +25,18 @@ import path from 'node:path';
 const LINK = /\[[^\]]*\]\(([^)\s]+)\)/g;
 const FENCE = /^\s*(?:```|~~~)/;
 const INLINE_CODE = /`[^`]*`/g;
+
+/**
+ * Stale anchors this repository accepts. Empty, and it should stay that way: unlike
+ * `UNRESOLVED_BASELINE`, a stale anchor is never a gap awaiting a document that does not
+ * exist yet -- the target file is present and simply no longer has the heading. Every such
+ * link is repointable now, so there is nothing to grandfather.
+ *
+ * Asserted in tests as a literal rather than as `STALE_ANCHOR_BASELINE.length`: a ratchet
+ * phrased in terms of itself moves when the constant moves and cannot detect being
+ * loosened.
+ */
+export const STALE_ANCHOR_BASELINE = [];
 
 /**
  * Targets that name a document this repository has never contained. Each is a real gap in
@@ -38,6 +55,50 @@ export const UNRESOLVED_BASELINE = [
   'docs/business/marketing/marketing-plan-sprints-6-10.md -> review-strategy.md',
   'docs/guides/release-process.md -> ../audits/accessibility-checklist.md',
 ];
+
+/**
+ * Slugify a heading the way GitHub's renderer does.
+ *
+ * Two details here are not cosmetic; each one, alone, produced a confident list of false
+ * positives when this was first measured:
+ *
+ * 1. Spaces are replaced **one for one**, not collapsed. Removing punctuation leaves the
+ *    surrounding spaces behind, so `Android distribution -- Google Play` renders an anchor
+ *    with a *double* hyphen. A `\s+` collapse mis-slugged 89 valid links as stale.
+ * 2. U+FE0F (variation selector) survives. GitHub strips the warning sign from a heading
+ *    beginning with a warning emoji but keeps the selector, so the real anchor begins with
+ *    an invisible character. Stripping it mis-slugged a further 3.
+ *
+ * 96.8% of the first reported stale count was this function disagreeing with the renderer,
+ * and nothing about a wrong slugger looks wrong -- it names real files and plausible
+ * anchors. Both cases are covered by tests for that reason.
+ *
+ * @param {string} heading
+ * @returns {string}
+ */
+export function slugify(heading) {
+  return String(heading)
+    .toLowerCase()
+    .replace(/[^\w\s\uFE0F-]/g, '')
+    .trim()
+    .replace(/\s/g, '-');
+}
+
+/**
+ * Every anchor a document offers: one per heading, outside fenced blocks.
+ *
+ * @param {string} text
+ * @returns {Set<string>}
+ */
+export function headingSlugs(text) {
+  const slugs = new Set();
+  for (const { line, fenced } of markFences(text)) {
+    if (fenced) continue;
+    const match = line.match(/^#{1,6}\s+(.*?)\s*$/);
+    if (match) slugs.add(slugify(match[1]));
+  }
+  return slugs;
+}
 
 /**
  * Split a document into lines, marking which are inside a fenced code block.
@@ -67,7 +128,7 @@ export function markFences(text) {
  * Collect relative markdown-file links from one document.
  *
  * @param {string} text
- * @returns {{ links: {href: string, target: string, line: number}[], skipped: number }}
+ * @returns {{ links: {href: string, target: string, fragment: string, line: number}[], skipped: number }}
  */
 export function collectLinks(text) {
   const links = [];
@@ -79,13 +140,15 @@ export function collectLinks(text) {
     for (const match of line.matchAll(LINK)) {
       const href = match[1];
       if (/^(?:[a-z][a-z0-9+.-]*:|#|\/\/)/i.test(href)) continue;
-      const target = href.split('#')[0].trim();
+      const hash = href.indexOf('#');
+      const target = (hash === -1 ? href : href.slice(0, hash)).trim();
       if (!target.endsWith('.md')) continue;
       if (marked[i].fenced) {
         skipped += 1;
         continue;
       }
-      links.push({ href, target, line: i + 1 });
+      const fragment = hash === -1 ? '' : href.slice(hash + 1).trim();
+      links.push({ href, target, fragment, line: i + 1 });
     }
   }
   return { links, skipped };
@@ -97,13 +160,22 @@ export function collectLinks(text) {
  * @param {(args: string[]) => string} git
  * @param {(p: string) => boolean} exists
  * @param {(p: string) => string} read
- * @returns {{files: number, total: number, fenced: number, broken: string[]}}
+ * @returns {{files: number, total: number, fenced: number, broken: string[], staleAnchors: string[], fragmentless: number, checkedAnchors: number}}
  */
 export function census(git, exists, read) {
   const files = git(['ls-files', '*.md']).trim().split('\n').filter(Boolean);
   const broken = [];
+  const staleAnchors = [];
+  const anchorCache = new Map();
   let total = 0;
   let fenced = 0;
+  let fragmentless = 0;
+  let checkedAnchors = 0;
+
+  const anchorsOf = (p) => {
+    if (!anchorCache.has(p)) anchorCache.set(p, headingSlugs(read(p)));
+    return anchorCache.get(p);
+  };
 
   for (const file of files) {
     const { links, skipped } = collectLinks(read(file));
@@ -113,10 +185,30 @@ export function census(git, exists, read) {
       const resolved = path.posix.normalize(
         path.posix.join(path.posix.dirname(file.split(path.sep).join('/')), link.target),
       );
-      if (!exists(resolved)) broken.push(`${file} -> ${link.href}`);
+      if (!exists(resolved)) {
+        broken.push(`${file} -> ${link.href}`);
+        continue;
+      }
+      if (!link.fragment) {
+        fragmentless += 1;
+        continue;
+      }
+      // A link that names a section is the only kind a moved-content change can falsify,
+      // so it is the only kind worth resolving further.
+      checkedAnchors += 1;
+      let decoded = link.fragment;
+      try {
+        decoded = decodeURIComponent(link.fragment);
+      } catch {
+        // A fragment that is not valid percent-encoding is compared as written rather
+        // than reported as stale; the renderer does not decode it either.
+      }
+      if (!anchorsOf(resolved).has(slugify(decoded))) {
+        staleAnchors.push(`${file}:${link.line} -> ${link.href}`);
+      }
     }
   }
-  return { files: files.length, total, fenced, broken };
+  return { files: files.length, total, fenced, broken, staleAnchors, fragmentless, checkedAnchors };
 }
 
 /**
@@ -124,15 +216,25 @@ export function census(git, exists, read) {
  * failing path. A control that reports its population only when it passes cannot be
  * distinguished from one that measured nothing.
  *
- * @param {{files: number, total: number, fenced: number}} scope
+ * The specificity split is printed because it bounds what this check can ever find. A link
+ * naming only a file asserts "this file is relevant", and almost no content change
+ * falsifies that; a link naming a section asserts something a heading rename breaks. That
+ * is a property of the citing sentence, not of the instrument, so no improvement here
+ * reaches the majority -- the only fix is to write a more specific link. Stating the split
+ * keeps a green result from reading as "the docs are verified".
+ *
+ * @param {{files: number, total: number, fenced: number, fragmentless: number, checkedAnchors: number}} scope
  * @returns {string[]}
  */
-export function scopeLines({ files, total, fenced }) {
+export function scopeLines({ files, total, fenced, fragmentless, checkedAnchors }) {
+  const share = total === 0 ? '0.0' : ((100 * fragmentless) / total).toFixed(1);
+  const unresolved = total - fragmentless - checkedAnchors;
   return [
     `Scope: ${total} relative markdown link(s) across ${files} tracked file(s); ${fenced} inside fenced blocks were skipped.`,
-    'Not measured: URL targets, anchor fragments, links to non-markdown files, or whether',
-    'a target still contains the content the citing text claims. A file that keeps its name',
-    'while its content moves elsewhere stays green here and is wrong.',
+    `Specificity: ${fragmentless} link(s) name only a file (${share}%); ${checkedAnchors} name a section and had their anchor resolved; ${unresolved} point at a file that does not exist and were not classified.`,
+    'Not measured: URL targets, links to non-markdown files, or whether a target still',
+    'contains the content the citing text claims. A file that keeps its name while its',
+    'content moves elsewhere stays green here unless the link named the section that moved.',
   ];
 }
 
@@ -143,7 +245,11 @@ function main() {
   const exists = (p) => fs.existsSync(path.join(root, p));
   const read = (p) => fs.readFileSync(path.join(root, p), 'utf8');
 
-  const { files, total, fenced, broken } = census(git, exists, read);
+  const { files, total, fenced, broken, staleAnchors, fragmentless, checkedAnchors } = census(
+    git,
+    exists,
+    read,
+  );
   const baseline = new Set(UNRESOLVED_BASELINE);
   const unexpected = broken.filter((b) => !baseline.has(b));
   const fixed = [...baseline].filter((b) => !broken.includes(b));
@@ -151,15 +257,36 @@ function main() {
   // them are linked from two places. Printing one as the other would report twelve
   // gaps against a nine-entry list and invite exactly the wrong correction.
   const distinctBroken = new Set(broken).size;
+  const scope = { files, total, fenced, fragmentless, checkedAnchors };
+  // Both axes are reported before exiting. Failing on the first one found would let a
+  // broken path mask every stale anchor, and the reader would fix the paths, see green,
+  // and conclude the anchors had been checked all along.
+  let failed = false;
 
   if (unexpected.length > 0) {
+    failed = true;
     console.error(`${unexpected.length} broken relative markdown link(s):`);
     for (const b of unexpected) console.error(`  ${b}`);
     console.error('');
     console.error('A moved or renamed file leaves the citing document syntactically intact,');
     console.error('so nothing in a lint or format pass notices. Repoint or remove the link.');
     console.error('');
-    for (const line of scopeLines({ files, total, fenced })) console.error(line);
+  }
+
+  const unexpectedAnchors = staleAnchors.filter((a) => !STALE_ANCHOR_BASELINE.includes(a));
+  if (unexpectedAnchors.length > 0) {
+    failed = true;
+    console.error(`${unexpectedAnchors.length} stale anchor(s):`);
+    for (const a of unexpectedAnchors) console.error(`  ${a}`);
+    console.error('');
+    console.error('The target file exists and the link is syntactically intact, but no heading');
+    console.error('in it produces this anchor. The section was renamed, renumbered, or moved;');
+    console.error('a reader following the link lands at the top of the document instead.');
+    console.error('');
+  }
+
+  if (failed) {
+    for (const line of scopeLines(scope)) console.error(line);
     console.error(
       `${broken.length} broken occurrence(s) over ${distinctBroken} distinct target(s); ${baseline.size - fixed.length} of those targets are recorded gaps where the document does not exist.`,
     );
@@ -167,7 +294,8 @@ function main() {
   }
 
   console.log(`All resolvable relative markdown links point at files that exist.`);
-  for (const line of scopeLines({ files, total, fenced })) console.log(line);
+  console.log(`All ${checkedAnchors} section-naming link(s) resolve to a heading that exists.`);
+  for (const line of scopeLines(scope)) console.log(line);
   console.log(
     `${distinctBroken} recorded gap(s) remain across ${broken.length} link(s), where the target names a document this repository has never contained.`,
   );

--- a/tools/check-doc-links.test.mjs
+++ b/tools/check-doc-links.test.mjs
@@ -4,11 +4,14 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import {
+  STALE_ANCHOR_BASELINE,
   UNRESOLVED_BASELINE,
   census,
   collectLinks,
+  headingSlugs,
   markFences,
   scopeLines,
+  slugify,
 } from './check-doc-links.mjs';
 
 test('a relative markdown link is collected', () => {
@@ -135,7 +138,15 @@ test('census returns an empty result for a repository with no markdown', () => {
     () => false,
     () => '',
   );
-  assert.deepEqual(result, { files: 0, total: 0, fenced: 0, broken: [] });
+  assert.deepEqual(result, {
+    files: 0,
+    total: 0,
+    fenced: 0,
+    broken: [],
+    staleAnchors: [],
+    fragmentless: 0,
+    checkedAnchors: 0,
+  });
 });
 
 test('scopeLines states the population on any branch that prints them', () => {
@@ -162,4 +173,170 @@ test('every baseline entry is in the file -> href form the census emits', () => 
   for (const entry of UNRESOLVED_BASELINE) {
     assert.match(entry, /^[^ ]+\.md -> \S+\.md$/, `malformed baseline entry: ${entry}`);
   }
+});
+
+// --- Anchor and specificity checks (issue #4274) ---
+
+test('slugify replaces each space individually, not runs of them', () => {
+  // Removing the em dash leaves two spaces, and GitHub renders a double hyphen. A
+  // `\s+` collapse here mis-slugged 89 valid links as stale when this was measured.
+  assert.equal(
+    slugify('3.1 Android distribution \u2014 Google Play (#1242)'),
+    '31-android-distribution--google-play-1242',
+  );
+});
+
+test('slugify keeps the variation selector a heading emoji leaves behind', () => {
+  // GitHub strips the warning sign but not U+FE0F, so the real anchor begins with an
+  // invisible character. Stripping it mis-slugged a further 3 valid links.
+  assert.equal(
+    slugify('\u26A0\uFE0F MANDATORY: Pre-Push Workflow (NEVER skip)'),
+    '\uFE0F-mandatory-pre-push-workflow-never-skip',
+  );
+});
+
+test('slugify lowercases and drops punctuation', () => {
+  assert.equal(slugify('Data Retention & Deletion?'), 'data-retention--deletion');
+});
+
+test('headingSlugs collects every heading level', () => {
+  const slugs = headingSlugs('# One\n\ntext\n\n### Two Words\n');
+  assert.deepEqual([...slugs].sort(), ['one', 'two-words']);
+});
+
+test('headingSlugs ignores headings inside fenced blocks', () => {
+  const slugs = headingSlugs('# Real\n\n```\n# Fake\n```\n');
+  assert.equal(slugs.has('real'), true);
+  assert.equal(slugs.has('fake'), false);
+});
+
+test('headingSlugs ignores a hash that is not a heading', () => {
+  assert.equal(headingSlugs('#NoSpace\n').size, 0);
+});
+
+test('collectLinks exposes the fragment separately from the target', () => {
+  const { links } = collectLinks('[x](./a.md#some-section)');
+  assert.equal(links[0].target, './a.md');
+  assert.equal(links[0].fragment, 'some-section');
+});
+
+test('a link with no fragment reports an empty fragment', () => {
+  const { links } = collectLinks('[x](./a.md)');
+  assert.equal(links[0].fragment, '');
+});
+
+const anchorFixture = (docs) => {
+  const git = () => Object.keys(docs).join('\n');
+  const exists = (p) => Object.prototype.hasOwnProperty.call(docs, p);
+  const read = (p) => docs[p];
+  return census(git, exists, read);
+};
+
+test('a link naming a heading that exists is not stale', () => {
+  const out = anchorFixture({
+    'a.md': '[x](b.md#the-section)',
+    'b.md': '## The Section\n',
+  });
+  assert.deepEqual(out.staleAnchors, []);
+  assert.equal(out.checkedAnchors, 1);
+  assert.equal(out.fragmentless, 0);
+});
+
+test('a link naming a heading that does not exist is stale', () => {
+  const out = anchorFixture({
+    'a.md': '[x](b.md#renamed-away)',
+    'b.md': '## The Section\n',
+  });
+  assert.deepEqual(out.staleAnchors, ['a.md:1 -> b.md#renamed-away']);
+});
+
+test('a fragmentless link is counted as such and never resolved', () => {
+  const out = anchorFixture({ 'a.md': '[x](b.md)', 'b.md': 'no headings\n' });
+  assert.equal(out.fragmentless, 1);
+  assert.equal(out.checkedAnchors, 0);
+  assert.deepEqual(out.staleAnchors, []);
+});
+
+test('a link to a missing file is not classified as either specificity class', () => {
+  // It is already reported as broken; counting it as fragmentless would inflate the
+  // share of links that were deliberately unspecific.
+  const out = anchorFixture({ 'a.md': '[x](gone.md#s)' });
+  assert.equal(out.broken.length, 1);
+  assert.equal(out.fragmentless, 0);
+  assert.equal(out.checkedAnchors, 0);
+  assert.deepEqual(out.staleAnchors, []);
+});
+
+test('a percent-encoded fragment is decoded before comparison', () => {
+  const out = anchorFixture({
+    'a.md': '[x](b.md#caf%C3%A9-notes)',
+    'b.md': '## Caf\u00E9 Notes\n',
+  });
+  assert.deepEqual(out.staleAnchors, []);
+});
+
+test('a malformed percent-encoding is compared as written rather than throwing', () => {
+  // `decodeURIComponent('100%-done')` throws. The fallback compares the fragment as
+  // written, which here slugifies to the same anchor the heading produces. Without the
+  // catch this case does not merely misreport -- the whole census dies on one bad link.
+  let out;
+  assert.doesNotThrow(() => {
+    out = anchorFixture({ 'a.md': '[x](b.md#100%-done)', 'b.md': '## 100 done\n' });
+  });
+  assert.equal(out.checkedAnchors, 1);
+  assert.deepEqual(out.staleAnchors, []);
+});
+
+test('a malformed percent-encoding that matches nothing is still reported stale', () => {
+  const out = anchorFixture({ 'a.md': '[x](b.md#100%-done)', 'b.md': '## Other\n' });
+  assert.deepEqual(out.staleAnchors, ['a.md:1 -> b.md#100%-done']);
+});
+
+test('an anchor is resolved against the target file, not the citing one', () => {
+  // The citing document has the heading; the target does not. Reading the wrong file
+  // would call this clean.
+  const out = anchorFixture({
+    'a.md': '## The Section\n\n[x](b.md#the-section)\n',
+    'b.md': '## Something Else\n',
+  });
+  assert.equal(out.staleAnchors.length, 1);
+});
+
+test('the stale-anchor baseline is empty', () => {
+  // Asserted as a literal, not as its own length: a ratchet phrased in terms of itself
+  // moves with the constant and cannot detect being loosened.
+  assert.deepEqual(STALE_ANCHOR_BASELINE, []);
+});
+
+test('scopeLines states the specificity split on both paths', () => {
+  const lines = scopeLines({
+    files: 2,
+    total: 10,
+    fenced: 0,
+    fragmentless: 7,
+    checkedAnchors: 2,
+  });
+  const specificity = lines.find((l) => l.startsWith('Specificity:'));
+  assert.match(specificity, /7 link\(s\) name only a file \(70\.0%\)/);
+  assert.match(specificity, /2 name a section/);
+  assert.match(specificity, /1 point at a file that does not exist/);
+});
+
+test('scopeLines no longer claims anchor fragments are unmeasured', () => {
+  const text = scopeLines({
+    files: 1,
+    total: 1,
+    fenced: 0,
+    fragmentless: 1,
+    checkedAnchors: 0,
+  }).join('\n');
+  assert.equal(text.includes('anchor fragments'), false);
+});
+
+test('scopeLines does not divide by zero on an empty tree', () => {
+  const lines = scopeLines({ files: 0, total: 0, fenced: 0, fragmentless: 0, checkedAnchors: 0 });
+  assert.match(
+    lines.find((l) => l.startsWith('Specificity:')),
+    /\(0\.0%\)/,
+  );
 });


### PR DESCRIPTION
Closes #4274

## Summary

A sibling session in `jrmoulckers/engineering` retracted its own claim that content moving
between files — while both paths stay valid — is unreachable by any checker. An **anchor**
check sees the subset where the citing link named the section that moved.

That retraction exposes an axis distinct from the three this work has been using. *Which
files*, *which point in time*, and *which direction* are all scope of **measurement**. This
is scope of the **claim**, and it sits upstream of them: a link naming only a file asserts
"this file is relevant", which almost no content change falsifies. No instrument reaches an
assertion that vague — only a more specific link does.

## Measured

| | count | share |
| --- | --- | --- |
| relative `.md` links | 3353 | |
| naming only a file | 3095 | **92.3%** |
| naming a section | 246 | 7.3% |
| pointing at a file that does not exist | 12 | 0.4% |

finance is materially less specific than engineering (92.3% fragmentless against 81%), and
the 7.3% that was checkable-in-principle was checked by nothing — `check-doc-links.mjs`
discarded the fragment and said so honestly in its scope lines. The scope line was accurate;
the gap behind it had never been measured.

Three anchors were stale, each the case the sibling had called invisible:

1. `docs/ai/workflow-metrics.md` → a pain-point heading renamed.
2. `docs/design/ios-dynamic-type-reflow-audit.md` → a document that dropped section numbering.
3. `docs/legal/ccpa-notice.md` → `privacy-policy.md#10-data-retention` after retention moved
   to §8. Section 10 still exists — it is now "Your privacy rights" — so the link reads as
   plausible in source while sending a reader to the wrong section of a privacy policy. The
   one instance here with consequences outside the repository.

## The instrument was wrong three times before the documents were wrong once

The probe reported **95**, then **6**, then **3**. Both corrections were mine:

- **`\s+` vs `\s`** — GitHub replaces each space individually, so a removed em dash leaves
  a **double** hyphen. Collapsing runs mis-slugged **89** valid links. Caught only because
  the first case checked by hand was linked from its own target file's table of contents:
  the target was asserting the anchor the probe called stale.
- **U+FE0F** — GitHub strips the warning glyph but keeps the variation selector, so the real
  anchor begins with an invisible character. Cost a further **3**.

96.8% of the first number was instrument error. **An anchor checker is exactly as good as
its slugger's agreement with the renderer, and a wrong slugger does not look wrong** — it
emits real paths and plausible anchors that survive a skim. Both cases are pinned by tests
and killed as mutants.

## Changes

- Repoint the three stale anchors.
- Add `slugify()` and `headingSlugs()`; resolve fragments against the **target** file.
- Print the specificity split on both the passing and failing path, so a green run does not
  read as "the documentation is verified" — a stronger claim than the evidence supports.
- Report both failure axes before exiting. Failing on broken paths alone would let them mask
  every stale anchor; the reader would repoint paths, see green, and conclude anchors had
  been checked all along.
- `STALE_ANCHOR_BASELINE` is empty and asserted as a **literal**, not as its own length.

## Testing

- [x] `node --test tools/check-doc-links.test.mjs` — 40/40
- [x] `node --test "tools/**/*.test.mjs"` — 356/356
- [x] 17/17 mutants killed, under a green-baseline guard
- [x] `npm run format:check`, `npx eslint . --max-warnings 0`, `npm run type-check`
- [x] all 12 gates exit 0

Cites `ENG-OBS-004`.