### PR TITLE
fix(tools): compose the trigger read-set from its producers (#4287)

### DIFF
--- a/tools/check-ai-manifest.js
+++ b/tools/check-ai-manifest.js
@@ -869,6 +869,36 @@ function triggerCovers(globs, file) {
   );
 }
 
+// Inputs named individually rather than counted, because each is a single self-referential file
+// whose wording carries the point: the guard reads the very file whose edit it cannot see.
+const NAMED_INPUTS = [ENFORCEMENT_WORKFLOW, SYNC_LOCK];
+
+/**
+ * Every repository path this check reads, composed from the validators that read it.
+ *
+ * Derived, not listed. The previous shape enumerated the two non-managed inputs by hand under a
+ * comment explaining that neither appears in the lock walk. That was true when written (#4251)
+ * and was outgrown three PRs later by the citation corpus (#4270), which walks the repository
+ * and reads 13 files that are neither managed entries nor named here — so the guard whose whole
+ * purpose is to notice unfireable inputs could not see ten of them (#4287).
+ *
+ * A hand list is correct on the day it is written and decays with no reader. Composing the set
+ * from its producers means a validator that starts reading new files is covered on arrival, with
+ * nothing to update and nothing to remember.
+ *
+ * @param {string[]} managedKeys Managed entry paths from the sync lock.
+ * @param {string[]} corpusPaths Repository-relative paths of the citation corpus.
+ * @returns {Map<string, string>} Path to the validator population that reads it.
+ */
+function checkInputs(managedKeys, corpusPaths) {
+  const inputs = new Map();
+  for (const key of managedKeys) inputs.set(key, 'managed entry');
+  // Read by validateEnforcementDoc and validateSyncLock respectively.
+  for (const file of NAMED_INPUTS) inputs.set(file, 'named input');
+  for (const file of corpusPaths) if (!inputs.has(file)) inputs.set(file, 'citation corpus');
+  return inputs;
+}
+
 /**
  * Report inputs this check reads that its own trigger cannot fire on.
  *
@@ -879,28 +909,39 @@ function triggerCovers(globs, file) {
  * workflow-only edit is precisely the change that guard exists to catch and precisely the change
  * that cannot trigger it (#4251).
  *
+ * Fails closed on an empty read-set: nothing to check and everything covered are the same verdict
+ * from a count alone, and only one of them is a report.
+ *
  * @param {string} workflowText Contents of the manifest-check workflow.
- * @param {string[]} managedKeys Managed entry paths from the sync lock.
+ * @param {Map<string, string>} inputs Read-set from `checkInputs`, path to population.
  * @returns {string[]} Findings; empty when every input is covered.
  */
-function triggerFindings(workflowText, managedKeys) {
+function triggerFindings(workflowText, inputs) {
   const read = triggerPaths(workflowText);
   if (read.error) return [`cannot read the trigger: ${read.error}`];
+  if (inputs.size === 0) return ['the read-set is empty, so trigger coverage is unverifiable'];
 
   const findings = [];
-  // Read by validateEnforcementDoc and validateSyncLock respectively. Named explicitly because
-  // neither is a managed entry, so neither appears in the lock walk below.
-  for (const file of [ENFORCEMENT_WORKFLOW, SYNC_LOCK]) {
-    if (!triggerCovers(read.globs, file)) {
+  const uncovered = [...inputs].filter(([file]) => !triggerCovers(read.globs, file));
+
+  for (const [file] of uncovered) {
+    if (NAMED_INPUTS.includes(file)) {
       findings.push(`${file} is read by this check but cannot trigger it`);
     }
   }
 
-  const uncovered = managedKeys.filter((key) => !triggerCovers(read.globs, key));
-  if (uncovered.length > 0) {
-    const groups = [...new Set(uncovered.map((key) => key.split('/').slice(0, 2).join('/')))];
+  const byPopulation = new Map();
+  for (const [file, population] of uncovered) {
+    if (NAMED_INPUTS.includes(file)) continue;
+    if (!byPopulation.has(population)) byPopulation.set(population, []);
+    byPopulation.get(population).push(file);
+  }
+
+  for (const [population, files] of byPopulation) {
+    const total = [...inputs.values()].filter((value) => value === population).length;
+    const groups = [...new Set(files.map((file) => file.split('/').slice(0, 2).join('/')))];
     findings.push(
-      `${uncovered.length} of ${managedKeys.length} managed entries cannot trigger this check ` +
+      `${files.length} of ${total} ${population} path(s) cannot trigger this check ` +
         `(${groups.join(', ')})`,
     );
   }
@@ -1457,7 +1498,11 @@ function validateTriggerCoverage() {
   if (!fs.existsSync(workflowPath)) return [`missing workflow: ${ENFORCEMENT_WORKFLOW}`];
   if (!fs.existsSync(lockPath)) return [`missing ${SYNC_LOCK}`];
   const lock = JSON.parse(fs.readFileSync(lockPath, 'utf8'));
-  return triggerFindings(fs.readFileSync(workflowPath, 'utf8'), Object.keys(lock.entries ?? lock));
+  const inputs = checkInputs(
+    Object.keys(lock.entries ?? lock),
+    citationCorpus().map((entry) => entry.path),
+  );
+  return triggerFindings(fs.readFileSync(workflowPath, 'utf8'), inputs);
 }
 
 /**
@@ -1649,6 +1694,7 @@ module.exports = {
   triggerPaths,
   triggerCovers,
   triggerFindings,
+  checkInputs,
   HELP_TEXT,
   VALIDATORS,
   dispatchValidators,

--- a/tools/check-ai-manifest.test.mjs
+++ b/tools/check-ai-manifest.test.mjs
@@ -42,6 +42,7 @@ const {
   triggerPaths,
   triggerCovers,
   triggerFindings,
+  checkInputs,
   METRICS,
   HELP_TEXT,
   VALIDATORS,
@@ -1001,10 +1002,14 @@ test('the workflow this check reads must be able to trigger it (#4251)', () => {
   const covering =
     "on:\n  pull_request:\n    paths:\n      - '.github/workflows/ai-manifest-check.yml'\n" +
     "      - '.studio-sync.lock.json'\n";
-  assert.deepEqual(triggerFindings(covering, []), [], 'fully covered inputs are not a finding');
+  assert.deepEqual(
+    triggerFindings(covering, checkInputs([], [])),
+    [],
+    'fully covered inputs are not a finding',
+  );
 
   const blind = "on:\n  pull_request:\n    paths:\n      - 'AGENTS.md'\n";
-  const findings = triggerFindings(blind, []);
+  const findings = triggerFindings(blind, checkInputs([], []));
   assert.equal(findings.length, 2);
   assert.ok(findings.some((f) => f.includes(ENFORCEMENT_WORKFLOW)));
   assert.ok(findings.some((f) => f.includes(SYNC_LOCK)));
@@ -1015,12 +1020,12 @@ test('uncovered managed entries are counted against the whole population (#4251)
     "on:\n  pull_request:\n    paths:\n      - '.github/workflows/ai-manifest-check.yml'\n" +
     "      - '.studio-sync.lock.json'\n      - '.github/agents/**'\n";
   const keys = ['.github/agents/a.md', 'vendor/@jrm/tokens/x.css', 'agency.toml'];
-  const findings = triggerFindings(globs, keys);
+  const findings = triggerFindings(globs, checkInputs(keys, []));
   assert.equal(findings.length, 1);
   // The denominator is the point: "2 uncovered" alone cannot be read without the population.
-  assert.match(findings[0], /2 of 3 managed entries/);
+  assert.match(findings[0], /2 of 3 managed entry path\(s\)/);
   assert.match(findings[0], /vendor\/@jrm/);
-  assert.deepEqual(triggerFindings(globs, ['.github/agents/a.md']), []);
+  assert.deepEqual(triggerFindings(globs, checkInputs(['.github/agents/a.md'], [])), []);
 });
 
 // --- #4256: a premise guard must live where a mutation can be seen -------------------------
@@ -1457,5 +1462,78 @@ test('the PRODUCTION predicate, not a test copy, distinguishes owned from receiv
     validateCitationCoverage().findings,
     [],
     'the tree is clean once the probe is gone',
+  );
+});
+
+// --- #4287: the read-set is composed from its producers, not enumerated -----------------------
+//
+// `triggerFindings` used to take the lock's managed keys plus two hand-named files. That list was
+// correct when written (#4251) and was outgrown by the citation corpus (#4270): ten files the
+// coordinate rule reads were neither managed nor named, so the guard whose purpose is to notice
+// unfireable inputs could not report them. These tests pin the composition, not the list.
+
+test('the read-set composes every producing population (#4287)', () => {
+  const inputs = checkInputs(['.github/agents/a.md'], ['README.md', '.github/agents/a.md']);
+  assert.equal(inputs.get('.github/agents/a.md'), 'managed entry', 'managed wins over corpus');
+  assert.equal(inputs.get('README.md'), 'citation corpus');
+  assert.equal(inputs.get(ENFORCEMENT_WORKFLOW), 'named input');
+  assert.equal(inputs.get(SYNC_LOCK), 'named input');
+});
+
+test('corpus files outside the trigger are reported against their own population (#4287)', () => {
+  const globs =
+    "on:\n  pull_request:\n    paths:\n      - '.github/workflows/ai-manifest-check.yml'\n" +
+    "      - '.studio-sync.lock.json'\n      - '.github/agents/**'\n";
+  // One corpus file covered, two not: the denominator must be the corpus, not the whole read-set,
+  // or a small uncovered count reads as reassuring against an inflated population.
+  const findings = triggerFindings(
+    globs,
+    checkInputs(['.github/agents/a.md'], ['.github/agents/a.md', 'README.md', 'PRODUCT.md']),
+  );
+  assert.equal(findings.length, 1);
+  assert.match(findings[0], /2 of 2 citation corpus path\(s\)/);
+  assert.match(findings[0], /README\.md/);
+});
+
+test('an empty read-set is unverifiable, never fully covered (#4287)', () => {
+  const globs = "on:\n  pull_request:\n    paths:\n      - 'AGENTS.md'\n";
+  const findings = triggerFindings(globs, new Map());
+  // Nothing to check and everything covered are the same verdict from a count alone. Only one of
+  // them is a report, so the empty case must not render as the clean one.
+  assert.equal(findings.length, 1);
+  assert.match(findings[0], /read-set is empty/);
+});
+
+test('the PRODUCTION walk, not a test list, supplies the corpus population (#4287)', () => {
+  // The call site is the claim. `checkInputs` accepting a corpus proves nothing about whether
+  // `validateTriggerCoverage` passes it one: the previous shape called triggerFindings with the
+  // lock keys alone and every unit test still passed. So this constructs a corpus file on disk,
+  // in a directory the trigger globs do not cover, and asserts the real validator reports it.
+  const probeDir = path.join(ROOT, 'docs', 'ops');
+  const probe = path.join(probeDir, 'PROBE-4287.md');
+  assert.ok(fs.existsSync(probeDir), 'PREMISE: the probe directory exists');
+  assert.ok(!fs.existsSync(probe), 'PREMISE: the probe path is free');
+
+  const before = activationRunners({}).triggerCoverage();
+  const corpusBefore = before.find((f) => f.includes('citation corpus'));
+
+  fs.writeFileSync(probe, '# probe\n\nA claim about jrmoulckers/.github and copier.mjs.\n');
+  try {
+    const after = activationRunners({}).triggerCoverage();
+    const corpusAfter = after.find((f) => f.includes('citation corpus'));
+    assert.ok(corpusAfter, 'the corpus population must be reported by the production validator');
+    assert.notEqual(
+      corpusAfter,
+      corpusBefore,
+      'a new uncovered corpus file must move the production count',
+    );
+    assert.match(corpusAfter, /docs\/ops/);
+  } finally {
+    fs.unlinkSync(probe);
+  }
+  assert.deepEqual(
+    activationRunners({}).triggerCoverage(),
+    before,
+    'the report returns once the probe is gone',
   );
 });

--- a/tools/check-ai-manifest.test.mjs
+++ b/tools/check-ai-manifest.test.mjs
@@ -1512,12 +1512,16 @@ test('the PRODUCTION walk, not a test list, supplies the corpus population (#428
   const probeDir = path.join(ROOT, 'docs', 'ops');
   const probe = path.join(probeDir, 'PROBE-4287.md');
   assert.ok(fs.existsSync(probeDir), 'PREMISE: the probe directory exists');
-  assert.ok(!fs.existsSync(probe), 'PREMISE: the probe path is free');
 
   const before = activationRunners({}).triggerCoverage();
   const corpusBefore = before.find((f) => f.includes('citation corpus'));
 
-  fs.writeFileSync(probe, '# probe\n\nA claim about jrmoulckers/.github and copier.mjs.\n');
+  // `wx` makes creation itself the existence check. Asserting the path is free and then writing
+  // it is a genuine TOCTOU race (CodeQL js/file-system-race) — the same finding `citationCorpus`
+  // resolved by taking one descriptor — and here it would also silently clobber a real file.
+  fs.writeFileSync(probe, '# probe\n\nA claim about jrmoulckers/.github and copier.mjs.\n', {
+    flag: 'wx',
+  });
   try {
     const after = activationRunners({}).triggerCoverage();
     const corpusAfter = after.find((f) => f.includes('citation corpus'));


### PR DESCRIPTION
## Summary

`triggerFindings` reports inputs this check reads that its own `pull_request.paths` trigger cannot fire on. Its population was the sync lock's managed entries plus **two hand-named files**, under a comment explaining that neither appears in the lock walk.

That list was correct when written (#4251). It was outgrown three PRs later by #4270, which added a citation corpus **derived** by walking the repository — and 13 of those files are neither managed entries nor named, so **10 uncovered files were unreportable** by the guard whose entire purpose is to notice unfireable inputs.

One tool, two populations: one derived, one transcribed. The transcribed one decays with no reader.

## Measurement

```
citation corpus                                  72 files
corpus files uncovered by the trigger globs      22
  of those, managed entries (already reported)   11
  of those, hand-named (already reported)         1
  INVISIBLE to triggerFindings                   10
```

Now reported, live, on every run:

```
[DRIFT] 10 of 13 citation corpus path(s) cannot trigger this check
        (.github/CONTRIBUTING.md, .github/SECURITY.md, .github/workflows,
         CODE_OF_CONDUCT.md, docs/architecture, docs/ops, PRODUCT.md,
         README.md, tools/check-workflow-security.mjs)
```

## Changes

- `checkInputs(managedKeys, corpusPaths)` composes the read-set from the populations that produce it and labels each path with its source. Managed wins over corpus, so a file in both keeps the stronger label.
- `triggerFindings` consumes that map and reports each uncovered population **against its own denominator** — a small uncovered count read against an inflated population is reassuring and wrong.
- Fails closed on an empty read-set. Nothing to check and everything covered are the same verdict from a count alone, and only one of them is a report.
- `validateTriggerCoverage` passes the real `citationCorpus()` walk.

## Controls

7 mutants, all killed, each verified by **failing test name** rather than count:

| | mutation | killed by |
| --- | --- | --- |
| A | corpus dropped from the read-set | composition + denominator + production |
| B | validator passes no corpus (the previous shape) | **production only** |
| C | fail-open on an empty read-set | vacuity |
| D | denominator becomes the whole read-set | denominator |
| E | `triggerCoverage` unwired from the dispatch | **production only** |
| F | corpus overwrites the managed label | composition |
| G | named inputs emptied | #4251 |

**B and E were killed by the production-path test alone.** Every unit test passed under both — a narrowed population and a fully unwired validator each ship green against tests that call the function directly. Testing the callee says nothing about the call site.

Disclosed: my first harness extracted failing test names with a TAP pattern the reporter does not emit, so the name column was empty and the count carried the whole verdict. Re-derived names in a second pass; the table above is from that pass.

## Issues

Closes #4287

## Out of scope

The workflow's `paths:` filter really is under-covering — the tool has reported that live since #4251 and reports more of it now. **Editing `.github/workflows/ai-manifest-check.yml` is human-gated and is deliberately not in this PR.** The globs a fix would need are exactly the paths printed above.

`packages/design-tokens` untouched. No workflow modified.

## Testing

- [x] `node --test tools/check-ai-manifest.test.mjs` — **87/87** (83 before)
- [x] `node tools/check-ai-manifest.js` — exit 0, `Validators: 7 advertised, 7 run`
- [x] `npx prettier --check` and `npx eslint --max-warnings 0` on both touched files
