### PR TITLE
fix(tools): key the citation exemption to ownership, not presence or basename (#4281)

### DIFF
--- a/tools/check-ai-manifest.js
+++ b/tools/check-ai-manifest.js
@@ -635,9 +635,11 @@ const CANON_CITATIONS = [
 //   detector covered              .mjs
 //   overlap                       NONE
 //
-// So `AGENTS.md:120` or `agency.toml:14` -- a coordinate into a file this repo is SENT, and which
+// So a coordinate into `AGENTS.md` or `agency.toml` -- a file this repo is SENT, and which
 // therefore moves under it without warning -- was invisible, twice over: the extension was not
-// listed, and the leading `[a-z]` also excluded every capitalised basename.
+// listed, and the leading `[a-z]` also excluded every capitalised basename. (Those two paths are
+// named without offsets deliberately: this comment is inside the corpus the rule scans, and the
+// rule now reaches them, so stating them as coordinates would be the tool violating itself.)
 //
 // The expected count of this rule is zero, which is what hid it. A detector that matches nothing
 // and a corpus that contains nothing print the identical clean line, and on a prohibition that
@@ -645,21 +647,22 @@ const CANON_CITATIONS = [
 const COORDINATE = /\b[A-Za-z0-9_][A-Za-z0-9_./-]*\.[A-Za-z][A-Za-z0-9]{0,9}:\d+(?:-\d+)?/g;
 
 /**
- * Report coordinate citations of files this repository does not contain.
+ * Report coordinate citations of files this repository does not own.
  *
  * @param {string} text Prose to inspect.
  * @param {object[]} citations Registry rows to validate.
- * @param {(p: string) => boolean} isLocal True when the cited path exists here. A self-reference
- *   moves with the edit that moves it, so only cross-repo coordinates decay unnoticed.
- * @returns {string[]} Findings; empty when no coordinate cites another repository.
+ * @param {(p: string) => boolean} isLocallyOwned True when the cited path is BOTH present here and
+ *   authored here. A self-reference moves with the edit that moves it; a coordinate into a file
+ *   this repo merely receives moves when the backbone re-delivers it, with no local edit (#4281).
+ * @returns {string[]} Findings; empty when no coordinate cites a file this repo does not own.
  */
-function citationFindings(text, citations = CANON_CITATIONS, isLocal = () => false) {
+function citationFindings(text, citations = CANON_CITATIONS, isLocallyOwned = () => false) {
   const findings = [];
   for (const match of text.match(COORDINATE) || []) {
-    if (isLocal(match.split(':')[0].replace(/^\.\//, ''))) continue;
+    if (isLocallyOwned(match.split(':')[0].replace(/^\.\//, ''))) continue;
     findings.push(
-      `cites another repository by line number, which decays unnoticed: ${match} — ` +
-        `name the symbol and register it in CANON_CITATIONS instead`,
+      `cites a file this repository does not own by line number, which decays unnoticed: ` +
+        `${match} — name the symbol and register it in CANON_CITATIONS instead`,
     );
   }
   if (!citations.length) {
@@ -719,14 +722,16 @@ function citationCorpus() {
  * Apply the coordinate rule across every claimant file, and state the population it covered.
  *
  * @param {{path: string, text: string}[]} corpus Claimant files.
- * @param {(p: string) => boolean} isLocal True when a cited path exists in this repository.
+ * @param {(p: string) => boolean} isLocallyOwned True when a cited path is present here AND
+ *   authored here, so the coordinate cannot move without a local edit.
  * @returns {{findings: string[], scanned: number}} Findings, and how many files were read.
  */
-function citationCoverage(corpus, isLocal) {
+function citationCoverage(corpus, isLocallyOwned) {
   const findings = [];
   for (const { path: relPath, text } of corpus) {
-    for (const finding of citationFindings(text, CANON_CITATIONS, isLocal)) {
-      if (finding.startsWith('cites another repository')) findings.push(`${relPath}: ${finding}`);
+    for (const finding of citationFindings(text, CANON_CITATIONS, isLocallyOwned)) {
+      if (finding.startsWith('cites a file this repository does not own'))
+        findings.push(`${relPath}: ${finding}`);
     }
   }
   // A zero here is only meaningful beside the number of files it was computed from. Emitted by
@@ -748,7 +753,30 @@ const ENFORCEMENT_STEP = 'Check for drift';
 const SYNC_LOCK = '.studio-sync.lock.json';
 
 /**
- * Run the coordinate rule over every claimant file, resolving locality against the walk.
+ * Paths this repository receives from the backbone rather than authors.
+ *
+ * Read from the lock at check time rather than listed here, so the set cannot drift from the
+ * delivered surface: a target added by a future sync is covered with nothing to update (#4281).
+ *
+ * @returns {Set<string>} Managed target paths; empty when the lock is absent or unreadable.
+ */
+function managedTargets() {
+  try {
+    const lock = JSON.parse(fs.readFileSync(path.join(ROOT, SYNC_LOCK), 'utf8'));
+    return new Set(Object.keys(lock.entries ?? lock));
+  } catch {
+    return new Set();
+  }
+}
+
+/**
+ * Run the coordinate rule over every claimant file, resolving OWNERSHIP against the walk.
+ *
+ * The exemption was keyed to presence and then widened to basename, while its stated reason was
+ * that a self-reference moves with the edit that moves it. Both widenings outran that reason:
+ * 81 managed targets are present but remotely owned, and a basename match exempted paths this
+ * repo does not contain at all (`sync/README.md:N` passed because finance has READMEs). Measured
+ * before the fix: 2 of 2 coordinates in the corpus were exempted, and both were managed (#4281).
  *
  * @returns {{findings: string[], scanned: number}} Findings and the population they came from.
  */
@@ -756,9 +784,9 @@ function validateCitationCoverage() {
   const present = new Set(
     walkFiles(ROOT).map((file) => path.relative(ROOT, file).split(path.sep).join('/')),
   );
-  const byBase = new Set([...present].map((relPath) => relPath.split('/').pop()));
-  const isLocal = (cited) => present.has(cited) || byBase.has(cited.split('/').pop());
-  return citationCoverage(citationCorpus(), isLocal);
+  const managed = managedTargets();
+  const isLocallyOwned = (cited) => present.has(cited) && !managed.has(cited);
+  return citationCoverage(citationCorpus(), isLocallyOwned);
 }
 
 /**
@@ -1470,8 +1498,9 @@ function main() {
   // the count of files scanned distinguishes them (#4270).
   const citations = validateCitationCoverage();
   process.stdout.write(
-    `Cross-repo citations: ${citations.findings.length} coordinate(s) in ` +
-      `${citations.scanned} file(s) making backbone claims\n\n`,
+    `Unowned-file citations: ${citations.findings.length} coordinate(s) in ` +
+      `${citations.scanned} file(s) making backbone claims; ` +
+      `${managedTargets().size} received target(s) count as unowned\n\n`,
   );
 
   const scan = scanDocs(counts);
@@ -1606,6 +1635,7 @@ module.exports = {
   verifySourceReproduction,
   KNOWN_UNREPRODUCED,
   CANON_CITATIONS,
+  managedTargets,
   ENFORCEMENT_WORKFLOW,
   driftEnforcement,
   enforcementFindings,

--- a/tools/check-ai-manifest.test.mjs
+++ b/tools/check-ai-manifest.test.mjs
@@ -50,6 +50,7 @@ const {
   EXPECTED_AGENTS,
   MANAGED_COUNTS,
   citationFindings,
+  managedTargets,
   citationCorpus,
   validateCitationCoverage,
   BACKBONE_CLAIM,
@@ -538,10 +539,10 @@ test('the disclosure names every path and never collapses to a count', () => {
 // described needs the network at check time (#4141, owner-gated). What is checkable offline is
 // that no citation reverts to a coordinate and that every registered row is complete.
 
-test('no tracked file cites another repository by line number', () => {
+test('no tracked file cites a file this repository does not own by line number', () => {
   // Was: this one file. The rule now runs over every file that makes a backbone claim, with
-  // locality resolved against the walk, so a self-reference is exempt and a cross-repo
-  // coordinate is not (#4270).
+  // OWNERSHIP resolved against the walk and the lock, so a self-reference is exempt and a
+  // coordinate into a received target is not (#4270, narrowed in #4281).
   const { findings } = validateCitationCoverage();
   assert.deepEqual(
     findings,
@@ -1227,15 +1228,15 @@ test('a constructed cross-repo coordinate reaches the report, not just the funct
     } catch (error) {
       out = String(error.stdout || '');
     }
-    assert.match(out, /Cross-repo citations: 1 coordinate\(s\) in \d+ file\(s\)/);
-    assert.match(out, /\[DRIFT\] PROBE-4270\.md: cites another repository by line number/);
+    assert.match(out, /Unowned-file citations: 1 coordinate\(s\) in \d+ file\(s\)/);
+    assert.match(out, /\[DRIFT\] PROBE-4270\.md: cites a file this repository does not own/);
   } finally {
     fs.unlinkSync(probe);
   }
   const clean = execFileSync(process.execPath, [TOOL], { encoding: 'utf8' });
-  assert.match(clean, /Cross-repo citations: 0 coordinate\(s\) in \d+ file\(s\)/);
+  assert.match(clean, /Unowned-file citations: 0 coordinate\(s\) in \d+ file\(s\)/);
   assert.ok(
-    clean.indexOf('Cross-repo citations:') < clean.indexOf('Canonical runtime activation:'),
+    clean.indexOf('Unowned-file citations:') < clean.indexOf('Canonical runtime activation:'),
     'the population must be stated before the verdict it qualifies',
   );
 });
@@ -1318,4 +1319,143 @@ test('the report states how many validators ran against how many it advertises (
   assert.ok(line, 'the report must disclose the validator populations');
   assert.equal(line[1], line[2], 'advertised and run must agree');
   assert.equal(Number(line[2]), Object.keys(activationRunners({})).length);
+});
+
+// --- #4281: the exemption is keyed to OWNERSHIP, not presence and not basename ----------------
+//
+// Every state below is CONSTRUCTED. The live corpus contains zero coordinates, so a test that
+// merely ran the corpus would pass under all of the mutations these pin -- the same concealing
+// zero that hid the narrow detector in #4270.
+const ownedOnly = (present, managed) => (cited) => present.has(cited) && !managed.has(cited);
+
+test('a coordinate into a received file is reported though the path is present here (#4281)', () => {
+  // The exemption's stated reason is that a self-reference moves with the edit that moves it.
+  // A managed target moves when the BACKBONE re-delivers it: present, but not owned.
+  const present = new Set(['AGENTS.md', 'agency.toml', 'tools/check-ai-manifest.js']);
+  const managed = new Set(['AGENTS.md', 'agency.toml']);
+  const findings = citationFindings(
+    `see ${at('AGENTS.md', 120)} and ${at('agency.toml', 14)}`,
+    CANON_CITATIONS,
+    ownedOnly(present, managed),
+  ).filter((f) => f.startsWith('cites a file'));
+  assert.equal(findings.length, 2, 'both received coordinates must be reported');
+  assert.ok(findings.some((f) => f.includes(at('AGENTS.md', 120))));
+  assert.ok(findings.some((f) => f.includes(at('agency.toml', 14))));
+});
+
+test('a coordinate is not exempted by a basename collision with an unrelated file (#4281)', () => {
+  // `sync/README.md` does not exist here at all. The old predicate exempted it because finance
+  // has files named README.md -- suppressing a coordinate into a path this repo does not contain,
+  // which is the literal case the function's docstring says it reports.
+  const present = new Set(['docs/README.md', 'apps/web/README.md']);
+  const findings = citationFindings(
+    `see ${at('sync/README.md', 12)}`,
+    CANON_CITATIONS,
+    ownedOnly(present, new Set()),
+  ).filter((f) => f.startsWith('cites a file'));
+  assert.equal(findings.length, 1, 'a basename match is not a path match');
+  assert.ok(findings[0].includes(at('sync/README.md', 12)));
+});
+
+test('a coordinate into a locally authored file stays exempt (#4281)', () => {
+  // The counter-state. Narrowing an exemption must not become deleting it: a self-reference
+  // really does move with the edit that moves it, and reporting it would be noise.
+  const present = new Set(['tools/check-ai-manifest.js', 'docs/ai/README.md']);
+  const managed = new Set(['AGENTS.md']);
+  const findings = citationFindings(
+    `see ${at('tools/check-ai-manifest.js', 100)} and ${at('docs/ai/README.md', 82)}`,
+    CANON_CITATIONS,
+    ownedOnly(present, managed),
+  ).filter((f) => f.startsWith('cites a file'));
+  assert.deepEqual(findings, [], 'owned self-references must not be reported');
+});
+
+test('the received set is read from the lock, not written down beside the rule (#4281)', () => {
+  // Independent enumeration, per #4278: the set the rule consults is compared against the lock
+  // on disk rather than against itself, so a hardcoded or emptied set is visible.
+  const lock = JSON.parse(fs.readFileSync(path.join(ROOT, '.studio-sync.lock.json'), 'utf8'));
+  const recorded = Object.keys(lock.entries ?? lock);
+  const managed = managedTargets();
+  assert.ok(recorded.length > 20, 'PREMISE: the lock records a non-trivial delivered surface');
+  assert.equal(managed.size, recorded.length, 'every recorded target counts as received');
+  for (const entry of recorded)
+    assert.ok(managed.has(entry), `missing from received set: ${entry}`);
+});
+
+test('this tool states received paths without offsets, as its own rule requires (#4281)', () => {
+  // The two coordinates this comment block used as EXAMPLES were the only two the corpus ever
+  // contained, and the old exemption hid both. With the rule repaired they would be findings,
+  // so the prose names the files without offsets -- the tool complying with itself.
+  const source = fs.readFileSync(TOOL, 'utf8');
+  const managed = managedTargets();
+  const owned = (cited) => !managed.has(cited);
+  const findings = citationFindings(source, CANON_CITATIONS, owned).filter((f) =>
+    f.startsWith('cites a file'),
+  );
+  assert.deepEqual(findings, [], 'this tool must not cite a received file by line number');
+});
+
+test('the report states the received population the exemption depends on (#4281)', () => {
+  // The count of files scanned made a zero meaningful (#4270); the size of the exempted set is
+  // the other half, because a silently empty received set restores the defect at a clean zero.
+  const out = execFileSync(process.execPath, [TOOL], { encoding: 'utf8' });
+  const line = out.match(
+    /Unowned-file citations: (\d+) coordinate\(s\) in (\d+) file\(s\)[^;]*; (\d+) received/,
+  );
+  assert.ok(line, 'the report must state coordinates, corpus size and received-set size');
+  assert.ok(Number(line[2]) > 10, 'the corpus must be non-trivial');
+  assert.equal(Number(line[3]), managedTargets().size);
+  assert.ok(Number(line[3]) > 20, 'an empty received set would silently restore the exemption');
+});
+test('the PRODUCTION predicate, not a test copy, distinguishes owned from received (#4281)', () => {
+  // DISCLOSURE: the three tests above build their own `ownedOnly` and hand it in, so they pin the
+  // CONTRACT of citationFindings and say nothing about the predicate validateCitationCoverage
+  // actually constructs. Reverting that predicate -- restoring the basename widening, or dropping
+  // the ownership conjunct -- survived the whole suite at 0 failures. A test that re-implements
+  // the thing it is checking is the mutant-F hazard with the operands swapped.
+  //
+  // So this constructs the state on disk and runs the real walk: one coordinate into a RECEIVED
+  // target (present here, owned upstream) and one into a path this repo does not contain whose
+  // basename collides with local files. Both must be reported by the production code path.
+  const probe = path.join(ROOT, 'PROBE-4281.md');
+  // Non-dotfile, no `@`: the coordinate pattern begins on a word character, so a received target
+  // like `.github/agents/x.agent.md` is still REPORTED but with its leading dot trimmed from the
+  // message. That truncation is cosmetic and out of scope here; this test avoids depending on it.
+  const received = [...managedTargets()].find(
+    (entry) => entry.endsWith('.md') && !entry.startsWith('.') && !entry.includes('@'),
+  );
+  assert.ok(received, 'PREMISE: the lock records a received markdown target to cite');
+  assert.ok(
+    fs.existsSync(path.join(ROOT, received)),
+    'PREMISE: that target is PRESENT here, so only ownership can distinguish it',
+  );
+  const collides = 'sync/README.md';
+  assert.ok(!fs.existsSync(path.join(ROOT, collides)), 'PREMISE: the colliding path is absent');
+  assert.ok(
+    fs.existsSync(path.join(ROOT, 'README.md')),
+    'PREMISE: a file with the same basename exists, so the old widening would exempt it',
+  );
+  fs.writeFileSync(
+    probe,
+    `Backbone note: jrmoulckers/.github at ${at(received, 3)} and ${at(collides, 12)}.\n`,
+  );
+  try {
+    const { findings } = validateCitationCoverage();
+    const text = findings.join('\n');
+    assert.ok(
+      text.includes(at(received, 3)),
+      'a coordinate into a received target must be reported though the path is present',
+    );
+    assert.ok(
+      text.includes(at(collides, 12)),
+      'a basename collision must not exempt a path this repo does not contain',
+    );
+  } finally {
+    fs.unlinkSync(probe);
+  }
+  assert.deepEqual(
+    validateCitationCoverage().findings,
+    [],
+    'the tree is clean once the probe is gone',
+  );
 });


### PR DESCRIPTION
## Summary

The self-reference exemption in the coordinate rule was keyed to **presence**, then widened again to **basename**, while its stated reason is about **ownership**:

> A self-reference moves with the edit that moves it, so only cross-repo coordinates decay unnoticed.

Both widenings outran that reason.

```
tracked 5543 | distinct basenames 4939 | managed lock entries 81

EXEMPT    sync/README.md:12    <- BASENAME COLLISION ONLY; this path does not exist here
EXEMPT    AGENTS.md:120        <- present, but received from the backbone
EXEMPT    agency.toml:14       <- present, but received from the backbone
REPORTED  sync/lib/lock.mjs:57
REPORTED  studio.config.json:9
```

A received target moves when the backbone re-delivers it — no local edit, no warning — which is exactly the decay the rule exists for. And `sync/README.md:12` names a file this repo does not contain, suppressed because finance has READMEs, contradicting the function's own docstring.

## Measured

```
corpus files                                    72
coordinates the pattern found                    2
exempted by isLocal                              2   (100%)
...of which cite a received target               2   (100%)
```

Both were the examples my own comment used to argue such coordinates "move under it without warning". #4270 widened the detector to see them; the exemption added in the same PR re-hid exactly them. The two halves cancelled and the tool printed a clean zero.

Live genuine violations: **0**. Another expected-zero — the point is the guard could not fire, not that there was a backlog.

## Changes

- Exemption is now `present.has(cited) && !managed.has(cited)`; the `byBase` widening is deleted.
- `managedTargets()` reads the received set from `.studio-sync.lock.json` at check time, so it cannot drift from the delivered surface.
- Predicate and docstrings renamed to say *own*, not *contain*; finding text and the report label follow.
- The report now states the received-set size, because a silently empty one restores the exemption at a clean zero.
- This tool's own prose now names those two paths without offsets — the tool complying with its own rule.

## Disclosure

My first three tests **built their own `ownedOnly` predicate and handed it in**. So they pinned the contract of `citationFindings` and said nothing about the predicate `validateCitationCoverage` constructs — and the two mutants that **revert this entire fix** survived the suite at 0 failures:

```
A  restore the basename widening        0 FAIL   <- SURVIVED
B  drop the ownership conjunct          0 FAIL   <- SURVIVED
```

A test that re-implements the thing it checks is the equivalent-mutant hazard with the operands swapped. Repaired by constructing the state on disk and running the real walk end-to-end, following this suite's existing probe-file pattern.

Also disclosed, not fixed: the coordinate pattern begins on a word character, so a received target like `.github/agents/x.agent.md` is still reported but with its leading dot trimmed from the message. Cosmetic, no false negative, out of scope.

## Controls

6 mutants, **all killed by distinct failing test name** after the repair:

| | mutation | before | after |
|---|---|---|---|
| A | restore the basename widening | SURVIVED (0) | KILLED (1) |
| B | drop the ownership conjunct | SURVIVED (0) | KILLED (1) |
| C | delete the exemption entirely | KILLED (2) | KILLED (2) |
| D | empty the received set | KILLED (2) | KILLED (3) |
| E | hardcode the received set | KILLED (2) | KILLED (2) |
| F | drop the received-set size from the report | KILLED (1) | KILLED (1) |

The harness now also refuses a mutation whose replacement leaves the file unchanged, after an earlier sweep reported a no-op as a survivor.

## Issues

Closes #4281

## Testing

- [x] `node --test tools/check-ai-manifest.test.mjs` — **83/83** (was 76)
- [x] `node tools/check-ai-manifest.js` — exit 0, `Unowned-file citations: 0 coordinate(s) in 72 file(s) making backbone claims; 81 received target(s) count as unowned`
- [x] `npx prettier --check` — clean on both touched files
- [x] `npx eslint … --max-warnings 0` — clean

Scope: this tool and its test only. No workflow, no `packages/design-tokens`, no vendored tokens, no lock edit.

## Provenance

Found by running a class reported by `jrmoulckers/.github` (#779): a falsifier licenses withdrawing the conjunct it touches, not the sentence containing it.