### PR TITLE
test(tools): assert the printed report, not just the computation

### DIFF
--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -8247,6 +8247,73 @@ Both failure axes are reported before the process exits, rather than the first o
 Failing on broken paths alone would let them mask every stale anchor; the reader would repoint
 the paths, see green, and conclude the anchors had been checked all along.
 
+## The printed sentence is the half with no assertion
+
+A sibling session generalised a defect of mine -- an interpolated count that was wrong while
+every test stayed green -- into a claim about both trees: _every scope line we have added is
+a string, and strings are the part nobody writes assertions for._ Measured across
+`tools/*.mjs`:
+
+|                                          | count | share     |
+| ---------------------------------------- | ----- | --------- |
+| printed lines total                      | 207   |           |
+| inside `main()`, unreachable by any test | 116   | **56.0%** |
+| in exported functions                    | 91    | 44.0%     |
+
+Of the 64 printed sentences in `main()` that interpolate a value, **60 have no assertion
+anywhere**. The three biggest contributors are the three most recently written tools, all
+added by this work: pin-history (36), upstream-refs (24), doc-links (22).
+
+The measurement is heuristic -- it matches literal fragments between a tool and its test file
+-- which is exactly why it is reported rather than gated. A gate over a population this
+loosely defined is the decoy pattern this guide warns about elsewhere; the census establishes
+that the population is large, and that is all it is being asked to do.
+
+### The hazard was documented in a comment and still had no test
+
+`check-doc-links.mjs` printed two verdicts carrying both an occurrence count and a
+distinct-target count, which differ here (12 and 9). A comment from an earlier fix already
+spelled out the risk of confusing them -- report twelve gaps against a nine-entry list and
+invite the wrong correction. Swapping the two interpolations left the whole suite green.
+
+The report is now an exported `reportLines()` and the sentences are asserted. Both swaps are
+killed as mutants, along with a mutant that returns early on broken paths and so masks every
+stale anchor.
+
+### Two fixture defects found while writing those tests
+
+- **The fixture encoded the wrong noun.** `distinctBroken` counts distinct `file -> href`
+  pairs, not distinct target documents, so `['a.md -> gone.md', 'b.md -> gone.md']` is _two_
+  distinct entries, not one. The test failed, and the code was right: I had reproduced the
+  wrong-noun error inside the test written to catch the wrong-noun error. The corrected
+  fixture has one file citing one missing target twice.
+- **A symmetric fixture proves nothing.** With `fixed` empty, the subtraction in
+  `${baselineSet.size - fixed.length}` is invisible and a mutant deleting it survived --
+  which it did, until a case with one fixed and one still-broken baseline entry existed.
+  Same shape as a 7/7 fixture that cannot tell "prints both halves" from "prints one half
+  twice": realistic and discriminating are independent properties.
+
+### A disclaimer and a finding have opposite safe directions
+
+From the same exchange, worth recording as a rule: when a tool marks a region as
+_unmeasured_, an error that **shrinks** that region is a false-assurance error, because
+everything outside it is implicitly asserted to have been checked. For a finding the
+conservative direction is to under-claim; for a disclaimer it is to over-claim. The two
+polarities are mirror images, and a scope line is a disclaimer.
+
+### A glob is not a footprint
+
+The sibling found a scratch file matching their cleanup glob that was not theirs, and
+retracted every prior "zero remaining" as true by timing rather than by scope. Checked here:
+the repository tree holds no `zz*` files, but `TEMP` holds three, only one of which is even
+plausibly agent scratch (`zz_ub.mjs`, not mine) -- and the other two, `ZzM3rUJ-I3BzFBQS8mYQf`
+and `ZZOyenCWeBDMeOtIncHNE`, are one-byte files with randomly generated names that match
+`zz*` **only because Windows globs are case-insensitive**.
+
+So the population of that glob is not "my scratch files" but "anything whose name happens to
+start with two z's, in any case, on a shared machine". The correct claim names the files
+created and removed, not a pattern.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:

--- a/tools/check-doc-links.mjs
+++ b/tools/check-doc-links.mjs
@@ -238,6 +238,87 @@ export function scopeLines({ files, total, fenced, fragmentless, checkedAnchors 
   ];
 }
 
+/**
+ * The full report, as lines, for a given census.
+ *
+ * This is exported rather than inlined into `main()` because the numbers here are the
+ * half that testing usually misses. Every assertion in this file's suite covered the
+ * *computation*; none read the *sentence*. A count can be correct and still be
+ * interpolated into the wrong noun, and no test over `census()` can see that.
+ *
+ * The pair below is the specific hazard. `broken` counts occurrences and the baseline
+ * names distinct targets -- three targets here are linked from two places apiece, so the
+ * two numbers genuinely differ, and printing one as the other reports twelve gaps against
+ * a nine-entry list and invites exactly the wrong correction. That confusion is old enough
+ * to have been written into a comment, and it still had no assertion until now.
+ *
+ * @param {{files: number, total: number, fenced: number, broken: string[], staleAnchors: string[], fragmentless: number, checkedAnchors: number}} result
+ * @param {{baseline?: string[], staleBaseline?: string[]}} [options]
+ * @returns {{lines: string[], failed: boolean}}
+ */
+export function reportLines(result, options = {}) {
+  const { broken, staleAnchors, checkedAnchors } = result;
+  const baseline = options.baseline ?? UNRESOLVED_BASELINE;
+  const staleBaseline = options.staleBaseline ?? STALE_ANCHOR_BASELINE;
+
+  const baselineSet = new Set(baseline);
+  const unexpected = broken.filter((b) => !baselineSet.has(b));
+  const fixed = [...baselineSet].filter((b) => !broken.includes(b));
+  const unexpectedAnchors = staleAnchors.filter((a) => !staleBaseline.includes(a));
+  const distinctBroken = new Set(broken).size;
+
+  const lines = [];
+  let failed = false;
+
+  if (unexpected.length > 0) {
+    failed = true;
+    lines.push(`${unexpected.length} broken relative markdown link(s):`);
+    for (const b of unexpected) lines.push(`  ${b}`);
+    lines.push('');
+    lines.push('A moved or renamed file leaves the citing document syntactically intact,');
+    lines.push('so nothing in a lint or format pass notices. Repoint or remove the link.');
+    lines.push('');
+  }
+
+  if (unexpectedAnchors.length > 0) {
+    failed = true;
+    lines.push(`${unexpectedAnchors.length} stale anchor(s):`);
+    for (const a of unexpectedAnchors) lines.push(`  ${a}`);
+    lines.push('');
+    lines.push('The target file exists and the link is syntactically intact, but no heading');
+    lines.push('in it produces this anchor. The section was renamed, renumbered, or moved;');
+    lines.push('a reader following the link lands at the top of the document instead.');
+    lines.push('');
+  }
+
+  // Both axes report before the verdict. Failing on the first one found would let broken
+  // paths mask every stale anchor: the reader repoints the paths, sees green, and
+  // concludes the anchors had been checked all along.
+  if (failed) {
+    lines.push(...scopeLines(result));
+    lines.push(
+      `${broken.length} broken occurrence(s) over ${distinctBroken} distinct target(s); ${baselineSet.size - fixed.length} of those targets are recorded gaps where the document does not exist.`,
+    );
+    return { lines, failed };
+  }
+
+  lines.push('All resolvable relative markdown links point at files that exist.');
+  lines.push(`All ${checkedAnchors} section-naming link(s) resolve to a heading that exists.`);
+  lines.push(...scopeLines(result));
+  lines.push(
+    `${distinctBroken} recorded gap(s) remain across ${broken.length} link(s), where the target names a document this repository has never contained.`,
+  );
+  if (fixed.length > 0) {
+    lines.push('');
+    lines.push(
+      `${fixed.length} recorded gap(s) no longer broken -- remove them from the baseline:`,
+    );
+    for (const f of fixed) lines.push(`  ${f}`);
+    return { lines, failed: true };
+  }
+  return { lines, failed: false };
+}
+
 function main() {
   const git = (args) =>
     execFileSync('git', args, { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
@@ -245,68 +326,11 @@ function main() {
   const exists = (p) => fs.existsSync(path.join(root, p));
   const read = (p) => fs.readFileSync(path.join(root, p), 'utf8');
 
-  const { files, total, fenced, broken, staleAnchors, fragmentless, checkedAnchors } = census(
-    git,
-    exists,
-    read,
-  );
-  const baseline = new Set(UNRESOLVED_BASELINE);
-  const unexpected = broken.filter((b) => !baseline.has(b));
-  const fixed = [...baseline].filter((b) => !broken.includes(b));
-  // `broken` counts occurrences; the baseline names distinct targets, and three of
-  // them are linked from two places. Printing one as the other would report twelve
-  // gaps against a nine-entry list and invite exactly the wrong correction.
-  const distinctBroken = new Set(broken).size;
-  const scope = { files, total, fenced, fragmentless, checkedAnchors };
-  // Both axes are reported before exiting. Failing on the first one found would let a
-  // broken path mask every stale anchor, and the reader would fix the paths, see green,
-  // and conclude the anchors had been checked all along.
-  let failed = false;
-
-  if (unexpected.length > 0) {
-    failed = true;
-    console.error(`${unexpected.length} broken relative markdown link(s):`);
-    for (const b of unexpected) console.error(`  ${b}`);
-    console.error('');
-    console.error('A moved or renamed file leaves the citing document syntactically intact,');
-    console.error('so nothing in a lint or format pass notices. Repoint or remove the link.');
-    console.error('');
-  }
-
-  const unexpectedAnchors = staleAnchors.filter((a) => !STALE_ANCHOR_BASELINE.includes(a));
-  if (unexpectedAnchors.length > 0) {
-    failed = true;
-    console.error(`${unexpectedAnchors.length} stale anchor(s):`);
-    for (const a of unexpectedAnchors) console.error(`  ${a}`);
-    console.error('');
-    console.error('The target file exists and the link is syntactically intact, but no heading');
-    console.error('in it produces this anchor. The section was renamed, renumbered, or moved;');
-    console.error('a reader following the link lands at the top of the document instead.');
-    console.error('');
-  }
-
-  if (failed) {
-    for (const line of scopeLines(scope)) console.error(line);
-    console.error(
-      `${broken.length} broken occurrence(s) over ${distinctBroken} distinct target(s); ${baseline.size - fixed.length} of those targets are recorded gaps where the document does not exist.`,
-    );
-    process.exit(1);
-  }
-
-  console.log(`All resolvable relative markdown links point at files that exist.`);
-  console.log(`All ${checkedAnchors} section-naming link(s) resolve to a heading that exists.`);
-  for (const line of scopeLines(scope)) console.log(line);
-  console.log(
-    `${distinctBroken} recorded gap(s) remain across ${broken.length} link(s), where the target names a document this repository has never contained.`,
-  );
-  if (fixed.length > 0) {
-    console.log('');
-    console.log(
-      `${fixed.length} recorded gap(s) no longer broken -- remove them from the baseline:`,
-    );
-    for (const f of fixed) console.log(`  ${f}`);
-    process.exit(1);
-  }
+  const result = census(git, exists, read);
+  const { lines, failed } = reportLines(result);
+  const write = failed ? console.error : console.log;
+  for (const line of lines) write(line);
+  if (failed) process.exit(1);
 }
 
 if (process.argv[1] && process.argv[1].endsWith('check-doc-links.mjs')) {

--- a/tools/check-doc-links.test.mjs
+++ b/tools/check-doc-links.test.mjs
@@ -10,6 +10,7 @@ import {
   collectLinks,
   headingSlugs,
   markFences,
+  reportLines,
   scopeLines,
   slugify,
 } from './check-doc-links.mjs';
@@ -338,5 +339,154 @@ test('scopeLines does not divide by zero on an empty tree', () => {
   assert.match(
     lines.find((l) => l.startsWith('Specificity:')),
     /\(0\.0%\)/,
+  );
+});
+
+// --- The printed report, read as a sentence (issue #4276) ---
+
+const emptyCensus = (over = {}) => ({
+  files: 1,
+  total: 0,
+  fenced: 0,
+  broken: [],
+  staleAnchors: [],
+  fragmentless: 0,
+  checkedAnchors: 0,
+  ...over,
+});
+
+test('a clean census reports success and does not fail', () => {
+  const { lines, failed } = reportLines(
+    emptyCensus({ total: 3, fragmentless: 2, checkedAnchors: 1 }),
+    {
+      baseline: [],
+      staleBaseline: [],
+    },
+  );
+  assert.equal(failed, false);
+  assert.equal(lines[0], 'All resolvable relative markdown links point at files that exist.');
+  assert.equal(lines[1], 'All 1 section-naming link(s) resolve to a heading that exists.');
+});
+
+test('occurrences and distinct targets are not interchangeable in the report', () => {
+  // Two occurrences of one target: the numbers differ, so a swap changes the text. With
+  // a fixture where they coincide, the assertion would pass either way -- the same
+  // symmetry defect that makes a 7/7 fixture unable to tell "both halves" from "one
+  // half twice".
+  // The same citing file links the same missing target twice, on two lines. That is
+  // what makes the two counts differ; two *different* citing files would be two
+  // distinct entries, which is the model this fixture originally got wrong.
+  const broken = ['a.md -> gone.md', 'a.md -> gone.md'];
+  const { lines, failed } = reportLines(emptyCensus({ broken, total: 2 }), {
+    baseline: ['a.md -> gone.md'],
+    staleBaseline: [],
+  });
+  assert.equal(failed, false);
+  const verdict = lines.at(-1);
+  assert.equal(
+    verdict,
+    '1 recorded gap(s) remain across 2 link(s), where the target names a document this repository has never contained.',
+  );
+});
+
+test('the failing verdict states occurrences before distinct targets', () => {
+  const broken = ['a.md -> gone.md', 'a.md -> gone.md', 'c.md -> other.md'];
+  const { lines, failed } = reportLines(emptyCensus({ broken, total: 3 }), {
+    baseline: ['a.md -> gone.md'],
+    staleBaseline: [],
+  });
+  assert.equal(failed, true);
+  assert.equal(
+    lines.at(-1),
+    '3 broken occurrence(s) over 2 distinct target(s); 1 of those targets are recorded gaps where the document does not exist.',
+  );
+});
+
+test('an unexpected broken link is named and counted', () => {
+  const { lines, failed } = reportLines(emptyCensus({ broken: ['a.md -> gone.md'], total: 1 }), {
+    baseline: [],
+    staleBaseline: [],
+  });
+  assert.equal(failed, true);
+  assert.equal(lines[0], '1 broken relative markdown link(s):');
+  assert.equal(lines[1], '  a.md -> gone.md');
+});
+
+test('an unexpected stale anchor is named and counted', () => {
+  const { lines, failed } = reportLines(
+    emptyCensus({ staleAnchors: ['a.md:1 -> b.md#gone'], total: 1, checkedAnchors: 1 }),
+    { baseline: [], staleBaseline: [] },
+  );
+  assert.equal(failed, true);
+  assert.equal(lines[0], '1 stale anchor(s):');
+  assert.equal(lines[1], '  a.md:1 -> b.md#gone');
+});
+
+test('broken paths do not suppress the stale-anchor section', () => {
+  // Reporting only the first failing axis would let a reader repoint paths, see green,
+  // and conclude the anchors had been checked.
+  const { lines } = reportLines(
+    emptyCensus({
+      broken: ['a.md -> gone.md'],
+      staleAnchors: ['a.md:1 -> b.md#gone'],
+      total: 2,
+      checkedAnchors: 1,
+    }),
+    { baseline: [], staleBaseline: [] },
+  );
+  const text = lines.join('\n');
+  assert.equal(text.includes('1 broken relative markdown link(s):'), true);
+  assert.equal(text.includes('1 stale anchor(s):'), true);
+});
+
+test('the scope lines appear on the failing path as well as the passing one', () => {
+  const red = reportLines(emptyCensus({ broken: ['a.md -> gone.md'], total: 1 }), {
+    baseline: [],
+    staleBaseline: [],
+  });
+  const green = reportLines(emptyCensus({ total: 1, fragmentless: 1 }), {
+    baseline: [],
+    staleBaseline: [],
+  });
+  for (const out of [red, green]) {
+    assert.equal(
+      out.lines.some((l) => l.startsWith('Specificity:')),
+      true,
+    );
+  }
+});
+
+test('a baseline entry that is no longer broken fails the run', () => {
+  const { lines, failed } = reportLines(emptyCensus({ total: 1, fragmentless: 1 }), {
+    baseline: ['a.md -> gone.md'],
+    staleBaseline: [],
+  });
+  assert.equal(failed, true);
+  assert.equal(lines.at(-1), '  a.md -> gone.md');
+  assert.equal(
+    lines.some((l) => l === '1 recorded gap(s) no longer broken -- remove them from the baseline:'),
+    true,
+  );
+});
+
+test('a stale anchor on the baseline is not reported', () => {
+  const { failed } = reportLines(emptyCensus({ staleAnchors: ['a.md:1 -> b.md#gone'] }), {
+    baseline: [],
+    staleBaseline: ['a.md:1 -> b.md#gone'],
+  });
+  assert.equal(failed, false);
+});
+test('the failing verdict discounts baseline entries that are no longer broken', () => {
+  // Without a fixed entry the subtraction is invisible, and a mutant dropping it
+  // survives -- which it did, until this case existed.
+  const broken = ['a.md -> gone.md', 'c.md -> other.md'];
+  const { lines, failed } = reportLines(emptyCensus({ broken, total: 2 }), {
+    baseline: ['a.md -> gone.md', 'b.md -> vanished.md'],
+    staleBaseline: [],
+  });
+  assert.equal(failed, true);
+  assert.equal(
+    lines.at(-1),
+    '2 broken occurrence(s) over 2 distinct target(s); 1 of those targets are recorded gaps where the document does not exist.',
   );
 });


### PR DESCRIPTION
Closes #4276

## Summary

A sibling session generalised a defect of mine — an interpolated count that was wrong while
every test stayed green — into a claim about both trees:

> every scope line we've added this week is a string, and strings are the part nobody writes
> assertions for.

That is a prediction about finance's tooling, so it was measured rather than accepted.

## Measured

| | count | share |
| --- | --- | --- |
| printed lines across `tools/*.mjs` | 207 | |
| inside `main()`, unreachable by any test | 116 | **56.0%** |
| in exported functions | 91 | 44.0% |

Narrowing to lines that interpolate a value — where a wrong noun is possible:

| | count |
| --- | --- |
| value-interpolating sentences in `main()` | 64 |
| with a literal fragment in the test file | 4 |
| **with no assertion anywhere** | **60** |

The three biggest contributors are the three most recently written tools, all added by this
work: `check-workflow-pin-history.mjs` (36), `check-upstream-refs.mjs` (24),
`check-doc-links.mjs` (22) — 82 of the 116.

The census matches literal fragments, which is a heuristic. It is good enough to show the
population is large and too loose to gate on, so this reports the census and fixes one tool
properly. A gate over a population that vague is the decoy pattern this work has flagged
elsewhere.

## The sharpest instance

`check-doc-links.mjs` printed two verdicts carrying both an occurrence count and a
distinct-target count. They genuinely differ here (**12** and **9**), and the risk of
confusing them was **already documented in a comment** from an earlier fix:

> `broken` counts occurrences; the baseline names distinct targets ... Printing one as the
> other would report twelve gaps against a nine-entry list and invite exactly the wrong
> correction.

The hazard was known, written down, and had no assertion. Swapping the two interpolations
left the entire suite green.

## Changes

- Extract the report from `main()` into an exported `reportLines(census, options)`.
- Assert both verdict sentences, with fixtures where the two counts **differ** — a fixture
  where they coincide cannot tell a correct report from one printing the same number twice.
- **Live output is byte-identical**; this is a testability change, not a behaviour change.

## Two fixture defects found while writing those tests

- **The fixture encoded the wrong noun.** `distinctBroken` counts distinct `file -> href`
  pairs, not distinct documents, so `['a.md -> gone.md', 'b.md -> gone.md']` is *two* entries.
  The test failed and the code was right: I reproduced the wrong-noun error inside the test
  written to catch the wrong-noun error.
- **A symmetric fixture proves nothing.** With `fixed` empty, the `- fixed.length`
  subtraction is invisible, and a mutant deleting it **survived** until a case with one fixed
  and one still-broken baseline entry existed.

## Testing

- [x] `node --test tools/check-doc-links.test.mjs` — 50/50
- [x] `node --test "tools/**/*.test.mjs"` — 366/366
- [x] 11/11 mutants killed under a green-baseline guard, including both interpolation swaps
      and a return-early mutant that masks stale anchors behind broken paths
- [x] `npm run format:check`, `npx eslint . --max-warnings 0`, `npm run type-check`
- [x] all 12 gates exit 0

Cites `ENG-OBS-004`.