### PR TITLE
fix(tools): treat an unknown ownership basis as unverifiable (#4292)

### DIFF
--- a/tools/check-ai-manifest.js
+++ b/tools/check-ai-manifest.js
@@ -752,21 +752,70 @@ const ENFORCEMENT_WORKFLOW = '.github/workflows/ai-manifest-check.yml';
 const ENFORCEMENT_STEP = 'Check for drift';
 const SYNC_LOCK = '.studio-sync.lock.json';
 
+// A managed population this small cannot be the real delivered surface, so treating it as one
+// would silently widen the ownership exemption to the whole repository. Deliberately a FLOOR and
+// not a pin on today's 81: a pin gets reverted the first time the fleet legitimately shrinks, and
+// a reverted check is a deleted check. The suite asserts a one-entry lock still validates, so
+// tightening this into a pin fails there (.github#834).
+const MANAGED_FLOOR = 1;
+
 /**
- * Paths this repository receives from the backbone rather than authors.
+ * Resolve the lock's entry map, treating an unexpected shape as unverifiable rather than as data.
+ *
+ * The previous read was `Object.keys(lock.entries ?? lock)`. That fallback does not degrade to
+ * empty — it degrades to the lock's own top-level keys, so a future engine that renames `entries`
+ * yields four plausible target names (`version`, `backbone`, `generatedAt`, ...) and every check
+ * built on ownership keeps reporting confident numbers about the wrong set. Nine other reads in
+ * this file already use `lock.entries || {}`; only the two that establish ownership and the
+ * trigger denominator used `?? lock` (#4292).
+ *
+ * @param {unknown} lock Parsed lock contents.
+ * @returns {{targets: Set<string>}|{error: string}} The recorded targets, or why they are unusable.
+ */
+function lockEntries(lock) {
+  const entries = lock && typeof lock === 'object' ? lock.entries : undefined;
+  if (entries === undefined) return { error: `${SYNC_LOCK} has no 'entries' map` };
+  if (entries === null || typeof entries !== 'object' || Array.isArray(entries)) {
+    return { error: `${SYNC_LOCK} 'entries' is not an object` };
+  }
+  const targets = new Set(Object.keys(entries));
+  if (targets.size < MANAGED_FLOOR) {
+    return {
+      error: `${SYNC_LOCK} records ${targets.size} targets, below the floor of ${MANAGED_FLOOR}`,
+    };
+  }
+  return { targets };
+}
+
+/**
+ * Paths this repository receives from the backbone rather than authors, with the basis stated.
  *
  * Read from the lock at check time rather than listed here, so the set cannot drift from the
  * delivered surface: a target added by a future sync is covered with nothing to update (#4281).
  *
- * @returns {Set<string>} Managed target paths; empty when the lock is absent or unreadable.
+ * @returns {{targets: Set<string>}|{error: string}} Managed targets, or why ownership is unknown.
+ */
+function managedBasis() {
+  let lock;
+  try {
+    lock = JSON.parse(fs.readFileSync(path.join(ROOT, SYNC_LOCK), 'utf8'));
+  } catch (error) {
+    return { error: `${SYNC_LOCK} is unreadable (${error.message})` };
+  }
+  return lockEntries(lock);
+}
+
+/**
+ * Managed target paths, empty when ownership cannot be established.
+ *
+ * Callers that must distinguish "nothing is managed" from "the basis is unknown" — which is every
+ * caller whose verdict gets quieter as this set shrinks — use `managedBasis` instead.
+ *
+ * @returns {Set<string>} Managed target paths.
  */
 function managedTargets() {
-  try {
-    const lock = JSON.parse(fs.readFileSync(path.join(ROOT, SYNC_LOCK), 'utf8'));
-    return new Set(Object.keys(lock.entries ?? lock));
-  } catch {
-    return new Set();
-  }
+  const basis = managedBasis();
+  return basis.error ? new Set() : basis.targets;
 }
 
 /**
@@ -778,14 +827,26 @@ function managedTargets() {
  * repo does not contain at all (`sync/README.md:N` passed because finance has READMEs). Measured
  * before the fix: 2 of 2 coordinates in the corpus were exempted, and both were managed (#4281).
  *
+ * The exemption widens as the managed set shrinks, so an unknown basis makes this rule quieter,
+ * not louder: measured with the lock's entry map renamed, it reported 0 coordinates across 72
+ * files and disclosed "4 received target(s)" — a precise, wrong number. A zero computed against
+ * an unknown owner set is not a result, so it is reported as a finding rather than printed as
+ * one (#4292).
+ *
  * @returns {{findings: string[], scanned: number}} Findings and the population they came from.
  */
 function validateCitationCoverage() {
+  const basis = managedBasis();
+  if (basis.error) {
+    return {
+      findings: [`ownership is unverifiable, so the coordinate rule cannot run: ${basis.error}`],
+      scanned: 0,
+    };
+  }
   const present = new Set(
     walkFiles(ROOT).map((file) => path.relative(ROOT, file).split(path.sep).join('/')),
   );
-  const managed = managedTargets();
-  const isLocallyOwned = (cited) => present.has(cited) && !managed.has(cited);
+  const isLocallyOwned = (cited) => present.has(cited) && !basis.targets.has(cited);
   return citationCoverage(citationCorpus(), isLocallyOwned);
 }
 
@@ -1494,12 +1555,13 @@ function readEnforcementMode() {
 
 function validateTriggerCoverage() {
   const workflowPath = path.join(ROOT, ENFORCEMENT_WORKFLOW);
-  const lockPath = path.join(ROOT, SYNC_LOCK);
   if (!fs.existsSync(workflowPath)) return [`missing workflow: ${ENFORCEMENT_WORKFLOW}`];
-  if (!fs.existsSync(lockPath)) return [`missing ${SYNC_LOCK}`];
-  const lock = JSON.parse(fs.readFileSync(lockPath, 'utf8'));
+  const basis = managedBasis();
+  // The denominator is part of the claim: "34 of 81 cannot trigger" and "34 of 4" read the same
+  // to a scanner and only one is a measurement, so an unknown basis is reported, not substituted.
+  if (basis.error) return [`cannot establish the managed population: ${basis.error}`];
   const inputs = checkInputs(
-    Object.keys(lock.entries ?? lock),
+    [...basis.targets],
     citationCorpus().map((entry) => entry.path),
   );
   return triggerFindings(fs.readFileSync(workflowPath, 'utf8'), inputs);
@@ -1681,6 +1743,9 @@ module.exports = {
   KNOWN_UNREPRODUCED,
   CANON_CITATIONS,
   managedTargets,
+  managedBasis,
+  lockEntries,
+  MANAGED_FLOOR,
   ENFORCEMENT_WORKFLOW,
   driftEnforcement,
   enforcementFindings,

--- a/tools/check-ai-manifest.test.mjs
+++ b/tools/check-ai-manifest.test.mjs
@@ -52,6 +52,9 @@ const {
   MANAGED_COUNTS,
   citationFindings,
   managedTargets,
+  managedBasis,
+  lockEntries,
+  MANAGED_FLOOR,
   citationCorpus,
   validateCitationCoverage,
   BACKBONE_CLAIM,
@@ -1540,4 +1543,91 @@ test('the PRODUCTION walk, not a test list, supplies the corpus population (#428
     before,
     'the report returns once the probe is gone',
   );
+});
+
+// --- #4292: an unknown ownership basis is a finding, never a clean zero -----------------------
+//
+// `managedTargets` resolved the entry map as `Object.keys(lock.entries ?? lock)`. That fallback
+// degrades to the lock's own top-level keys, not to empty, so a renamed `entries` yielded four
+// plausible target names and every ownership verdict kept reporting confident numbers about the
+// wrong set. The exemption widens as the managed set shrinks, so the failure is SILENCE: measured
+// before the fix, 0 coordinates across 72 files while disclosing "4 received target(s)".
+
+test('a lock whose entry map is missing or misshapen is unverifiable, not empty (#4292)', () => {
+  assert.ok('error' in lockEntries({ version: 1, files: { 'AGENTS.md': {} } }), 'renamed key');
+  assert.ok('error' in lockEntries({ entries: null }), 'null entries');
+  assert.ok('error' in lockEntries({ entries: [] }), 'array entries');
+  assert.ok('error' in lockEntries(null), 'no lock at all');
+
+  // A NON-EMPTY array is the case that needs the Array.isArray arm specifically: an empty one is
+  // already refused by the floor, so testing only `[]` leaves the arm unexercised and it can be
+  // deleted with the suite green (survived a mutant that did exactly that). A populated array
+  // clears the floor and would otherwise hand back its indices as delivered target names.
+  const indexed = lockEntries({ entries: [{ targetSha256: 'a' }, { targetSha256: 'b' }] });
+  assert.ok('error' in indexed, 'a populated array clears the floor and must still be refused');
+  assert.ok(!('targets' in indexed), 'array indices must never be mistaken for delivered targets');
+
+  // The specific regression: the old `?? lock` fallback returned these four as target names.
+  const reshaped = lockEntries({ version: 1, backbone: 'x', generatedAt: 'y', files: {} });
+  assert.ok('error' in reshaped);
+  assert.ok(
+    !('targets' in reshaped),
+    'top-level meta keys must never be mistaken for delivered targets',
+  );
+});
+
+test('the managed population is a floor, not a pin on the current fleet (#4292)', () => {
+  assert.equal(MANAGED_FLOOR, 1, 'a floor above 1 would pin the check to a particular fleet size');
+
+  const below = lockEntries({ entries: {} });
+  assert.ok('error' in below);
+  assert.match(below.error, /below the floor/);
+
+  // The other direction, and the reason this is a floor: a one-entry lock MUST validate. Without
+  // this arm the floor can be tightened into a pin on today's 81 with the suite still green, and
+  // a pin gets reverted the first time the fleet legitimately shrinks — a reverted check is a
+  // deleted check (.github#834).
+  const minimal = lockEntries({ entries: { 'AGENTS.md': { targetSha256: 'a' } } });
+  assert.ok('targets' in minimal, 'a one-entry lock is a small fleet, not a broken basis');
+  assert.deepEqual([...minimal.targets], ['AGENTS.md']);
+});
+
+test('the PRODUCTION ownership rule refuses to report a zero it cannot justify (#4292)', () => {
+  // Unit tests on `lockEntries` say nothing about whether `validateCitationCoverage` consults it:
+  // the previous shape called `managedTargets()` and would pass every assertion above. So this
+  // constructs the state on disk and drives the real validators, restoring the engine-owned lock
+  // in `finally` and asserting byte-identical restoration afterwards.
+  const lockPath = path.join(ROOT, '.studio-sync.lock.json');
+  const original = fs.readFileSync(lockPath);
+  const real = JSON.parse(original.toString('utf8'));
+
+  const healthy = validateCitationCoverage();
+  assert.equal(healthy.findings.length, 0, 'PREMISE: the real basis is healthy');
+  assert.ok(healthy.scanned > 0, 'PREMISE: the real corpus is non-empty');
+
+  try {
+    // Valid JSON, every byte of data intact, one key renamed.
+    fs.writeFileSync(
+      lockPath,
+      JSON.stringify({ version: real.version, files: real.entries }, null, 2) + '\n',
+    );
+    const basis = managedBasis();
+    assert.ok('error' in basis, 'a renamed entry map must not resolve to targets');
+
+    const blind = validateCitationCoverage();
+    assert.equal(blind.findings.length, 1, 'silence is the failure mode, so it must be reported');
+    assert.match(blind.findings[0], /ownership is unverifiable/);
+    assert.equal(blind.scanned, 0, 'a population of 0 must not read as a clean sweep of 72');
+
+    const trigger = activationRunners({}).triggerCoverage();
+    assert.ok(
+      trigger.some((f) => f.includes('cannot establish the managed population')),
+      'the denominator is part of the claim, so it is reported rather than substituted',
+    );
+  } finally {
+    fs.writeFileSync(lockPath, original);
+  }
+
+  assert.deepEqual(fs.readFileSync(lockPath), original, 'the engine-owned lock is restored');
+  assert.deepEqual(validateCitationCoverage(), healthy, 'and the healthy verdict returns');
 });


### PR DESCRIPTION
## Summary

`managedTargets()` read `Object.keys(lock.entries ?? lock)`. When the entry map is absent or renamed, `?? lock` degrades to the **lock file''s top-level meta keys** rather than to empty. The citation exemption is `present.has(cited) && !managed.has(cited)`, so a **shrunken managed set exempts more of the repository** and the coordinate rule gets *quieter*. The failure direction is silence, not noise.

## Constructed states

Measured against the real lock, copied aside and restored byte-identically each time (`git status --porcelain` verified clean after each):

| state | managed | citation | exit |
| --- | --- | --- | --- |
| lock absent | 0 | 0 findings / 71 scanned | non-zero |
| lock valid, `entries: {}` | 0 | 0 findings / 72 scanned | non-zero |
| lock valid, `entries` renamed to `files` | **4 bogus names** | 0 findings / 72 scanned | **0** |

The first two rows only *look* covered: `syncLock` and `triggerCoverage` also report a missing file. **A rejection caused by a second inconsistency is not a check on the first** (jrmoulckers/.github#834). The isolated third row exits 0, and the #4281 disclosure prints `4 received target(s) count as unowned` — a precise, confident, wrong number.

## Scope

Nine entry-map reads already used `lock.entries || {}`, which degrades to empty and is safe. **Exactly two** used `?? lock`: `managedTargets` (the ownership basis) and `validateTriggerCoverage` (the trigger denominator).

## Changes

- `lockEntries(lock)` / `managedBasis()` return `{targets} | {error}`; refuse `undefined`, `null`, non-objects, arrays (including populated ones), and sizes below the floor.
- `MANAGED_FLOOR = 1`, a **floor, not a pin**. A pin on today''s 81 gets reverted the first time the fleet legitimately shrinks, and a reverted check is a deleted check. A dedicated arm asserts a one-entry lock still validates, so tightening the floor into a pin fails the suite.
- Both call sites report the basis as unverifiable rather than reporting a zero they cannot justify.
- `managedTargets()` keeps its signature for existing callers.

## Mutation sweep

Firing control first (`assert.ok(false)` injected): `fail=1 FIRES`, so a zero from this harness means something.

| mutant | result | killed by |
| --- | --- | --- |
| A restore the `?? lock` fallback | KILLED (2) | shape test + production arm |
| B floor lowered to 0 | KILLED | floor-not-pin |
| C floor tightened into a pin (`!== 81`) | KILLED | floor-not-pin |
| D citation ignores an unknown basis | KILLED | **production arm only** |
| E trigger ignores an unknown basis | KILLED | **production arm only** |
| F arrays accepted as an entry map | **SURVIVED**, then KILLED | see below |

D and E passed **every** unit test — the production-path arm was the sole killer, the third time in this program that testing the callee proved nothing about the call site.

F is disclosed as a real survivor and a real gap in my own test: the shape test used `entries: []`, which the **floor** already refuses, so the `Array.isArray` arm was never load-bearing and could be deleted with the suite green. Fixed by adding a **populated** array, which clears the floor and would otherwise hand back its indices as target names. Re-run: KILLED by name.

Every mutation asserted to have applied before its result was read; sources restored and verified byte-identical.

## Issues

Closes #4292

## Testing

- [x] `node --test tools/check-ai-manifest.test.mjs` — **90 passing** (87 before; +3 tests for #4292). Correction: this line originally read "91 passing (90 before)". Both numbers were wrong — the populated-array case was added as assertions inside the existing shape test, not as a new test, so the count did not move. Verified on merged main.
- [x] `npx eslint tools/check-ai-manifest.js tools/check-ai-manifest.test.mjs --max-warnings 0` — exit 0
- [x] `npx prettier --check` on both files — unchanged
- [x] `.studio-sync.lock.json` intact and untracked-clean after every constructed state
