### PR TITLE
test(tools): gate tests that reimplement the code they verify

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -136,6 +136,15 @@ jobs:
 
       - name: Enumeration checker tests
         run: npm run citations:enumerations:test
+
+      - name: Cross-repo refs are pinned
+        run: npm run upstream:refs:check
+
+      - name: Documentation links and anchors resolve
+        run: npm run docs:links:check
+
+      - name: Tool tests do not reimplement their tools
+        run: npm run test:independence:check
   pr-title:
     name: Semantic PR Title
     needs: changes

--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -8314,6 +8314,97 @@ So the population of that glob is not "my scratch files" but "anything whose nam
 start with two z's, in any case, on a shared machine". The correct claim names the files
 created and removed, not a pattern.
 
+## A test that recomputes its rule reports agreement about a question nobody asked
+
+A sibling session found a coverage test whose expected values were the checker's
+own expressions — one written `known.has(id)`, the other
+`baseline.uncovered.includes(id)`. Both files agreed, the suite was green, and
+changing the rule in the checker would have left the test computing the old rule
+and passing.
+
+Finance has ten tool/test pairs. Measured:
+
+|                                  |       |
+| -------------------------------- | ----- |
+| tool/test pairs examined         | 10    |
+| lines sharing a normalised shape | 4     |
+| input construction               | 4     |
+| **rule reimplementation**        | **0** |
+
+The four are a `readdirSync(...).filter(...).sort().map(...)` chain that two test
+files use to load workflows before calling the real scanner. Duplicated input
+construction is cheap and honest; the defect is a duplicated _decision_.
+
+`tools/check-test-independence.mjs` gates it. Four things it taught, none of
+which were the result:
+
+**A length threshold excluded the shape it was written to find.** The first
+probe skipped shapes under 22 characters as noise, and the sibling's pair
+normalises to a 19-character shape. Its self-test asserted
+`shapeOf(a) === shapeOf(b)` and passed — while the pipeline dropped both lines
+before they ever reached that comparison. The assertion tested a _function_; the
+claim was about a _pipeline_. An instrument's self-test has to run the
+instrument, not its components.
+
+**The classifier's population was the line; the decision was the statement.**
+`classify()` looked for a filesystem read on the matched line and called
+everything else a reimplemented rule. Method chains put the read on one line and
+the traversal on the next, so two of four matches were reported as rules when
+both were continuations of a `readdirSync`. Note the polarity: a _disclaimer_
+that shrinks is a false-assurance error, but a _classifier_ that over-reports is
+a false accusation. Both are wrong-population errors and they fail in opposite
+directions.
+
+**A normaliser needs a matched pair of assertions.** The identifier regex
+originally wrote `[\w$.]*`, which swallowed the dot and consumed
+`uncovered.filter` as one token — so the keep-word list never fired for a method
+call and `filter` and `map` shared a shape. Excluding the dot fixed that and
+immediately broke the sibling's pair, because `known` and `baseline.uncovered`
+stopped matching. Both properties have to be asserted together:
+`() => ''` satisfies every must-match test, `identity` satisfies every
+must-differ test, and neither is a normaliser.
+
+**The symmetric fixture came back one PR later.** A mutant swapping the input
+and rule counts survived, because the fixture held exactly one of each.
+[The previous section](#the-printed-sentence-is-the-half-with-no-assertion)
+records the same defect, and the fixture was rebuilt in the same shape while
+that text was in the repo. Knowing a defect class does not prevent instantiating
+it: the symmetric fixture is the one that looks careful.
+
+## Four gates were invoked by nothing
+
+Wiring the new checker meant reading how the others were wired, which produced a
+worse finding than the checker did. Of fourteen `*:check` scripts, a census of
+workflow invocations returned:
+
+|                      |     |
+| -------------------- | --- |
+| `*:check` scripts    | 14  |
+| named in a workflow  | 7   |
+| named in no workflow | 7   |
+
+Three of the seven are explainable — `format:check` runs inside `lint`,
+`ci:check` is a local aggregate, `agent:check` is a pre-push helper. One was a
+false positive: `ai:manifest:check` **is** enforced, by its own workflow calling
+`tools/check-ai-manifest.js` by path, which a matcher looking for `npm run` could
+not see.
+
+That leaves two real ones: `upstream:refs:check` and `docs:links:check` — both
+built here, both described in six successive reports as gates, and neither run
+by any workflow. Every "all gates green" statement in those reports was a claim
+about _running them locally_, not about enforcement, and the distinction was
+never stated because it was never noticed.
+
+This is the sibling's own finding — a checker its owning repo never executes —
+arriving in this tree by the same route: the script exists, `npm run` proves it
+passes, and nothing distinguishes _passes_ from _is required to pass_. All three
+are now steps in `ci-lint.yml`.
+
+The general form is worth keeping: **a gate is a workflow step, not a script.**
+Registering a `package.json` entry produces something that behaves identically
+to a gate every time a human runs it, and identically to nothing the rest of the
+time.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:

--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -8371,6 +8371,32 @@ records the same defect, and the fixture was rebuilt in the same shape while
 that text was in the repo. Knowing a defect class does not prevent instantiating
 it: the symmetric fixture is the one that looks careful.
 
+### The checker failed itself, and only in CI
+
+The first push was red. `check-test-independence` reported one reimplemented
+rule, in `check-test-independence.test.mjs`:
+
+```
+const rules = result.matches.filter((match) => match.kind === 'rule');
+```
+
+character-identical to the line in `reportLines()` that owns that decision. The
+test written to prove the tree had no reimplemented rules was one — the whole
+defect class, instantiated inside its own detector, on the first run that could
+see it.
+
+That qualifier is the second finding. It passed locally and failed in CI because
+`census()` enumerates with `git ls-files`, and both new files were untracked
+until the commit. **The instrument was outside its own population while being
+tested.** Local runs counted 10 pairs; CI counted 11. Nothing was wrong with
+either run — they were answers to different questions, and only one of them was
+the question.
+
+Any tool that discovers its input from version control is blind to itself until
+committed, which is precisely the window in which it is being written. The fix
+was to assert through `reportLines()` — using the tool's own classification
+rather than recomputing it — which is the remedy the tool exists to recommend.
+
 ## Four gates were invoked by nothing
 
 Wiring the new checker meant reading how the others were wired, which produced a

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "node:version:check": "node tools/check-node-version-consistency.mjs",
     "node:version:test": "node --test tools/check-node-version-consistency.test.mjs",
     "citations:context:test": "node --test tools/citations-context.test.mjs",
+    "test:independence:check": "node tools/check-test-independence.mjs",
     "docs:links:check": "node tools/check-doc-links.mjs",
     "docs:links:test": "node --test tools/check-doc-links.test.mjs"
   },

--- a/tools/check-test-independence.mjs
+++ b/tools/check-test-independence.mjs
@@ -1,0 +1,269 @@
+#!/usr/bin/env node
+/**
+ * check-test-independence.mjs
+ *
+ * Fails when a test file recomputes a rule its implementation already owns.
+ *
+ * Origin: a sibling session found a coverage test whose `regressions` and
+ * `stale` expressions were the checker's own expressions, one written with
+ * `Set.has` and the other with `Array.includes`. Both files agreed, the suite
+ * was green, and changing the rule in the checker would have left the test
+ * computing the old rule -- reporting agreement about a question nobody asked.
+ *
+ * Exact-text matching cannot see that pair, so this compares normalised
+ * SHAPES: identifiers collapse to `X`, and interchangeable membership tests
+ * (`Set.has` / `Array.includes`) normalise together.
+ *
+ * Not every shared shape is a defect. A test that discovers its input the way
+ * the tool does, then calls the real function and asserts its behaviour, is
+ * duplicating INPUT CONSTRUCTION, which is cheap and honest. The defect is
+ * duplicated RULE: the test deciding the answer for itself. `classify()` draws
+ * that line, and the baseline records which side each known match sits on.
+ *
+ * The gate deliberately fails on any UNCLASSIFIED match rather than asserting a
+ * verdict, because shape matching is a heuristic. A new match is a question for
+ * a reader -- "is this input or rule?" -- and the population is small enough
+ * (4 today, across 10 pairs) that answering it by eye is a minute's work.
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+
+/**
+ * Line shapes that are known duplication of input construction, not of a rule.
+ *
+ * Literal entries, never derived from a run: a baseline expressed in terms of
+ * the census it constrains cannot detect being loosened.
+ */
+export const DUPLICATION_BASELINE = [
+  'check-node-version-consistency.test.mjs:107 ~ check-node-version-consistency.mjs:425',
+  'check-workflow-security.test.mjs:337 ~ check-workflow-security.mjs:608',
+  'check-workflow-security.test.mjs:338 ~ check-workflow-security.mjs:609',
+  'check-workflow-security.test.mjs:339 ~ check-workflow-security.mjs:610',
+];
+
+/** Operations whose presence makes a line a candidate for carrying a rule. */
+const COMPUTES = /\.(filter|map|reduce|some|every|sort|find|findIndex)\(|\.includes\(|\.has\(/;
+
+/** Reads that make a line input construction rather than a decision. */
+const READS_INPUT = /readdirSync|readFileSync|execFileSync|globSync|import\(/;
+
+const KEEP_WORDS = new Set([
+  'filter',
+  'map',
+  'reduce',
+  'some',
+  'every',
+  'sort',
+  'find',
+  'findIndex',
+  'includes',
+  'test',
+  'match',
+  'replace',
+  'split',
+  'join',
+  'length',
+  'push',
+  'slice',
+  'trim',
+  'startsWith',
+  'endsWith',
+  'const',
+  'let',
+  'return',
+  'of',
+  'in',
+]);
+
+/**
+ * Collapse a line to a comparable shape.
+ *
+ * `known.has(id)` and `baseline.uncovered.includes(id)` must produce the same
+ * shape; that pair is the reason this function exists, and the test suite
+ * exercises it through the whole census rather than in isolation.
+ *
+ * @param {string} line Source line.
+ * @returns {string} Normalised shape.
+ */
+export function shapeOf(line) {
+  return (
+    line
+      .trim()
+      .replace(/\/\/.*$/, '')
+      .replace(/\s+/g, ' ')
+      .replace(/\.has\(/g, '.includes(')
+      .replace(/\bnew Set\(([^)]*)\)/g, '$1')
+      // The character class must exclude `.`. An earlier version wrote
+      // `[\w$.]*`, which consumed `uncovered.filter` as a single token and
+      // replaced it wholesale -- so KEEP_WORDS never fired for a method call,
+      // `filter` and `map` shared a shape, and the matcher was far looser than
+      // its own word list claimed. Over-looseness only ever inflates a match
+      // count, so it could not have produced a false clean bill; it could and
+      // did produce a false understanding of what the tool compares.
+      .replace(/[A-Za-z_$][\w$]*/g, (word) => (KEEP_WORDS.has(word) ? word : 'X'))
+      // Collapse property chains, so `known` and `baseline.uncovered` are the
+      // same shape of thing. Excluding `.` above and collapsing here are a pair:
+      // excluding it alone made the sibling's `X.includes` / `X.X.includes` pair
+      // stop matching, which is the case the tool exists for. Every normaliser
+      // needs both a must-match and a must-differ assertion, because
+      // `() => ''` satisfies all of the first kind and `identity` all of the
+      // second, and neither is a normaliser.
+      .replace(/X(?:\.X)+/g, 'X')
+      .trim()
+      .replace(/;$/, '')
+      .trim()
+  );
+}
+
+/**
+ * Recover the whole statement a line belongs to.
+ *
+ * Method chains put the read on one line and the decision on the next, so a
+ * per-line classifier reads `.filter(...)` with no `readdirSync` in sight and
+ * calls it a rule. Walking back over leading-dot continuations restores the
+ * population the classification is actually about.
+ *
+ * @param {string[]} lines All lines of the file.
+ * @param {number} index Zero-based index of the matched line.
+ * @returns {string} The enclosing statement.
+ */
+export function statementAt(lines, index) {
+  let start = index;
+  while (start > 0 && lines[start].trim().startsWith('.')) start -= 1;
+  return lines
+    .slice(start, index + 1)
+    .map((line) => line.trim())
+    .join(' ');
+}
+
+/**
+ * Decide whether shared code duplicates input construction or a rule.
+ *
+ * Takes the statement, not the line: classifying the line mislabelled two of
+ * this repo's four matches as reimplemented rules when both were continuations
+ * of a `readdirSync` chain. An over-reporting classifier is a false accusation,
+ * the mirror of an under-reporting disclaimer.
+ *
+ * @param {string} statement Enclosing statement text.
+ * @returns {'input' | 'rule'} Classification.
+ */
+export function classify(statement) {
+  return READS_INPUT.test(statement) ? 'input' : 'rule';
+}
+
+/**
+ * Compare one implementation against its test file.
+ *
+ * @param {string} sourceText Implementation text.
+ * @param {string} testText Test text.
+ * @returns {Array<{testLine: number, sourceLine: number, raw: string, kind: string}>} Matches.
+ */
+export function censusPair(sourceText, testText) {
+  const shapes = new Map();
+  const eligible = (raw) =>
+    raw.length > 0 && !raw.startsWith('*') && !raw.startsWith('//') && COMPUTES.test(raw);
+
+  sourceText.split('\n').forEach((line, index) => {
+    const raw = line.trim();
+    if (!eligible(raw)) return;
+    const shape = shapeOf(line);
+    // No length threshold. An earlier probe dropped shapes under 22 characters
+    // and would have excluded the 19-character shape it was written to find.
+    if (shape.length === 0) return;
+    if (!shapes.has(shape)) shapes.set(shape, index + 1);
+  });
+
+  const matches = [];
+  const testLines = testText.split('\n');
+  testLines.forEach((line, index) => {
+    const raw = line.trim();
+    if (!eligible(raw)) return;
+    const shape = shapeOf(line);
+    if (shape.length === 0) return;
+    if (!shapes.has(shape)) return;
+    matches.push({
+      testLine: index + 1,
+      sourceLine: shapes.get(shape),
+      raw,
+      kind: classify(statementAt(testLines, index)),
+    });
+  });
+  return matches;
+}
+
+/**
+ * Census every tool that has a sibling test file.
+ *
+ * @param {(file: string) => string} read File reader, injectable for tests.
+ * @param {string[]} [toolFiles] Implementation paths.
+ * @returns {{pairs: number, matches: object[]}} Census result.
+ */
+export function census(read, toolFiles) {
+  const tools =
+    toolFiles ??
+    execFileSync('git', ['ls-files', 'tools/*.mjs'], { encoding: 'utf8' })
+      .split('\n')
+      .filter((file) => file && !file.endsWith('.test.mjs'));
+
+  let pairs = 0;
+  const matches = [];
+  for (const tool of tools) {
+    const testFile = tool.replace(/\.mjs$/, '.test.mjs');
+    if (!existsSync(testFile)) continue;
+    pairs += 1;
+    for (const hit of censusPair(read(tool), read(testFile))) {
+      matches.push({
+        ...hit,
+        id: `${testFile.split('/').pop()}:${hit.testLine} ~ ${tool.split('/').pop()}:${hit.sourceLine}`,
+      });
+    }
+  }
+  return { pairs, matches };
+}
+
+/**
+ * Build the printed report.
+ *
+ * Returned rather than printed so the sentences can be asserted; the counts
+ * were never the untested half.
+ *
+ * @param {{pairs: number, matches: object[]}} result Census result.
+ * @param {string[]} [baseline] Known-classified match ids.
+ * @returns {{lines: string[], failed: boolean}} Report.
+ */
+export function reportLines(result, baseline = DUPLICATION_BASELINE) {
+  const known = new Set(baseline);
+  const unclassified = result.matches.filter((match) => !known.has(match.id));
+  const rules = result.matches.filter((match) => match.kind === 'rule');
+  const lines = [
+    `tool/test pairs examined      ${result.pairs}`,
+    `lines sharing a shape         ${result.matches.length}`,
+    `  input construction          ${result.matches.filter((m) => m.kind === 'input').length}`,
+    `  rule reimplementation       ${rules.length}`,
+    `unclassified (not in baseline) ${unclassified.length}`,
+    '',
+    'Not measured: duplication expressed differently enough that the shapes',
+    'diverge, and duplication across files that are not a tool/test pair.',
+    'A shared shape is evidence of a shared decision, not proof of one.',
+  ];
+  for (const match of unclassified) {
+    lines.push(`  UNCLASSIFIED ${match.id}`, `    ${match.raw.slice(0, 100)}`);
+  }
+  return { lines, failed: unclassified.length > 0 };
+}
+
+function main() {
+  const result = census((file) => readFileSync(file, 'utf8'));
+  const report = reportLines(result);
+  for (const line of report.lines) console.log(line);
+  if (report.failed) {
+    console.error('\nA test line now shares a shape with the code it verifies.');
+    console.error('Classify it: input construction is fine and belongs in the');
+    console.error('baseline; a reimplemented rule means the test decides the');
+    console.error('answer itself and cannot detect the rule changing.');
+    process.exit(1);
+  }
+}
+
+if (process.argv[1] && process.argv[1].endsWith('check-test-independence.mjs')) main();

--- a/tools/check-test-independence.test.mjs
+++ b/tools/check-test-independence.test.mjs
@@ -204,10 +204,20 @@ test('the baseline is four literal entries', () => {
 });
 
 test('every live match is input construction', () => {
+  // Asserted through the report rather than by re-filtering `matches`.
+  //
+  // The first draft recomputed `matches.filter((m) => m.kind === 'rule')` --
+  // character-identical to the line in `reportLines` that owns that decision --
+  // and this checker failed itself in CI over it. It passed locally because
+  // `census()` enumerates with `git ls-files`, and both new files were still
+  // untracked: the instrument was outside its own population until committed.
   const result = census((file) => readFileSync(file, 'utf8'));
-  assert.ok(result.pairs >= 10);
-  const rules = result.matches.filter((match) => match.kind === 'rule');
-  assert.deepEqual(rules, [], 'a tool test now recomputes its own rule');
+  assert.ok(result.pairs >= 11, `pairs: ${result.pairs}`);
+  const { lines } = reportLines(result);
+  assert.ok(
+    lines.includes('  rule reimplementation       0'),
+    `a tool test now recomputes its own rule:\n${lines.join('\n')}`,
+  );
 });
 
 test('the live tree is clean against the literal baseline', () => {

--- a/tools/check-test-independence.test.mjs
+++ b/tools/check-test-independence.test.mjs
@@ -1,0 +1,216 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import {
+  shapeOf,
+  classify,
+  statementAt,
+  censusPair,
+  census,
+  reportLines,
+  DUPLICATION_BASELINE,
+} from './check-test-independence.mjs';
+
+// The pair this checker exists for, quoted from the report that found it.
+const SIBLING_IMPL = [
+  'export function compare(uncovered, known, covered, baseline) {',
+  '  const regressions = uncovered.filter((id) => !known.has(id));',
+  '  const stale = baseline.uncovered.filter((id) => covered.includes(id));',
+  '  return { regressions, stale };',
+  '}',
+].join('\n');
+
+const SIBLING_TEST = [
+  "test('coverage agrees with the tree', () => {",
+  '  const regressions = uncovered.filter((id) => !baseline.uncovered.includes(id));',
+  '  const stale = baseline.uncovered.filter((id) => covered.includes(id));',
+  '  assert.equal(regressions.length, 0);',
+  '});',
+].join('\n');
+
+// ---------------------------------------------------------------------------
+// End-to-end detection.
+//
+// An earlier probe asserted `shapeOf(a) === shapeOf(b)` for this pair and
+// passed, while the census dropped both lines on a 22-character length filter
+// the assertion never ran through. The comparator was tested; the claim was
+// about the pipeline. Every test below drives the census.
+// ---------------------------------------------------------------------------
+
+test('the census detects a rule recomputed with a different membership test', () => {
+  const matches = censusPair(SIBLING_IMPL, SIBLING_TEST);
+  const ids = matches.map((match) => `${match.testLine}~${match.sourceLine}`);
+  assert.ok(ids.includes('2~2'), `Set.has vs Array.includes not matched: ${ids.join(',')}`);
+});
+
+test('the census detects a character-identical recomputed rule', () => {
+  const matches = censusPair(SIBLING_IMPL, SIBLING_TEST);
+  assert.ok(matches.some((match) => match.testLine === 3 && match.sourceLine === 3));
+});
+
+test('a recomputed rule is classified rule, not input', () => {
+  const matches = censusPair(SIBLING_IMPL, SIBLING_TEST);
+  assert.deepEqual(
+    [...new Set(matches.map((match) => match.kind))],
+    ['rule'],
+    'a filter over an in-memory array reads no input',
+  );
+});
+
+test('a very short shape still reaches a match', () => {
+  // Regression on a length filter an earlier probe carried: it dropped shapes
+  // under 22 characters, and the whole point of the tool is a shape that short.
+  // The claim is the CONJUNCTION -- short AND detected -- because asserting the
+  // comparator alone is what let the filter hide.
+  const impl = 'const a = rows\n  .sort()\n  .filter((r) => r.ok);';
+  const spec = "test('x', () => {\n  const b = rows\n    .sort()\n    .filter((r) => r.ok);\n});";
+  assert.ok(shapeOf('  .sort()').length < 10);
+  const matches = censusPair(impl, spec);
+  assert.ok(
+    matches.some((match) => match.raw === '.sort()'),
+    `a 7-character shape was dropped: ${JSON.stringify(matches.map((m) => m.raw))}`,
+  );
+});
+
+test('the sibling pair matches and a different operation does not', () => {
+  // A normaliser needs both directions asserted together: `() => ''` passes
+  // every must-match test and `identity` passes every must-differ test.
+  assert.equal(
+    shapeOf('const r = uncovered.filter((id) => !known.has(id));'),
+    shapeOf('const r = uncovered.filter((id) => !baseline.uncovered.includes(id));'),
+  );
+  assert.notEqual(shapeOf('const r = u.filter((i) => i);'), shapeOf('const r = u.map((i) => i);'));
+});
+
+test('a test calling the real function is not reported', () => {
+  const impl = 'export function scan(files) {\n  return files.filter((f) => f.bad);\n}';
+  const spec = "test('x', () => {\n  assert.equal(scan(fixture).length, 0);\n});";
+  assert.deepEqual(censusPair(impl, spec), []);
+});
+
+// ---------------------------------------------------------------------------
+// Classification
+// ---------------------------------------------------------------------------
+
+test('a chained continuation is classified by its statement', () => {
+  const lines = [
+    '  readdirSync(dir)',
+    '    .filter((file) => /\\.ya?ml$/.test(file))',
+    '    .sort()',
+  ];
+  assert.equal(classify(statementAt(lines, 1)), 'input');
+  assert.equal(classify(statementAt(lines, 2)), 'input');
+  // The defect this replaced: judged alone, both read as rules.
+  assert.equal(classify(lines[1]), 'rule');
+});
+
+test('statement recovery stops at the chain head', () => {
+  const lines = ['const a = 1;', '  readFileSync(p)', '    .split()'];
+  assert.equal(statementAt(lines, 2), 'readFileSync(p) .split()');
+});
+
+test('a filter over memory is a rule even beside a read elsewhere', () => {
+  const lines = ['const raw = readFileSync(p);', 'const bad = ids.filter((id) => !known.has(id));'];
+  assert.equal(classify(statementAt(lines, 1)), 'rule');
+});
+
+// ---------------------------------------------------------------------------
+// Shape normalisation
+// ---------------------------------------------------------------------------
+
+test('Set.has and Array.includes normalise together', () => {
+  assert.equal(
+    shapeOf('const r = u.filter((id) => !known.has(id));'),
+    shapeOf('const r = u.filter((id) => !baseline.uncovered.includes(id));'),
+  );
+});
+
+test('different operations keep different shapes', () => {
+  assert.notEqual(
+    shapeOf('const r = u.filter((id) => !known.has(id));'),
+    shapeOf('const r = u.map((id) => !known.has(id));'),
+    'collapsing filter and map would make every traversal look alike',
+  );
+});
+
+test('negation is part of the shape', () => {
+  assert.notEqual(
+    shapeOf('const r = u.filter((id) => !known.has(id));'),
+    shapeOf('const r = u.filter((id) => known.has(id));'),
+    'an inverted rule must not read as the same rule',
+  );
+});
+
+test('comments do not enter the shape', () => {
+  assert.equal(shapeOf('a.filter((x) => x); // note'), shapeOf('a.filter((x) => x);'));
+});
+
+// ---------------------------------------------------------------------------
+// Report sentences
+// ---------------------------------------------------------------------------
+
+const ALL = ['a.test.mjs:1 ~ a.mjs:1', 'b.test.mjs:2 ~ b.mjs:9', 'c.test.mjs:3 ~ c.mjs:4'];
+
+// Deliberately asymmetric: two input, one rule. A fixture holding one of each
+// cannot distinguish a report that separates the classes from one that swaps
+// them, and a mutant doing exactly that survived the symmetric first draft.
+const fakeResult = {
+  pairs: 3,
+  matches: [
+    { id: ALL[0], kind: 'input', raw: 'readdirSync(d).filter((f) => f)' },
+    { id: ALL[2], kind: 'input', raw: 'readFileSync(p).split()' },
+    { id: ALL[1], kind: 'rule', raw: 'ids.filter((i) => !k.has(i))' },
+  ],
+};
+
+test('the report separates input from rule rather than printing one total', () => {
+  const { lines } = reportLines(fakeResult, ALL);
+  assert.ok(lines.includes('  input construction          2'), lines.join('\n'));
+  assert.ok(lines.includes('  rule reimplementation       1'), lines.join('\n'));
+  assert.ok(lines.includes('lines sharing a shape         3'));
+});
+
+test('an unbaselined match fails and is named', () => {
+  const { lines, failed } = reportLines(fakeResult, [ALL[0], ALL[2]]);
+  assert.equal(failed, true);
+  assert.ok(lines.some((line) => line.includes('UNCLASSIFIED b.test.mjs:2 ~ b.mjs:9')));
+  assert.ok(lines.includes('unclassified (not in baseline) 1'));
+});
+
+test('a fully baselined census passes', () => {
+  assert.equal(reportLines(fakeResult, ALL).failed, false);
+});
+
+test('a trailing semicolon is not part of the shape', () => {
+  // Source and test rarely agree on punctuation: the same rule appears as a
+  // statement in one file and as an argument in the other.
+  const impl = 'const bad = ids.filter((i) => !k.has(i));';
+  const spec = "test('x', () => {\n  const bad = ids.filter((i) => !k.has(i))\n});";
+  assert.equal(censusPair(impl, spec).length, 1, 'punctuation split an identical rule');
+});
+
+test('the scope line is printed on the failing path too', () => {
+  const { lines } = reportLines(fakeResult, []);
+  assert.ok(lines.some((line) => line.startsWith('Not measured:')));
+});
+
+// ---------------------------------------------------------------------------
+// Baseline and live tree
+// ---------------------------------------------------------------------------
+
+test('the baseline is four literal entries', () => {
+  assert.equal(DUPLICATION_BASELINE.length, 4);
+  assert.ok(DUPLICATION_BASELINE.every((entry) => entry.includes(' ~ ')));
+});
+
+test('every live match is input construction', () => {
+  const result = census((file) => readFileSync(file, 'utf8'));
+  assert.ok(result.pairs >= 10);
+  const rules = result.matches.filter((match) => match.kind === 'rule');
+  assert.deepEqual(rules, [], 'a tool test now recomputes its own rule');
+});
+
+test('the live tree is clean against the literal baseline', () => {
+  const result = census((file) => readFileSync(file, 'utf8'));
+  assert.equal(reportLines(result).failed, false);
+});


### PR DESCRIPTION
## Summary

A sibling session found a coverage test whose expected values were the checker's own
expressions -- one written `known.has(id)`, the other `baseline.uncovered.includes(id)`.
Both files agreed, the suite was green, and changing the rule in the checker would have
left the test computing the old rule and reporting agreement about a question nobody asked.

Measured finance's 10 tool/test pairs for the same shape.

| | |
| --- | --- |
| tool/test pairs examined | 10 |
| lines sharing a normalised shape | 4 |
| input construction | 4 |
| **rule reimplementation** | **0** |

The 4 are a `readdirSync(...).filter(...).sort().map(...)` chain two test files use to
load workflows before calling the real scanner. Duplicated input construction is honest;
the defect is a duplicated decision.

## Four gates were invoked by nothing

Wiring the new checker meant reading how the others were wired, which produced the worse
finding. Of 14 `*:check` scripts, 7 are named in no workflow. Three are explainable
(`format:check` runs inside `lint`, `ci:check` is a local aggregate, `agent:check` is a
pre-push helper) and one was a false positive -- `ai:manifest:check` **is** enforced, by
its own workflow calling the tool by path, invisible to a matcher looking for `npm run`.

That leaves two real ones: `upstream:refs:check` and `docs:links:check`, both built here,
both described in six successive reports as gates, neither run by anything. Every "all
gates green" claim in those reports was about running them locally, not about enforcement.
All three are now steps in `ci-lint.yml`.

**A gate is a workflow step, not a script.** A `package.json` entry behaves identically to
a gate whenever a human runs it, and identically to nothing the rest of the time.

## Four defects in the instrument, before it found anything

- **A length threshold excluded the shape it was built to find.** The first probe skipped
  shapes under 22 characters; the sibling's pair normalises to 19. Its self-test asserted
  `shapeOf(a) === shapeOf(b)` and passed, while the pipeline dropped both lines before they
  reached that comparison. The assertion tested a function; the claim was about a pipeline.
- **The classifier's population was the line, the decision was the statement.** Method
  chains put the read on one line and the traversal on the next, so 2 of 4 matches were
  reported as reimplemented rules when both were `readdirSync` continuations. A disclaimer
  that shrinks is false assurance; a classifier that over-reports is false accusation.
- **A normaliser needs a matched pair of assertions.** `[\w$.]*` swallowed the dot, so
  `uncovered.filter` was one token, the keep-word list never fired, and `filter`/`map`
  shared a shape. Excluding the dot immediately broke the sibling's pair. `() => ''` passes
  every must-match test and `identity` passes every must-differ test; neither is a normaliser.
- **The symmetric fixture returned one PR later.** A mutant swapping the input and rule
  counts survived because the fixture held exactly one of each -- the defect documented in
  #4277, rebuilt while that text was in the repo.

## Changes

- `tools/check-test-independence.mjs` -- `shapeOf`, `statementAt`, `classify`, `censusPair`,
  `census`, `reportLines`, literal `DUPLICATION_BASELINE` (4 entries)
- `tools/check-test-independence.test.mjs` -- 21 tests, driven through the census rather
  than the comparator
- `ci-lint.yml` -- three new steps: `upstream:refs:check`, `docs:links:check`,
  `test:independence:check`
- guide sections recording both findings

Also verified the sibling's newly-found second mutable ref (`check-pins.mjs:42`) does not
reach finance: only `check-citations.mjs` and the prettier config are vendored, so
`EXECUTED_BASELINE = 1` is still correct.

## Issues

Closes #4280
Refs #4029

## Testing

- [x] `npm run format:check`, `npx eslint . --max-warnings 0`, `npm run type-check`
- [x] `node --test "tools/**/*.test.mjs"` -- 387/387
- [x] all 13 gates exit 0
- [x] mutation: 12/12 killed under a green-baseline guard