### PR TITLE
fix(tools): derive the help text's validator list from the dispatch it advertises (#4278)

### DIFF
--- a/tools/check-ai-manifest.js
+++ b/tools/check-ai-manifest.js
@@ -86,6 +86,94 @@ const MANAGED_COUNTS = {
 // transcribed, because a hand-written number here decays exactly when the surface it describes
 // changes -- and this file is not in DOC_FILES, so the count arm it advertises never read it.
 // Correctness by construction; the test then pins that the construction is still a derivation.
+//
+// That reasoning covered the NUMBERS inside the sentence and not the sentence. The list of what
+// this tool validates was transcribed prose, and three validators added in #4233, #4251 and
+// #4270 never reached it: each shipped past a green test named for this very text, because that
+// test pins the two counts and says nothing about the capability list. Measured before the fix:
+// 7 advertised phrases, 7 validators wired into the report, 3 of them unadvertised.
+//
+// So the list is DERIVED from the same registry `main` dispatches over. The advertisement and
+// the behaviour are now one object: a validator with no row is reported, a row with no validator
+// is reported, and neither can be added silently (#4278).
+const VALIDATORS = [
+  { id: 'docCounts', label: 'filesystem count claims across the declared documents' },
+  {
+    id: 'agentRoster',
+    label:
+      `the exact ${EXPECTED_AGENTS.length}-agent activated roster, its generated provenance, ` +
+      'the sole local finance-domain agent, and retired-role absence',
+  },
+  { id: 'activationDoc', label: 'canonical runtime documentation' },
+  {
+    id: 'syncLock',
+    label:
+      `the ${MANAGED_COUNTS.total}-entry Studio sync inventory, its source reproduction, ` +
+      'and its corpus breadth',
+  },
+  { id: 'enforcementDoc', label: 'the CI drift-enforcement mode against the prose describing it' },
+  { id: 'triggerCoverage', label: "this check's own trigger coverage" },
+  { id: 'citations', label: 'cross-repo citation of another repository by line number' },
+];
+
+/**
+ * Run every wired validator and report any disagreement with what `--help` advertises.
+ *
+ * Runs the union rather than the advertised set: an unadvertised validator is a documentation
+ * defect, and dropping its findings would convert that into a silently missing check.
+ *
+ * @param {Record<string, () => string[]>} runners Validator implementations, keyed by id.
+ * @returns {{findings: string[], advertised: number, ran: number, disclosure: string}} Findings,
+ *   the two populations, and the report line stating them — emitted here rather than by the
+ *   caller so that bypassing this function loses the disclosure instead of forging it.
+ */
+function dispatchValidators(runners) {
+  const advertised = VALIDATORS.map((validator) => validator.id);
+  const wired = Object.keys(runners);
+  const findings = [];
+  for (const id of advertised) {
+    if (!wired.includes(id)) findings.push(`validator advertised by --help but never run: ${id}`);
+  }
+  for (const id of wired) {
+    if (!advertised.includes(id))
+      findings.push(`validator runs but --help never mentions it: ${id}`);
+  }
+  const ordered = [
+    ...advertised.filter((id) => wired.includes(id)),
+    ...wired.filter((id) => !advertised.includes(id)),
+  ];
+  for (const id of ordered) findings.push(...runners[id]());
+  return {
+    findings,
+    advertised: advertised.length,
+    ran: ordered.length,
+    disclosure: `Validators: ${advertised.length} advertised, ${ordered.length} run\n`,
+  };
+}
+
+/**
+ * The validators `main` actually dispatches, as a named value rather than an inline literal.
+ *
+ * This exists so the registry can be checked against an INDEPENDENT enumeration. Every test
+ * that built its expectation from `VALIDATORS` was blind to `VALIDATORS` shrinking -- deleting
+ * a row survived the whole suite at zero failures, because the population and the expectation
+ * were the same object. The runner keys come from the call site instead (#4278).
+ *
+ * @param {object} context Values the runners close over; not read until a runner is invoked.
+ * @returns {Record<string, () => string[]>} Validator implementations, keyed by id.
+ */
+function activationRunners(context) {
+  return {
+    docCounts: () => context.scan.findings,
+    agentRoster: () => validateAgentRoster(context.manifest.agents),
+    activationDoc: () => validateActivationDoc(),
+    syncLock: () => validateSyncLock(),
+    enforcementDoc: () => validateEnforcementDoc(),
+    triggerCoverage: () => validateTriggerCoverage(),
+    citations: () => context.citations.findings,
+  };
+}
+
 const HELP_TEXT = `
 AI Manifest Drift Check — Finance monorepo
 
@@ -94,9 +182,8 @@ Usage:
   node tools/check-ai-manifest.js --strict   # blocking (exit 1 on drift)
   STRICT=1 node tools/check-ai-manifest.js   # blocking (exit 1 on drift)
 
-Validates filesystem counts, the exact ${EXPECTED_AGENTS.length}-agent activated roster, generated
-provenance, the sole local finance-domain agent, retired-role absence, canonical
-runtime documentation, and the ${MANAGED_COUNTS.total}-entry Studio sync inventory.
+Validates:
+${VALIDATORS.map((validator) => `  - ${validator.label}`).join('\n')}
 `;
 
 if (args.includes('--help') || args.includes('-h')) {
@@ -1390,15 +1477,12 @@ function main() {
   const scan = scanDocs(counts);
   const countFindings = scan.claims;
   const driftedCounts = countFindings.filter((finding) => finding.drift);
-  const activationFindings = [
-    ...scan.findings,
-    ...validateAgentRoster(manifest.agents),
-    ...validateActivationDoc(),
-    ...validateSyncLock(),
-    ...validateEnforcementDoc(),
-    ...validateTriggerCoverage(),
-    ...citations.findings,
-  ];
+  const activation = dispatchValidators(activationRunners({ scan, manifest, citations }));
+  const activationFindings = activation.findings;
+  // Disclosed unconditionally for the reason the citation population is (#4270): the agreement
+  // between what runs and what is advertised is invisible while it holds, so it is stated. The
+  // line is BUILT BY the dispatch, so bypassing the dispatch loses it rather than reproducing it.
+  process.stdout.write(activation.disclosure);
   for (const doc of scan.missing) process.stdout.write(`- ${doc}: not found\n`);
   // Printed unconditionally, in both the passing and the failing branch. The old report emitted
   // the "Detected count claims:" section only when the set was non-empty, so the sole trace of a
@@ -1536,6 +1620,9 @@ module.exports = {
   triggerCovers,
   triggerFindings,
   HELP_TEXT,
+  VALIDATORS,
+  dispatchValidators,
+  activationRunners,
   EXPECTED_AGENTS,
   MANAGED_COUNTS,
   citationFindings,

--- a/tools/check-ai-manifest.test.mjs
+++ b/tools/check-ai-manifest.test.mjs
@@ -44,6 +44,9 @@ const {
   triggerFindings,
   METRICS,
   HELP_TEXT,
+  VALIDATORS,
+  dispatchValidators,
+  activationRunners,
   EXPECTED_AGENTS,
   MANAGED_COUNTS,
   citationFindings,
@@ -1235,4 +1238,84 @@ test('a constructed cross-repo coordinate reaches the report, not just the funct
     clean.indexOf('Cross-repo citations:') < clean.indexOf('Canonical runtime activation:'),
     'the population must be stated before the verdict it qualifies',
   );
+});
+
+// --- #4278: the advertisement was transcribed while the numbers inside it were derived --------
+//
+// `--help` is this tool's front door and it enumerated what the tool validates. The comment
+// above HELP_TEXT reasoned explicitly about the two COUNTS in that sentence -- interpolating
+// both so they could not decay -- and left the sentence itself hand-written. Three validators
+// added in #4233, #4251 and #4270 therefore never appeared in it, each shipping past a green
+// test whose name is about this exact text, because that test pins the counts and not the list.
+//
+// Measured before the fix: 7 advertised phrases, 7 validators wired, 3 of them unadvertised.
+// The list is now derived from the registry `main` dispatches over, so the two cannot diverge.
+
+test('every validator that runs is advertised, and every advertisement runs (#4278)', () => {
+  // The real registry against the real dispatch, by construction rather than by transcription.
+  const runners = Object.fromEntries(VALIDATORS.map((validator) => [validator.id, () => []]));
+  assert.deepEqual(dispatchValidators(runners).findings, [], 'registry and dispatch must agree');
+});
+
+test('a validator wired without an advertisement is reported (#4278)', () => {
+  // The state that actually occurred, three times, constructed rather than asserted about.
+  const runners = Object.fromEntries(VALIDATORS.map((validator) => [validator.id, () => []]));
+  runners.somethingNew = () => [];
+  const { findings } = dispatchValidators(runners);
+  assert.equal(findings.length, 1, 'exactly the unadvertised validator must be reported');
+  assert.match(findings[0], /--help never mentions it: somethingNew/);
+});
+
+test('an advertisement with no validator behind it is reported (#4278)', () => {
+  const runners = Object.fromEntries(VALIDATORS.map((validator) => [validator.id, () => []]));
+  const dropped = VALIDATORS.at(-1).id;
+  delete runners[dropped];
+  const { findings } = dispatchValidators(runners);
+  assert.equal(findings.length, 1, 'exactly the unbacked advertisement must be reported');
+  assert.match(findings[0], new RegExp(`advertised by --help but never run: ${dropped}`));
+});
+
+test('an unadvertised validator still contributes its findings (#4278)', () => {
+  // Reporting the documentation defect must not convert it into a missing check: running only
+  // the advertised set would drop a real finding to punish a missing label.
+  const runners = Object.fromEntries(VALIDATORS.map((validator) => [validator.id, () => []]));
+  runners.somethingNew = () => ['a real finding from an unlabelled validator'];
+  const { findings } = dispatchValidators(runners);
+  assert.ok(
+    findings.includes('a real finding from an unlabelled validator'),
+    'findings from an unadvertised validator must survive',
+  );
+});
+
+test('the printed help lists every validator, not a sentence about some of them (#4278)', () => {
+  // Asserted by EXECUTION, not over the constant: a derivation nothing prints is the defect
+  // one level up. The count claims are re-checked here because deriving the list must not
+  // quietly drop the interpolation the older test pins.
+  const out = execFileSync(process.execPath, [TOOL, '--help'], { encoding: 'utf8' });
+  assert.ok(VALIDATORS.length > 3, 'PREMISE: there is a non-trivial registry to advertise');
+  for (const validator of VALIDATORS) {
+    assert.ok(out.includes(validator.label), `--help omits a validator: ${validator.id}`);
+  }
+  assert.match(out, /23-agent/);
+  assert.match(out, /81-entry/);
+});
+test('the registry is checked against the dispatch, not against itself (#4278)', () => {
+  // DISCLOSURE: every test above builds its expectation FROM `VALIDATORS`, so deleting a row
+  // survived the entire suite at 0 failures -- the population and the expectation were the same
+  // object. This is the class reported to me and then reproduced inside my own fix for it.
+  // The independent enumeration is the dispatch `main` really passes: runner keys, not labels.
+  const wired = Object.keys(activationRunners({})).sort();
+  const advertised = VALIDATORS.map((validator) => validator.id).sort();
+  assert.ok(wired.length > 3, 'PREMISE: a non-trivial dispatch exists to compare against');
+  assert.deepEqual(advertised, wired, 'every dispatched validator needs a --help row, and back');
+});
+
+test('the report states how many validators ran against how many it advertises (#4278)', () => {
+  // Asserted by execution, and by the EQUALITY of the two printed numbers rather than by either
+  // one, so this survives legitimate growth of the registry while still failing on divergence.
+  const out = execFileSync(process.execPath, [TOOL], { encoding: 'utf8' });
+  const line = out.match(/Validators: (\d+) advertised, (\d+) run/);
+  assert.ok(line, 'the report must disclose the validator populations');
+  assert.equal(line[1], line[2], 'advertised and run must agree');
+  assert.equal(Number(line[2]), Object.keys(activationRunners({})).length);
 });


### PR DESCRIPTION
## Summary

`--help` advertised 7 validators while `main` wired 7, **3 of them unadvertised**. The comment above `HELP_TEXT` reasons at length about interpolating the two counts so they cannot decay — and leaves the sentence containing them transcribed. The analysis covered one operand of its own claim.

The three missing validators (`validateEnforcementDoc` #4233, `validateTriggerCoverage` #4251, citation coverage #4270) were all added by me in this program of work, each shipping green past a test named **"the help text derives its counts instead of transcribing them"**.

## Changes

- `VALIDATORS` registry (id + label) as the single source for both the advertisement and the dispatch.
- `dispatchValidators(runners)` runs the **union** of advertised and wired, and reports each direction of disagreement — a missing label must not become a silently missing check.
- `activationRunners(context)` extracts the dispatch map as a named value so the registry can be compared against an **independent** enumeration.
- `HELP_TEXT` interpolates its list from the registry; `main()` dispatches through it.
- Unconditional `Validators: N advertised, M run` line, built **by** the dispatch and returned as `disclosure`, so bypassing the dispatch loses the line rather than forging it.

## Disclosure

Deleting a registry row **survived the entire suite at 0 failures** on the first sweep: every test built its expectation from `VALIDATORS`, so the population and the expectation were the same object. That is the defect this PR fixes, reproduced one level up inside the fix, in the same commit. Repaired via `activationRunners`.

An earlier sweep recorded MUT D as a survivor. That was an **instrument error** — the anchor left the interpolation intact, so the described mutation was never applied. Re-run correctly: killed.

## Controls

8 mutants, 7 killed by distinct failing test name: A drop-advertised-check (1), B drop-wired-check (1), C advertised-set-not-union (1), D transcribe-the-list (2), E delete-registry-row (2), G unwire-a-runner (2), H drop-disclosure-line (1).

**F (bypass the dispatch with a faithful inline re-implementation) SURVIVED at 0** — and is shown to be *equivalent* rather than uncovered: compound mutant **F2** (same bypass, forged counts, plus an unwired runner) is **KILLED (2)**, including by the report test, which anchors the printed number against `activationRunners` rather than `VALIDATORS.length`.

## Issues

Closes #4278

## Testing

- [x] `node --test tools/check-ai-manifest.test.mjs` — **76/76**
- [x] `node tools/check-ai-manifest.js` — exit 0, prints `Validators: 7 advertised, 7 run`, `--help` lists all seven
- [x] `npx prettier --check` on both touched files — clean
- [x] `npx eslint … --max-warnings 0` — clean

Scope: this tool and its test only. No workflow, no `packages/design-tokens`, no vendored tokens, no lock edit.