### PR TITLE
feat(tools): date the pin-history exposure figure and print its drift

### DIFF
--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -8431,6 +8431,75 @@ Registering a `package.json` entry produces something that behaves identically
 to a gate every time a human runs it, and identically to nothing the rest of the
 time.
 
+## A compliance percentage over an open interval improves while nobody acts
+
+A sibling session published its workflow-pinning exposure twice — `56.8% of
+5d 1.2h`, then `55.7% of 5d 4h` — with the same 17 commits, the same 7 dirty,
+and no push in between. The span had grown because the newest interval ends at
+the reading time.
+
+The same is true here, and finance has enough history to make it stark:
+
+| reading time   | exposure  | numerator moved | denominator moved |
+| -------------- | --------- | --------------- | ----------------- |
+| today          | **39.2%** | —               | —                 |
+| +30 idle days  | 33.0%     | no              | yes               |
+| +90 idle days  | 25.1%     | no              | yes               |
+| +365 idle days | **12.0%** | no              | yes               |
+
+Nothing happens in any of those rows. A clean HEAD freezes the numerator while
+the denominator grows, so **the repository improves its own compliance score by
+waiting** — and an unpinned HEAD makes the number worsen the same way, which is
+the direction everyone assumes it has.
+
+The report already said the final interval "grows until the next commit
+touching this directory." That sentence is true, it was written deliberately,
+and it is not the finding. It states the _mechanism_ and omits the
+_consequence_: that the percentage moves, and which way. This is the
+false-assurance polarity again — [a disclaimer that shrinks over-claims](#a-disclaimers-safe-direction-is-the-mirror-of-a-findings),
+and so does one that explains a caveat without saying what it costs. The reader
+is told enough to trust the number and not enough to date it.
+
+Three changes:
+
+- an explicit `as of <ISO>` stamp, so two runs are comparable and a difference
+  between them is not by itself evidence that anything changed;
+- a **closed** figure measured to the newest commit rather than to now, which is
+  a function of history alone and does not drift;
+- the drift itself, printed with a direction: `open figure falls 6.2 pts per
+30 idle days`.
+
+### The new statistic printed `0h of 0h` and nothing objected
+
+The first wiring returned the closed totals from `exposure()` but never
+propagated them through `censusHistory()`, so the report interpolated
+`undefined` as zero and printed `closed history only 0h of 0h (0.0%)`. A
+brand-new statistic reading exactly zero, rendered identically to a real zero,
+in a tool whose whole subject is figures that mislead. It now throws when a
+closed span is zero across more than one commit, because that is not a clean
+history — it is an unwired one.
+
+### The live tree could not have caught it
+
+The gap between the open and closed spans is currently **455 seconds**, because
+the newest commit touching `.github/workflows` is the PR that shipped the
+previous checker, minutes earlier. Any error in the closed span would be
+invisible against this tree today; the two figures converge right after a commit
+and diverge as the repository idles.
+
+So every discriminating assertion is synthetic, and that is not a compromise.
+The sibling's phrase for it is exact — **a tree is a fixture nobody chose** —
+and this one was made non-discriminating by the previous commit in this same
+session.
+
+Four mutants survived the first suite, all of them because the fixture had a
+clean HEAD, where the open interval contributes nothing to the numerator either
+way. One of the four survived an assertion written specifically to guard the
+wiring: `assert.notEqual(closed, open)` passes for a mutant that never accrues
+closed time at all, because zero is also unequal to the open figure. **An
+inequality distinguishes a value from exactly one other value**, which is nearly
+the weakest claim an assertion can make while still looking like a check.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:

--- a/tools/check-workflow-pin-history.mjs
+++ b/tools/check-workflow-pin-history.mjs
@@ -139,7 +139,10 @@ export function censusHistory(
     }
   }
 
-  const { dirtySeconds, spanSeconds } = exposure(states, nowSeconds);
+  const { dirtySeconds, spanSeconds, closedDirtySeconds, closedSpanSeconds } = exposure(
+    states,
+    nowSeconds,
+  );
   const shape = episodes(states, nowSeconds);
 
   return {
@@ -150,6 +153,8 @@ export function censusHistory(
     headClean,
     dirtySeconds,
     spanSeconds,
+    closedDirtySeconds,
+    closedSpanSeconds,
     shape,
   };
 }
@@ -167,15 +172,64 @@ export function censusHistory(
  * @returns {{dirtySeconds: number, spanSeconds: number}}
  */
 export function exposure(states, nowSeconds) {
-  if (states.length === 0) return { dirtySeconds: 0, spanSeconds: 0 };
+  if (states.length === 0) {
+    return { dirtySeconds: 0, spanSeconds: 0, closedDirtySeconds: 0, closedSpanSeconds: 0 };
+  }
   let dirtySeconds = 0;
+  let closedDirtySeconds = 0;
   for (let i = 0; i < states.length; i += 1) {
     const until = i === 0 ? nowSeconds : states[i - 1].at;
     const held = Math.max(0, until - states[i].at);
-    if (states[i].bad) dirtySeconds += held;
+    if (states[i].bad) {
+      dirtySeconds += held;
+      // The closed figure stops at the newest commit instead of at the reading
+      // time, so the open interval at HEAD contributes to neither side.
+      if (i > 0) closedDirtySeconds += held;
+    }
   }
-  const spanSeconds = Math.max(0, nowSeconds - states[states.length - 1].at);
-  return { dirtySeconds, spanSeconds };
+  const oldest = states[states.length - 1].at;
+  return {
+    dirtySeconds,
+    spanSeconds: Math.max(0, nowSeconds - oldest),
+    closedDirtySeconds,
+    closedSpanSeconds: Math.max(0, states[0].at - oldest),
+  };
+}
+
+/**
+ * Percentage of a span spent non-compliant, and how fast that figure moves.
+ *
+ * The open figure is a function of the reading time, not only of the history.
+ * With a clean HEAD the numerator is frozen and the denominator grows, so the
+ * percentage falls while nobody does anything: measured on this repository it
+ * reads 39.2% today, 33.0% after thirty idle days and 12.0% after a year, on
+ * an unchanged history. With an unpinned HEAD it climbs instead.
+ *
+ * The report already said the final interval grows and never said the
+ * percentage moves or which way. A scope note that states a mechanism and
+ * omits its consequence is the false-assurance direction of the same error as
+ * a disclaimer that shrinks: the reader is told enough to trust the number and
+ * not enough to date it.
+ *
+ * @param {{dirtySeconds: number, spanSeconds: number, closedDirtySeconds: number,
+ *   closedSpanSeconds: number}} e Exposure totals.
+ * @param {boolean} headClean Whether the newest commit is compliant.
+ * @param {number} [idleSeconds] Idle interval to project the drift over.
+ * @returns {{open: number, closed: number, driftPoints: number, direction: string}}
+ */
+export function exposureDrift(e, headClean, idleSeconds = 30 * 86400) {
+  const pct = (n, d) => (d > 0 ? (n / d) * 100 : 0);
+  const open = pct(e.dirtySeconds, e.spanSeconds);
+  const later = pct(
+    headClean ? e.dirtySeconds : e.dirtySeconds + idleSeconds,
+    e.spanSeconds + idleSeconds,
+  );
+  return {
+    open,
+    closed: pct(e.closedDirtySeconds, e.closedSpanSeconds),
+    driftPoints: later - open,
+    direction: headClean ? 'falls' : 'climbs',
+  };
 }
 
 /**
@@ -269,8 +323,18 @@ function main() {
   const git = (args) =>
     execFileSync('git', args, { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
 
-  const { examined, dirty, refs, lastDirty, headClean, dirtySeconds, spanSeconds, shape } =
-    censusHistory(git, ref);
+  const {
+    examined,
+    dirty,
+    refs,
+    lastDirty,
+    headClean,
+    dirtySeconds,
+    spanSeconds,
+    closedDirtySeconds: closedDirty,
+    closedSpanSeconds: closedSpan,
+    shape,
+  } = censusHistory(git, ref);
 
   if (examined === 0) {
     console.log(`No commits touching .github/workflows found on ${ref}.`);
@@ -279,6 +343,19 @@ function main() {
 
   const percent = ((dirty / examined) * 100).toFixed(1);
   const timePercent = spanSeconds > 0 ? ((dirtySeconds / spanSeconds) * 100).toFixed(1) : '0.0';
+  const drift = exposureDrift(
+    { dirtySeconds, spanSeconds, closedDirtySeconds: closedDirty, closedSpanSeconds: closedSpan },
+    headClean,
+  );
+  const closedPercent = drift.closed.toFixed(1);
+  if (spanSeconds > 0 && closedSpan === 0 && examined > 1) {
+    // A closed span of zero across more than one commit is not a clean history,
+    // it is an unwired statistic. The first draft of this figure printed
+    // `0h of 0h (0.0%)` because censusHistory never returned the fields, and
+    // nothing distinguished that from a genuine zero.
+    throw new Error('closed exposure span is zero across multiple commits');
+  }
+  const asOf = new Date().toISOString().replace(/\.\d+Z$/, 'Z');
   console.log(`Workflow pin history for ${ref}:`);
   console.log(`  commits examined            ${examined}`);
   console.log(`  commits with >=1 unpinned   ${dirty} (${percent}%)`);
@@ -286,6 +363,13 @@ function main() {
   console.log(
     `  time in a non-compliant state ${humanDuration(dirtySeconds)} of ${humanDuration(spanSeconds)} (${timePercent}%)`,
   );
+  console.log(
+    `    closed history only         ${humanDuration(closedDirty)} of ${humanDuration(closedSpan)} (${closedPercent}%)`,
+  );
+  console.log(
+    `    open figure ${drift.direction} ${Math.abs(drift.driftPoints).toFixed(1)} pts per 30 idle days`,
+  );
+  console.log(`    as of                       ${asOf}`);
   console.log(`  working tree at ${ref}      ${headClean ? 'clean' : 'UNPINNED REFS PRESENT'}`);
   console.log(`  non-compliant episodes      ${shape.episodes.length}`);
   console.log(`  state transitions           ${shape.transitions}`);
@@ -315,6 +399,13 @@ function main() {
   console.log('the same seven lapses may be seven minutes or four days of exposure. The');
   console.log('time figures close that gap, and are measured against wall-clock now, so');
   console.log('the final interval grows until the next commit touching this directory.');
+  console.log('');
+  console.log('That makes the open percentage a function of the reading time as well as');
+  console.log('of the history: a clean HEAD freezes the numerator while the denominator');
+  console.log('grows, so the figure improves while nobody does anything, and an unpinned');
+  console.log('HEAD makes it worsen the same way. A difference between two runs of this');
+  console.log('tool is therefore not by itself evidence that anything changed. The closed');
+  console.log('figure stops at the newest commit and is a function of history alone.');
   console.log('');
   console.log('A duration is in turn silent about shape. Eighty-nine non-compliant');
   console.log('commits may be eighty-nine regressions or three episodes, and only the');

--- a/tools/check-workflow-pin-history.test.mjs
+++ b/tools/check-workflow-pin-history.test.mjs
@@ -9,6 +9,7 @@ import {
   humanDuration,
   unpinnedRefs,
   episodes,
+  exposureDrift,
 } from './check-workflow-pin-history.mjs';
 
 const SHA = 'a'.repeat(40);
@@ -218,7 +219,12 @@ test('exposure distinguishes many brief lapses from one long one', () => {
 });
 
 test('exposure is zero over an empty history rather than NaN', () => {
-  assert.deepEqual(exposure([], T0), { dirtySeconds: 0, spanSeconds: 0 });
+  assert.deepEqual(exposure([], T0), {
+    dirtySeconds: 0,
+    spanSeconds: 0,
+    closedDirtySeconds: 0,
+    closedSpanSeconds: 0,
+  });
 });
 
 test('exposure never charges negative time for out-of-order timestamps', () => {
@@ -404,4 +410,136 @@ test('episode seconds sum to the exposure measured independently', () => {
   const total = episodes(states, 1100).episodes.reduce((s, e) => s + e.seconds, 0);
   assert.equal(total, exposure(states, 1100).dirtySeconds);
   assert.equal(total, 400);
+});
+
+// ---------------------------------------------------------------------------
+// The open figure is a function of the reading time, not only of the history.
+//
+// A sibling repository published this percentage twice with no commits between
+// the runs and a different value each time. Same cause here: the newest
+// interval and the span both end at "now", so a clean HEAD freezes the
+// numerator while the denominator grows.
+//
+// These are synthetic on purpose. The live tree cannot discriminate today --
+// its newest workflow commit landed minutes ago, so the closed and open spans
+// differ by 455 seconds and any error in either would be invisible. A tree is
+// a fixture nobody chose, and this one was made non-discriminating by the
+// commit that shipped the previous checker.
+// ---------------------------------------------------------------------------
+
+const IDLE_DAY = 86400;
+// newest first: clean at IDLE_DAY 10, dirty from IDLE_DAY 2 to IDLE_DAY 10, clean at IDLE_DAY 0.
+const CLEAN_HEAD = [
+  { at: 10 * IDLE_DAY, bad: false },
+  { at: 2 * IDLE_DAY, bad: true },
+  { at: 0, bad: false },
+];
+const DIRTY_HEAD = [
+  { at: 10 * IDLE_DAY, bad: true },
+  { at: 2 * IDLE_DAY, bad: true },
+  { at: 0, bad: false },
+];
+
+test('the open percentage falls as a clean tree idles', () => {
+  const early = exposure(CLEAN_HEAD, 11 * IDLE_DAY);
+  const late = exposure(CLEAN_HEAD, 40 * IDLE_DAY);
+  assert.equal(early.dirtySeconds, late.dirtySeconds, 'numerator must be frozen');
+  assert.ok(late.spanSeconds > early.spanSeconds, 'denominator must grow');
+  assert.ok(
+    late.dirtySeconds / late.spanSeconds < early.dirtySeconds / early.spanSeconds,
+    'a repaired tree improves its own score by waiting',
+  );
+});
+
+test('the open percentage climbs as an unpinned tree idles', () => {
+  const early = exposure(DIRTY_HEAD, 11 * IDLE_DAY);
+  const late = exposure(DIRTY_HEAD, 40 * IDLE_DAY);
+  assert.ok(late.dirtySeconds > early.dirtySeconds, 'numerator must grow');
+  assert.ok(
+    late.dirtySeconds / late.spanSeconds > early.dirtySeconds / early.spanSeconds,
+    'both directions must be exercised: only one of them flatters',
+  );
+});
+
+test('the closed figure does not move with the reading time', () => {
+  const early = exposure(CLEAN_HEAD, 11 * IDLE_DAY);
+  const late = exposure(CLEAN_HEAD, 400 * IDLE_DAY);
+  assert.equal(early.closedDirtySeconds, late.closedDirtySeconds);
+  assert.equal(early.closedSpanSeconds, late.closedSpanSeconds);
+  assert.equal(early.closedSpanSeconds, 10 * IDLE_DAY, 'closed span is newest commit minus oldest');
+});
+
+test('the closed figure differs from the open one once a tree idles', () => {
+  // Guards the wiring, not the arithmetic: the first draft printed
+  // `0h of 0h (0.0%)` because censusHistory never returned these fields, and
+  // a zero over an empty population renders exactly like a real zero.
+  //
+  // Asserted as exact values, not as `notEqual`. A mutant that never accrued
+  // closed time survived a notEqual here, because zero is also unequal to the
+  // open figure -- an inequality distinguishes a value from exactly one other.
+  const e = exposure(CLEAN_HEAD, 40 * IDLE_DAY);
+  assert.equal(e.closedDirtySeconds, 8 * IDLE_DAY, 'dirty ran day 2 to day 10');
+  assert.equal(e.closedSpanSeconds, 10 * IDLE_DAY);
+  assert.equal(e.dirtySeconds, 8 * IDLE_DAY);
+  assert.equal(e.spanSeconds, 40 * IDLE_DAY);
+});
+
+test('the closed figure excludes the open interval when HEAD is unpinned', () => {
+  // The discriminating case for the open/closed split: with a clean HEAD the
+  // open interval contributes nothing to the numerator either way, so a mutant
+  // charging it to the closed total is invisible.
+  const e = exposure(DIRTY_HEAD, 40 * IDLE_DAY);
+  assert.equal(e.closedDirtySeconds, 8 * IDLE_DAY, 'closed stops at the newest commit');
+  assert.equal(e.dirtySeconds, 38 * IDLE_DAY, 'open charges the 30 idle days too');
+});
+
+test('the drift report carries the closed figure, not the open one twice', () => {
+  const e = exposure(CLEAN_HEAD, 40 * IDLE_DAY);
+  const d = exposureDrift(e, true, 30 * IDLE_DAY);
+  assert.equal(d.closed.toFixed(1), '80.0', 'closed is 8 of 10 days');
+  assert.equal(d.open.toFixed(1), '20.0', 'open is 8 of 40 days');
+});
+
+test('closed span is never negative for out-of-order timestamps', () => {
+  const e = exposure(
+    [
+      { at: 0, bad: true },
+      { at: 5 * IDLE_DAY, bad: false },
+    ],
+    9 * IDLE_DAY,
+  );
+  assert.ok(e.closedSpanSeconds >= 0, `negative closed span: ${e.closedSpanSeconds}`);
+});
+
+test('drift is reported with a direction and it tracks head state', () => {
+  const e = exposure(CLEAN_HEAD, 11 * IDLE_DAY);
+  const clean = exposureDrift(e, true, 30 * IDLE_DAY);
+  const dirty = exposureDrift(e, false, 30 * IDLE_DAY);
+  assert.equal(clean.direction, 'falls');
+  assert.equal(dirty.direction, 'climbs');
+  assert.ok(clean.driftPoints < 0, `expected negative drift, got ${clean.driftPoints}`);
+  assert.ok(dirty.driftPoints > 0, `expected positive drift, got ${dirty.driftPoints}`);
+});
+
+test('drift over zero idle time is zero', () => {
+  const e = exposure(CLEAN_HEAD, 11 * IDLE_DAY);
+  assert.equal(exposureDrift(e, true, 0).driftPoints, 0);
+});
+
+test('an empty history yields all four totals rather than two', () => {
+  const e = exposure([], 100);
+  assert.deepEqual(e, {
+    dirtySeconds: 0,
+    spanSeconds: 0,
+    closedDirtySeconds: 0,
+    closedSpanSeconds: 0,
+  });
+});
+
+test('a single-commit history has a closed span of zero', () => {
+  // The only case where `0h of 0h` is honest, and the reason the report guards
+  // on `examined > 1` rather than on the span alone.
+  const e = exposure([{ at: 5 * IDLE_DAY, bad: true }], 9 * IDLE_DAY);
+  assert.equal(e.closedSpanSeconds, 0);
+  assert.ok(e.spanSeconds > 0);
 });


### PR DESCRIPTION
## Summary

A compliance percentage whose final interval ends at the reading time is a function of when it was read, not only of the history it describes.

A sibling session published its pinning exposure twice — `56.8% of 5d 1.2h` then `55.7% of 5d 4h` — with the same commits and no push. Measured the same here:

| reading time | exposure |
| --- | --- |
| today | **39.2%** |
| +30 idle days | 33.0% |
| +365 idle days | **12.0%** |

Nothing happens in any row. A clean HEAD freezes the numerator while the denominator grows, so **the repo improves its own score by waiting**.

The scope note already said the final interval "grows until the next commit." True, deliberate, and it states the mechanism while omitting the consequence — that the percentage moves, and which way. Same false-assurance polarity as a disclaimer that shrinks.

## Changes

- `exposure()` returns `closedDirtySeconds` / `closedSpanSeconds`, measured to the newest commit
- new `exposureDrift()` — points per 30 idle days, with a direction
- report prints the closed figure, the drift line, and an `as of <ISO>` stamp
- throws when a closed span is zero across >1 commit: an unwired statistic, not a clean history
- guide section

## Notes

The first wiring printed `closed history only 0h of 0h (0.0%)` — a new statistic reading exactly zero, rendered identically to a real zero, in a tool about misleading figures. Hence the guard.

The open/closed gap on this tree is **455 seconds**, because the newest workflow commit is the previous PR in this session. Every discriminating assertion is therefore synthetic: a tree is a fixture nobody chose, and this one was made non-discriminating by my own last commit.

Four mutants survived the first suite, all needing a dirty HEAD. One survived `assert.notEqual(closed, open)` because zero is also unequal to the open figure — **an inequality distinguishes a value from exactly one other**.

## Issues

Closes #4283
Refs #4029

## Testing

- [x] 56/56 tests, 10/10 mutants killed
- [x] format:check, eslint --max-warnings 0, type-check
- [x] all 13 gates