### PR TITLE
test(tools): measure report-assertion coverage by mutation and retract the threshold-derived figure

### DIFF
--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -8269,6 +8269,11 @@ The measurement is heuristic -- it matches literal fragments between a tool and 
 loosely defined is the decoy pattern this guide warns about elsewhere; the census establishes
 that the population is large, and that is all it is being asked to do.
 
+> **RETRACTED.** The `64 / 4 / 60` triple above is withdrawn in full. It is not a fact about
+> this repository. See _Two instruments sharing a defect agree perfectly_ below for the
+> replacement figure and the method that produced it. The paragraph is kept rather than edited
+> because the retraction is the finding.
+
 ### The hazard was documented in a comment and still had no test
 
 `check-doc-links.mjs` printed two verdicts carrying both an occurrence count and a
@@ -8609,6 +8614,101 @@ something is not measuring what it claims to.**
 where the assertions checked the share and not the residual: over the wrong
 denominator the residual reads `6 point at a file that does not exist` instead of
 `0`, which is a plausible number naming nothing real.
+
+## Two instruments sharing a defect agree perfectly
+
+The upstream engineering session ran our report-assertion heuristic on its own tree and got
+`64 / 4 / 60` -- digit for digit, over a **different population** (theirs was not restricted to
+`main()`). Three matching integers across two definitions is not corroboration. It is a property
+of the shared instrument.
+
+Their sensitivity sweep on the one arbitrary constant, the minimum fragment length, settles it:
+
+| min fragment | 4   | 8   | 12  | 16  | 20  |
+| ------------ | --- | --- | --- | --- | --- |
+| matched      | 8   | 5   | 4   | 2   | 0   |
+
+The published `4` was the value at 12, a threshold chosen while writing the script and never
+mentioned. **A metric whose numerator swings from 8 to 0 across a constant nobody chose has no
+numerator.** What literal-fragment matching detects is whether a test happens to quote a static
+_label prefix_, which is uncorrelated with whether it asserts the interpolated _value_.
+
+Re-running the heuristic here reproduced neither figure: 36 sites, matched 3 to 1 across the same
+sweep, against the published 64 and 4. So the denominator was not stable either.
+
+This is the failure mode that cross-checking structurally cannot catch. Every earlier round in
+this exchange worked _because_ the two instruments differed. Here they did not, and the result was
+maximally convincing: agreement is the evidence both parties had been treating as strongest.
+
+### The replacement is a direct measurement
+
+`tools/check-report-assertions.mjs`. For each interpolation site on a report-building line,
+substitute a sentinel for the interpolated expression and re-run that tool's own test file. A
+green run means no test reads that value. There is no threshold.
+
+It has its own arbitrary constant -- the sentinel -- so it gets the same treatment. Swept `${0}`,
+`${-1}`, `${"MUTANT"}`, `${undefined}`: the caught **set**, not merely its cardinality, is
+identical across all four. That sweep is what would detect a site whose true value coincides with
+the sentinel, and it found none.
+
+The first sweep was worthless and said so anyway. The `SENTINEL` constant was read from `argv`,
+printed in the report, and echoed a different value on each of five runs -- but the substitution
+line still used a hard-coded `${0}`, because the string replacement that was supposed to wire it
+up silently matched nothing. Five runs, five sentinels printed, one measurement performed. **A
+parameter echoed in the report is not a parameter used in the computation**, and echoing it is
+what made the run look audited.
+
+### The number, and why the first version of it was also wrong
+
+| tool                                 | sites | caught | unasserted | `console.log` |
+| ------------------------------------ | ----- | ------ | ---------- | ------------- |
+| `check-doc-links.mjs`                | 30    | **30** | 0          | 0             |
+| `citations-context.mjs`              | 5     | 5      | 0          | 0             |
+| `check-citation-enumerations.mjs`    | 7     | **0**  | 7          | **0**         |
+| `check-report-assertions.mjs`        | 16    | 13     | 3          | 7             |
+| `check-test-independence.mjs`        | 7     | 5      | 2          | 5             |
+| `check-workflow-security.mjs`        | 23    | 8      | 15         | 8             |
+| `check-tool-imports.mjs`             | 12    | 3      | 9          | 6             |
+| `check-gradle-prefetch.mjs`          | 17    | 3      | 14         | 4             |
+| `check-node-version-consistency.mjs` | 50    | 9      | 41         | 6             |
+| `check-upstream-refs.mjs`            | 37    | 5      | 32         | 24            |
+| `check-workflow-pin-history.mjs`     | 32    | 3      | 29         | 46            |
+| `verify-required-checks.mjs`         | 35    | 0      | 35         | 24            |
+| **total**                            | 271   | 84     | **187**    |               |
+
+The first run of this tool reported `80 / 19 / 61`. That was wrong by 3x, and the way it was
+caught matters more than the correction.
+
+After extracting three printers out of `main()` in this tool, the total dropped 85 to 82 while the
+caught count stayed at 21. The three sites had not become asserted -- they had **left the
+population**, because the site detector matched only `console.log(` and `.push(\``, not a template
+literal that is returned or used as an array element. Array-literal template entries alone
+outnumbered the entire counted population.
+
+So the metric improved when something was fixed, for a reason unrelated to the fix. That is the
+same defect as a scope line whose denominator shrinks when you repair the thing it measures, and
+it was found only because the _direction_ of the change was implausible: an extraction that makes
+a value assertable should move it from unasserted to caught, not delete it.
+
+### Extraction is a precondition, not a remedy
+
+The obvious reading of the table is that detection tracks report structure: you cannot assert a
+value inside `console.log` without capturing stdout, whereas a value in a returned array is
+trivially asserted. `check-doc-links.mjs` scores 30/30 with zero `console.log` calls because
+PR #4288 extracted `reportLines()`/`scopeLines()` and left `main()` a thin printer.
+
+`check-citation-enumerations.mjs` breaks it: **zero `console.log`, seven assertable sites, zero
+asserted.** Extraction makes assertion possible; it does not make it happen. The correct claim is
+that inline printing is a _hard_ barrier and extraction removes it, leaving an ordinary gap that
+someone still has to close.
+
+### Why this is reported and not gated
+
+Not for the reason the retracted census gave. That one said "heuristic, therefore report-only",
+which was true but is no longer the operative constraint -- this measurement is direct. The real
+reasons are mechanical: it rewrites source files in place, and it runs for 31 seconds. It refuses
+to start on a dirty `tools/` tree, restores every file in a `finally`, and requires a green
+baseline per tool before mutating, because a red baseline makes every mutant look caught.
 
 ## Worth hoisting up
 

--- a/tools/check-report-assertions.mjs
+++ b/tools/check-report-assertions.mjs
@@ -25,6 +25,13 @@ export const TOOLS_DIR = 'tools';
 
 const PRINT_CALL = /console\.(?:log|error|warn)\(/;
 const PUSH_CALL = /\w+\.push\(`/;
+const RETURN_TEMPLATE = /return\s+`/;
+// A report line may also be a bare template literal used as an array element or a call argument,
+// e.g. `const lines = [`a ${x}`, `b ${y}`];`. Those carry the same values as a logged line and
+// were invisible to an earlier version of this detector that only looked at calls -- which meant
+// extracting a printer into a returning function removed its sites from the population instead of
+// making them asserted, improving the ratio for the wrong reason.
+const BARE_TEMPLATE = /^`/;
 
 /**
  * Find interpolation sites on lines that build report output.
@@ -38,7 +45,15 @@ export function reportSites(source) {
   for (let i = 0; i < lines.length; i++) {
     const text = lines[i];
     if (!text.includes('${')) continue;
-    if (!PRINT_CALL.test(text) && !PUSH_CALL.test(text)) continue;
+    const trimmed = text.trim();
+    if (
+      !PRINT_CALL.test(text) &&
+      !PUSH_CALL.test(text) &&
+      !RETURN_TEMPLATE.test(text) &&
+      !BARE_TEMPLATE.test(trimmed)
+    ) {
+      continue;
+    }
     for (const m of text.matchAll(/\$\{([^{}]+)\}/g)) {
       out.push({ line: i + 1, expr: m[1] });
     }

--- a/tools/check-report-assertions.mjs
+++ b/tools/check-report-assertions.mjs
@@ -1,0 +1,261 @@
+#!/usr/bin/env node
+/**
+ * Measure how many interpolated values in tool report lines are actually asserted by a test.
+ *
+ * Method: direct mutation. For each interpolation site in a printed or pushed report line,
+ * substitute a sentinel for the interpolated expression and re-run that tool's own test file.
+ * A green run means no test reads that value.
+ *
+ * This deliberately replaces an earlier literal-fragment heuristic (does the test file contain a
+ * static substring of the printed line?). That heuristic's numerator moved 8 -> 0 across a
+ * minimum-fragment-length constant nobody chose, and it detects whether a test quotes a static
+ * *label*, which is uncorrelated with whether it asserts the interpolated *value*. Two sessions
+ * running it on different trees over different populations obtained identical figures, because
+ * the figures were a property of the instrument rather than of either repository.
+ *
+ * Report-only. Not wired into CI: it rewrites source files in place, and runs for ~30 s.
+ */
+
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+export const DEFAULT_SENTINEL = '${0}';
+export const TOOLS_DIR = 'tools';
+
+const PRINT_CALL = /console\.(?:log|error|warn)\(/;
+const PUSH_CALL = /\w+\.push\(`/;
+
+/**
+ * Find interpolation sites on lines that build report output.
+ *
+ * @param {string} source Full source text of a tool.
+ * @returns {{line: number, expr: string}[]} One entry per `${...}` on a report-building line.
+ */
+export function reportSites(source) {
+  const lines = source.split('\n');
+  const out = [];
+  for (let i = 0; i < lines.length; i++) {
+    const text = lines[i];
+    if (!text.includes('${')) continue;
+    if (!PRINT_CALL.test(text) && !PUSH_CALL.test(text)) continue;
+    for (const m of text.matchAll(/\$\{([^{}]+)\}/g)) {
+      out.push({ line: i + 1, expr: m[1] });
+    }
+  }
+  return out;
+}
+
+/**
+ * Apply a sentinel substitution to one interpolation site.
+ *
+ * Returns `null` when the substitution is a no-op, which happens when the site's own text already
+ * equals the sentinel. Such a site cannot be measured: a surviving mutant would be indistinguishable
+ * from an unchanged file, so it is excluded from the denominator rather than counted as unasserted.
+ *
+ * @param {string[]} lines Source split on newlines.
+ * @param {{line: number, expr: string}} site Site to mutate.
+ * @param {string} sentinel Replacement text for the whole `${...}` expression.
+ * @returns {string[] | null} Mutated lines, or `null` if the substitution changed nothing.
+ */
+export function mutateSite(lines, site, sentinel) {
+  const before = lines[site.line - 1];
+  const after = before.replace(`\${${site.expr}}`, sentinel);
+  if (after === before) return null;
+  const mutated = [...lines];
+  mutated[site.line - 1] = after;
+  return mutated;
+}
+
+/**
+ * List tools that have a colocated `*.test.mjs` file.
+ *
+ * @param {string} dir Directory to scan.
+ * @param {{readdirSync: Function, existsSync: Function}} [fsImpl] Injectable fs for tests.
+ * @returns {string[]} Tool filenames, sorted.
+ */
+export function toolsWithTests(dir, fsImpl = fs) {
+  return fsImpl
+    .readdirSync(dir)
+    .filter((f) => f.endsWith('.mjs') && !f.endsWith('.test.mjs'))
+    .filter((f) => fsImpl.existsSync(path.join(dir, f.replace(/\.mjs$/, '.test.mjs'))))
+    .sort();
+}
+
+/**
+ * Summarise a completed run.
+ *
+ * @param {{tools: number, caught: string[], survivors: string[], unmeasurable: number,
+ *   skippedRed: string[]}} result Raw counts.
+ * @returns {string[]} Report lines.
+ */
+export function reportLines(result) {
+  const sites = result.caught.length + result.survivors.length;
+  const lines = [
+    `tools with tests        ${result.tools}`,
+    `interpolation sites     ${sites}`,
+    `  detected by a test    ${result.caught.length}`,
+    `  unasserted            ${result.survivors.length}`,
+  ];
+  if (result.unmeasurable > 0) {
+    lines.push(`  unmeasurable          ${result.unmeasurable} (site text equals the sentinel)`);
+  }
+  if (result.skippedRed.length > 0) {
+    lines.push(
+      `  skipped, red baseline ${result.skippedRed.length}: ${result.skippedRed.join(', ')}`,
+    );
+  }
+  return lines;
+}
+
+/**
+ * Describe what this run did and did not cover.
+ *
+ * Every figure above is over tools that have a colocated test file and a green baseline. Tools
+ * without tests contribute no sites and are therefore invisible in the ratio rather than counted
+ * as unasserted -- the omission that would otherwise make the number look better than the tree.
+ *
+ * @param {{tools: number, allTools: number, skippedRed: string[], sentinel: string}} result Counts.
+ * @returns {string[]} Scope lines.
+ */
+export function scopeLines(result) {
+  const untested = result.allTools - result.tools;
+  const lines = [
+    `Scope: ${result.tools} of ${result.allTools} tools in ${TOOLS_DIR}/ have a colocated test file.`,
+  ];
+  if (untested > 0) {
+    lines.push(
+      `  ${untested} tool(s) have no test file; their report lines are unmeasured, not counted as asserted.`,
+    );
+  }
+  if (result.skippedRed.length > 0) {
+    lines.push(
+      `  ${result.skippedRed.length} tool(s) had a red baseline and were skipped; a red baseline makes every mutant look caught.`,
+    );
+  }
+  lines.push(`  Sentinel: ${result.sentinel}. Counts are stable across sentinel choice;`);
+  lines.push(`  a site whose true value equals the sentinel is reported as unmeasurable.`);
+  return lines;
+}
+
+const runTests = (dir, tool) => {
+  try {
+    execFileSync(
+      process.execPath,
+      ['--test', path.join(dir, tool.replace(/\.mjs$/, '.test.mjs'))],
+      { stdio: 'pipe', timeout: 180000 },
+    );
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Run the full measurement.
+ *
+ * @param {{dir?: string, sentinel?: string, run?: Function}} [options] Overrides for tests.
+ * @returns {{tools: number, allTools: number, caught: string[], survivors: string[],
+ *   unmeasurable: number, skippedRed: string[], sentinel: string}} Result.
+ */
+export function measure(options = {}) {
+  const dir = options.dir ?? TOOLS_DIR;
+  const sentinel = options.sentinel ?? DEFAULT_SENTINEL;
+  const run = options.run ?? runTests;
+
+  const allTools = fs
+    .readdirSync(dir)
+    .filter((f) => f.endsWith('.mjs') && !f.endsWith('.test.mjs')).length;
+  const tools = toolsWithTests(dir);
+
+  const caught = [];
+  const survivors = [];
+  const skippedRed = [];
+  let unmeasurable = 0;
+
+  for (const tool of tools) {
+    const file = path.join(dir, tool);
+    const original = fs.readFileSync(file, 'utf8');
+    if (!run(dir, tool)) {
+      skippedRed.push(tool);
+      continue;
+    }
+    const lines = original.split('\n');
+    try {
+      for (const site of reportSites(original)) {
+        const mutated = mutateSite(lines, site, sentinel);
+        if (mutated === null) {
+          unmeasurable++;
+          continue;
+        }
+        fs.writeFileSync(file, mutated.join('\n'));
+        const green = run(dir, tool);
+        fs.writeFileSync(file, original);
+        const label = `${tool}:${site.line}  \${${site.expr}}`;
+        if (green) survivors.push(label);
+        else caught.push(label);
+      }
+    } finally {
+      // Restore unconditionally: an interrupted run must not leave a mutant on disk.
+      fs.writeFileSync(file, original);
+    }
+  }
+
+  return {
+    tools: tools.length - skippedRed.length,
+    allTools,
+    caught,
+    survivors,
+    unmeasurable,
+    skippedRed,
+    sentinel,
+  };
+}
+
+/**
+ * Refuse to run when the working tree is dirty.
+ *
+ * The measurement rewrites source files in place. On a clean tree a crash is recoverable with
+ * `git checkout`; on a dirty tree it could destroy uncommitted work.
+ *
+ * @returns {string | null} Reason to refuse, or `null` when safe.
+ */
+export function refuseReason() {
+  let status;
+  try {
+    status = execFileSync('git', ['status', '--porcelain', '--', TOOLS_DIR], {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+  } catch {
+    return 'unable to determine git status; refusing to mutate source files';
+  }
+  if (status.trim() !== '') {
+    return `uncommitted changes under ${TOOLS_DIR}/; commit or stash before running`;
+  }
+  return null;
+}
+
+function main() {
+  const sentinel = process.argv[2] ?? DEFAULT_SENTINEL;
+  const reason = refuseReason();
+  if (reason !== null) {
+    console.error(`check-report-assertions: ${reason}`);
+    process.exitCode = 1;
+    return;
+  }
+  const started = Date.now();
+  const result = measure({ sentinel });
+  for (const line of reportLines(result)) console.log(line);
+  console.log('');
+  for (const line of scopeLines(result)) console.log(line);
+  console.log(`\nelapsed                 ${((Date.now() - started) / 1000).toFixed(1)}s`);
+  if (result.survivors.length > 0) {
+    console.log('\nunasserted sites:');
+    for (const s of result.survivors) console.log(`  ${s}`);
+  }
+}
+
+if (process.argv[1] && process.argv[1].endsWith('check-report-assertions.mjs')) {
+  main();
+}

--- a/tools/check-report-assertions.mjs
+++ b/tools/check-report-assertions.mjs
@@ -236,11 +236,42 @@ export function refuseReason() {
   return null;
 }
 
+/**
+ * Render the unasserted-site list.
+ *
+ * @param {string[]} survivors Site labels.
+ * @returns {string[]} Report lines, empty when nothing survived.
+ */
+export function survivorLines(survivors) {
+  if (survivors.length === 0) return [];
+  return ['', 'unasserted sites:', ...survivors.map((s) => `  ${s}`)];
+}
+
+/**
+ * Render the elapsed-time line.
+ *
+ * @param {number} ms Duration in milliseconds.
+ * @returns {string} Report line.
+ */
+export function elapsedLine(ms) {
+  return `elapsed                 ${(ms / 1000).toFixed(1)}s`;
+}
+
+/**
+ * Render the refusal message.
+ *
+ * @param {string} reason Why the run was refused.
+ * @returns {string} Message written to stderr.
+ */
+export function refusalLine(reason) {
+  return `check-report-assertions: ${reason}`;
+}
+
 function main() {
   const sentinel = process.argv[2] ?? DEFAULT_SENTINEL;
   const reason = refuseReason();
   if (reason !== null) {
-    console.error(`check-report-assertions: ${reason}`);
+    console.error(refusalLine(reason));
     process.exitCode = 1;
     return;
   }
@@ -249,11 +280,9 @@ function main() {
   for (const line of reportLines(result)) console.log(line);
   console.log('');
   for (const line of scopeLines(result)) console.log(line);
-  console.log(`\nelapsed                 ${((Date.now() - started) / 1000).toFixed(1)}s`);
-  if (result.survivors.length > 0) {
-    console.log('\nunasserted sites:');
-    for (const s of result.survivors) console.log(`  ${s}`);
-  }
+  console.log('');
+  console.log(elapsedLine(Date.now() - started));
+  for (const line of survivorLines(result.survivors)) console.log(line);
 }
 
 if (process.argv[1] && process.argv[1].endsWith('check-report-assertions.mjs')) {

--- a/tools/check-report-assertions.test.mjs
+++ b/tools/check-report-assertions.test.mjs
@@ -6,8 +6,11 @@ import {
   measure,
   mutateSite,
   reportLines,
+  elapsedLine,
+  refusalLine,
   reportSites,
   scopeLines,
+  survivorLines,
   toolsWithTests,
 } from './check-report-assertions.mjs';
 
@@ -192,4 +195,31 @@ test('measure records the sentinel it was given', () => {
 test('measure defaults to the documented sentinel', () => {
   const result = measure({ dir: 'tools', run: () => false });
   assert.equal(result.sentinel, DEFAULT_SENTINEL);
+});
+
+test('survivorLines returns nothing when every site is asserted', () => {
+  assert.deepEqual(survivorLines([]), []);
+});
+
+test('survivorLines lists each survivor by value', () => {
+  const lines = survivorLines(['a.mjs:1  ${x}', 'b.mjs:2  ${y}']);
+  assert.ok(lines.includes('  a.mjs:1  ${x}'));
+  assert.ok(lines.includes('  b.mjs:2  ${y}'));
+});
+
+test('survivorLines heads the list so it is not read as report output', () => {
+  assert.equal(survivorLines(['a.mjs:1  ${x}'])[1], 'unasserted sites:');
+});
+
+test('elapsedLine reports seconds to one decimal', () => {
+  assert.equal(elapsedLine(30800), 'elapsed                 30.8s');
+});
+
+test('elapsedLine distinguishes durations that differ only below a second', () => {
+  assert.notEqual(elapsedLine(1100), elapsedLine(1900));
+  assert.equal(elapsedLine(1100), 'elapsed                 1.1s');
+});
+
+test('refusalLine names the tool and carries the reason verbatim', () => {
+  assert.equal(refusalLine('tree is dirty'), 'check-report-assertions: tree is dirty');
 });

--- a/tools/check-report-assertions.test.mjs
+++ b/tools/check-report-assertions.test.mjs
@@ -223,3 +223,28 @@ test('elapsedLine distinguishes durations that differ only below a second', () =
 test('refusalLine names the tool and carries the reason verbatim', () => {
   assert.equal(refusalLine('tree is dirty'), 'check-report-assertions: tree is dirty');
 });
+
+test('reportSites finds interpolations in returned template literals', () => {
+  assert.deepEqual(
+    reportSites('  return `count ${n}`;').map((s) => s.expr),
+    ['n'],
+  );
+});
+
+test('reportSites finds interpolations in bare template array elements', () => {
+  const src = ['const lines = [', '  `a ${x}`,', '  `b ${y}`,', '];'].join('\n');
+  assert.deepEqual(
+    reportSites(src).map((s) => s.expr),
+    ['x', 'y'],
+  );
+});
+
+test('reportSites still ignores a template assigned to a variable', () => {
+  assert.deepEqual(reportSites('  const x = `${a}`;'), []);
+});
+
+test('reportSites counts a returned template and a logged one alike', () => {
+  const logged = reportSites('console.log(`${v}`);');
+  const returned = reportSites('  return `${v}`;');
+  assert.equal(logged.length, returned.length);
+});

--- a/tools/check-report-assertions.test.mjs
+++ b/tools/check-report-assertions.test.mjs
@@ -1,0 +1,195 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  DEFAULT_SENTINEL,
+  measure,
+  mutateSite,
+  reportLines,
+  reportSites,
+  scopeLines,
+  toolsWithTests,
+} from './check-report-assertions.mjs';
+
+test('reportSites finds interpolations in console calls', () => {
+  const src = ['console.log(`count ${n}`);'].join('\n');
+  const sites = reportSites(src);
+  assert.equal(sites.length, 1);
+  assert.equal(sites[0].line, 1);
+  assert.equal(sites[0].expr, 'n');
+});
+
+test('reportSites finds interpolations in pushed template lines', () => {
+  const src = ['lines.push(`total ${a} of ${b}`);'].join('\n');
+  const sites = reportSites(src);
+  assert.deepEqual(
+    sites.map((s) => s.expr),
+    ['a', 'b'],
+  );
+});
+
+test('reportSites ignores interpolation outside report-building calls', () => {
+  const src = ['const x = `${a}`;', 'throw new Error(`${b}`);'].join('\n');
+  assert.deepEqual(reportSites(src), []);
+});
+
+test('reportSites ignores report lines with no interpolation', () => {
+  assert.deepEqual(reportSites('console.log("static");'), []);
+});
+
+test('reportSites reports 1-based line numbers', () => {
+  const src = ['// a', '// b', 'console.log(`${v}`);'].join('\n');
+  assert.equal(reportSites(src)[0].line, 3);
+});
+
+test('mutateSite substitutes the sentinel for the whole expression', () => {
+  const lines = ['console.log(`count ${n}`);'];
+  const out = mutateSite(lines, { line: 1, expr: 'n' }, '${0}');
+  assert.equal(out[0], 'console.log(`count ${0}`);');
+});
+
+test('mutateSite leaves other lines untouched', () => {
+  const lines = ['const a = 1;', 'console.log(`${n}`);', 'const b = 2;'];
+  const out = mutateSite(lines, { line: 2, expr: 'n' }, '${0}');
+  assert.equal(out[0], 'const a = 1;');
+  assert.equal(out[2], 'const b = 2;');
+});
+
+test('mutateSite does not mutate the input array', () => {
+  const lines = ['console.log(`${n}`);'];
+  mutateSite(lines, { line: 1, expr: 'n' }, '${0}');
+  assert.equal(lines[0], 'console.log(`${n}`);');
+});
+
+test('mutateSite returns null when the substitution is a no-op', () => {
+  const lines = ['console.log(`${0}`);'];
+  assert.equal(mutateSite(lines, { line: 1, expr: '0' }, '${0}'), null);
+});
+
+test('mutateSite substitutes only the first occurrence of a repeated expression', () => {
+  const lines = ['console.log(`${n} ${n}`);'];
+  const out = mutateSite(lines, { line: 1, expr: 'n' }, '${0}');
+  assert.equal(out[0], 'console.log(`${0} ${n}`);');
+});
+
+test('toolsWithTests pairs tools with colocated test files', () => {
+  const fake = {
+    readdirSync: () => ['b.mjs', 'b.test.mjs', 'a.mjs'],
+    existsSync: (p) => p.endsWith('b.test.mjs'),
+  };
+  assert.deepEqual(toolsWithTests('tools', fake), ['b.mjs']);
+});
+
+test('toolsWithTests excludes test files themselves', () => {
+  const fake = { readdirSync: () => ['a.test.mjs'], existsSync: () => true };
+  assert.deepEqual(toolsWithTests('tools', fake), []);
+});
+
+test('toolsWithTests returns a sorted list', () => {
+  const fake = { readdirSync: () => ['z.mjs', 'a.mjs'], existsSync: () => true };
+  assert.deepEqual(toolsWithTests('tools', fake), ['a.mjs', 'z.mjs']);
+});
+
+const baseResult = {
+  tools: 3,
+  allTools: 5,
+  caught: ['a.mjs:1  ${x}'],
+  survivors: ['b.mjs:2  ${y}', 'b.mjs:3  ${z}'],
+  unmeasurable: 0,
+  skippedRed: [],
+  sentinel: DEFAULT_SENTINEL,
+};
+
+test('reportLines states every count by value', () => {
+  const lines = reportLines(baseResult);
+  assert.equal(lines[0], 'tools with tests        3');
+  assert.equal(lines[1], 'interpolation sites     3');
+  assert.equal(lines[2], '  detected by a test    1');
+  assert.equal(lines[3], '  unasserted            2');
+});
+
+test('reportLines derives the site total from both outcome lists', () => {
+  const lines = reportLines({ ...baseResult, caught: [], survivors: [] });
+  assert.equal(lines[1], 'interpolation sites     0');
+});
+
+test('reportLines omits the unmeasurable line when there are none', () => {
+  assert.ok(!reportLines(baseResult).some((l) => l.includes('unmeasurable')));
+});
+
+test('reportLines states the unmeasurable count when nonzero', () => {
+  const lines = reportLines({ ...baseResult, unmeasurable: 4 });
+  assert.ok(lines.some((l) => l.includes('unmeasurable          4')));
+});
+
+test('reportLines omits the red-baseline line when there are none', () => {
+  assert.ok(!reportLines(baseResult).some((l) => l.includes('red baseline')));
+});
+
+test('reportLines names each red-baseline tool', () => {
+  const lines = reportLines({ ...baseResult, skippedRed: ['x.mjs', 'y.mjs'] });
+  const line = lines.find((l) => l.includes('red baseline'));
+  assert.ok(line.includes('2'));
+  assert.ok(line.includes('x.mjs'));
+  assert.ok(line.includes('y.mjs'));
+});
+
+test('scopeLines states the measured and total tool counts', () => {
+  const lines = scopeLines(baseResult);
+  assert.ok(lines[0].includes('3 of 5'));
+});
+
+test('scopeLines states the untested residual by value', () => {
+  const line = scopeLines(baseResult).find((l) => l.includes('no test file'));
+  assert.ok(line.startsWith('  2 tool(s)'), line);
+});
+
+test('scopeLines says untested tools are unmeasured rather than asserted', () => {
+  const line = scopeLines(baseResult).find((l) => l.includes('no test file'));
+  assert.ok(line.includes('not counted as asserted'));
+});
+
+test('scopeLines omits the residual line when every tool is measured', () => {
+  const lines = scopeLines({ ...baseResult, tools: 5, allTools: 5 });
+  assert.ok(!lines.some((l) => l.includes('no test file')));
+});
+
+test('scopeLines reports the sentinel in use', () => {
+  const lines = scopeLines({ ...baseResult, sentinel: '${-1}' });
+  assert.ok(lines.some((l) => l.includes('${-1}')));
+});
+
+test('scopeLines explains why a red baseline is disqualifying', () => {
+  const lines = scopeLines({ ...baseResult, skippedRed: ['x.mjs'] });
+  assert.ok(lines.some((l) => l.includes('every mutant look caught')));
+});
+
+test('measure skips a tool whose baseline is red and never mutates it', () => {
+  const result = measure({ dir: 'tools', run: () => false });
+  assert.equal(result.caught.length, 0);
+  assert.equal(result.survivors.length, 0);
+  assert.ok(result.skippedRed.length > 0);
+  assert.equal(result.tools, 0);
+});
+
+test('measure excludes red-baseline tools from the measured count', () => {
+  const result = measure({ dir: 'tools', run: () => false });
+  assert.equal(result.tools, 0);
+  assert.ok(result.allTools > 0);
+});
+
+test('measure counts every site as unasserted when no test ever fails', () => {
+  const result = measure({ dir: 'tools', run: () => true });
+  assert.equal(result.caught.length, 0);
+  assert.ok(result.survivors.length > 0);
+});
+
+test('measure records the sentinel it was given', () => {
+  const result = measure({ dir: 'tools', run: () => false, sentinel: '${"M"}' });
+  assert.equal(result.sentinel, '${"M"}');
+});
+
+test('measure defaults to the documented sentinel', () => {
+  const result = measure({ dir: 'tools', run: () => false });
+  assert.equal(result.sentinel, DEFAULT_SENTINEL);
+});


### PR DESCRIPTION
Closes #4289

## Summary

Retracts a figure this guide published, and replaces the instrument that produced it.

The claim was **60 of 64 printed sentences have no assertion anywhere**. The upstream
engineering session ran the same literal-fragment heuristic on its own tree, over a
**different population**, and obtained `64 / 4 / 60` — digit for digit. Three matching
integers across two definitions is not corroboration; it is a property of the shared
instrument. Their sweep on the minimum-fragment-length constant moved the matched count
`8 → 5 → 4 → 2 → 0`. The published `4` was the value at a threshold chosen while writing
the script and never mentioned.

Re-running the heuristic here reproduced **neither** figure — 36 sites, matched 3→1.

## Replacement: direct mutation

`tools/check-report-assertions.mjs`. Substitute a sentinel for each interpolated
expression on a report-building line and re-run that tool's own test file. Green means no
test reads that value. No threshold.

```
tools with tests        12
interpolation sites     271
  detected by a test    84
  unasserted            187
```

**3× the retracted number.** Stable under sentinel choice: the caught *set*, not merely
its cardinality, is identical across `${0}`, `${-1}`, `${"MUTANT"}`, `${undefined}`.

## Three defects found while building it

1. **A parameter echoed in the report is not a parameter used in the computation.** The
   first sweep printed a different sentinel on each of five runs and performed one
   measurement — the wiring substitution silently matched nothing. Echoing the constant is
   what made the run look audited.

2. **The metric improved for the wrong reason.** After extracting three printers out of
   `main()`, sites fell 85→82 while caught stayed 21. They had not become asserted; they
   had left the population, because the detector saw only `console.log(` and `` .push(` ``,
   not returned or array-element templates. Array-literal entries alone outnumbered the
   entire counted population. Caught only because the *direction* was implausible.

3. **Extraction is a precondition, not a remedy.** `check-doc-links.mjs` scores 30/30 with
   zero `console.log`, supporting a clean structural hypothesis — which
   `check-citation-enumerations.mjs` then breaks: zero `console.log`, seven assertable
   sites, **zero asserted**. Inline printing is a hard barrier; removing it leaves an
   ordinary gap someone still has to close.

## Safety

Report-only, not wired into CI: it rewrites source files in place and runs 31 s. Refuses to
start on a dirty `tools/` tree, restores every file in a `finally`, and requires a green
baseline per tool — a red baseline makes every mutant look caught.

## Testing

- [x] `npm run format:check` — clean
- [x] `npx eslint . --max-warnings 0` — exit 0
- [x] `npm run type-check` — pass
- [x] `node --test "tools/**/*.test.mjs"` — **468/468** (+44)
- [x] All 13 gates pass
- [x] Tool measures itself: 13/16 caught, 3 unasserted, disclosed in the table