### PR TITLE
feat(tools): census script reachability and enforce every tool test suite

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -145,6 +145,16 @@ jobs:
 
       - name: Tool tests do not reimplement their tools
         run: npm run test:independence:check
+
+      # Runs every tools/*.test.mjs, enumerated from disk. Without this step a test file is
+      # enforced only if someone remembers to register a script AND add a workflow step, so a
+      # new suite defaults to unenforced -- which is how 270 of 472 tool tests came to be run
+      # by no workflow, including the suite for a checker that is itself a required gate.
+      - name: Tool test suites
+        run: npm run tools:test
+
+      - name: Every script is reachable, or reported unreached
+        run: npm run gate:enforcement
   pr-title:
     name: Semantic PR Title
     needs: changes

--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -8710,6 +8710,107 @@ reasons are mechanical: it rewrites source files in place, and it runs for 31 se
 to start on a dirty `tools/` tree, restores every file in a `finally`, and requires a green
 baseline per tool before mutating, because a red baseline makes every mutant look caught.
 
+## The census chose its population by naming convention
+
+The finding two sections up -- _Four gates were invoked by nothing_ -- was produced by a hand
+census of the **14** `package.json` scripts ending in `:check`. Three things were wrong with it,
+and the third is the one that matters.
+
+### The population was a proxy
+
+The root `package.json` has **62** scripts. Selecting the 14 ending in `:check` is selecting by
+naming convention, which is a proxy for gate-ness -- and the proxy has a known exception inside
+this very document: the documented gate list's **first entry is `eng:citations`**, which does not
+end in `:check` and was therefore never in the census population. `type-check`, a required status
+check, was excluded the same way.
+
+Two populations, "scripts ending in `:check`" and "things this guide calls gates", were used
+interchangeably for six sections without ever being reconciled.
+
+### Absence was resolved by one route, so it was unfalsifiable
+
+The matcher looked for `npm run <name>`. One false positive was already corrected in prose
+(`ai:manifest:check` is enforced by path). The upstream session then hit the same class from the
+other side: their matcher missed `npm test`, a **bare npm lifecycle**, which briefly implied their
+repository ran no tests in CI. This repository has the identical construct at `ci-web.yml:144`.
+
+Both false positives were caught by **collision with prior knowledge** -- one of us recognised an
+orphan we knew was enforced. That is not a control. It is available only to a reader who already
+knows the answer, which is precisely the reader who does not need the census.
+
+`tools/check-gate-enforcement.mjs` resolves five routes and **reports which one matched**, so a
+"reached" verdict carries its own evidence:
+
+```
+scripts in package.json     62
+  invoked by a workflow     26
+  same command runs, but     5
+    not via the script
+  reached by nothing        31
+```
+
+### An unreached script is not an unenforced check
+
+This is the distinction the original finding collapsed. CI runs `npx eslint . --max-warnings 0
+--cache` and `npx prettier --check .` **directly** -- never `npm run lint` or `npm run
+format:check`. So those scripts are genuinely unreached _and_ the checks they perform are
+genuinely enforced, by the required `ESLint & Prettier` context. Hence the third bucket.
+
+The naive reading of the residue is also wrong. `lint` is `turbo run lint && npx eslint .
+--max-warnings 0`, and `turbo run lint` appears in **zero** workflows, which looks like a gap in
+package-level linting. It is not: root `npx eslint .` lints **2,301** files under `apps/web/src`,
+so the turbo half is redundant rather than missing. Verified by counting the files ESLint actually
+reports on, not by reading the config.
+
+## The gate was enforced; the gate's correctness was not
+
+Running the corrected census over test files rather than scripts produced the worse finding.
+
+| tool tests                | count |
+| ------------------------- | ----- |
+| in `tools/`               | 472   |
+| reachable from a workflow | 202   |
+| reachable from nothing    | 270   |
+
+No workflow ran the tools suite -- `node --test` appeared **zero** times outside individual script
+bodies. A test file was enforced only if someone registered a `package.json` script _and_ added a
+matching workflow step, so a new suite **defaults to unenforced**, and the default held for eight
+of thirteen suites.
+
+Among the unreachable: `check-doc-links.test.mjs`, 66 tests, whose checker `docs:links:check` is a
+required gate wired at `ci-lint.yml:144`. The gate ran on every PR. Nothing verified the gate was
+still correct. The slugger defects found earlier -- three of them, in one function -- are exactly
+the class of regression those 66 tests exist to catch, and CI could not have caught a reintroduction.
+
+Every **"468/468 tests pass"** reported to the sibling session was, for 270 of those tests, a
+purely local result. Same shape as their finding that engineering's own citation checker is run by
+no workflow in the repository that publishes it, and same shape as this guide's earlier discovery
+that its scope lines were all on the green path: the claim was true, and enforcement of it was not
+where the claim implied.
+
+### The fix is structural, not a list of steps
+
+Adding eight workflow steps would close today's gap and restore the default tomorrow. Instead
+`tools/run-tool-tests.mjs` enumerates `tools/*.test.mjs` **from disk** and runs all of them in one
+step, so a new suite is enforced by existing rather than by remembering.
+
+The population is enumerated rather than passed as a shell glob deliberately: a glob that matches
+nothing exits zero, and a green step over an empty population is indistinguishable from a passing
+one -- the decoy pattern flagged in the sibling's `pins:check`. `assertPopulation` throws instead.
+
+After wiring: **512 tool tests, 512 reachable, 0 unreachable.**
+
+### One failure the suite step found and this section cannot explain
+
+The first whole-suite run reported `pass 511, fail 1`. Four subsequent runs reported `512 / 0`, and
+the failing test's identity was not captured before the output was overwritten.
+
+Recorded as observed and unreproduced rather than fixed, because that is what is known. It does
+argue for the step on its own: fifteen files run concurrently exercise cross-file interactions that
+fifteen separate per-file runs cannot, and no per-file run had ever produced a failure. The
+`test:independence:check` gate checks that a test does not reimplement its tool; nothing was
+checking that a test does not interfere with another test.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:

--- a/package.json
+++ b/package.json
@@ -70,6 +70,8 @@
     "node:version:test": "node --test tools/check-node-version-consistency.test.mjs",
     "citations:context:test": "node --test tools/citations-context.test.mjs",
     "test:independence:check": "node tools/check-test-independence.mjs",
+    "tools:test": "node tools/run-tool-tests.mjs",
+    "gate:enforcement": "node tools/check-gate-enforcement.mjs",
     "docs:links:check": "node tools/check-doc-links.mjs",
     "docs:links:test": "node --test tools/check-doc-links.test.mjs"
   },

--- a/tools/check-gate-enforcement.mjs
+++ b/tools/check-gate-enforcement.mjs
@@ -1,0 +1,232 @@
+#!/usr/bin/env node
+/**
+ * Census which `package.json` scripts are actually invoked by a workflow.
+ *
+ * A gate is a workflow step, not a script. A `package.json` entry behaves identically to a gate
+ * every time a human runs it, and identically to nothing the rest of the time -- so "the script
+ * passes" and "the script is required to pass" are different claims that produce the same output.
+ *
+ * Two properties this instrument exists to hold, both learned from getting them wrong:
+ *
+ * 1. The population is **every** root script, never a suffix-filtered subset. An earlier hand
+ *    census looked at scripts ending in `:check` and thereby excluded `eng:citations`, which the
+ *    same document lists as a gate. Selecting by naming convention is a proxy for gate-ness, and
+ *    the proxy had known exceptions inside the document that used it.
+ *
+ * 2. Resolution tries **several** routes and reports which one matched. An orphan list is a claim
+ *    of absence; a single-route matcher cannot distinguish "not wired" from "wired by a route I
+ *    did not implement". Two such false positives were caught in practice -- one here, one
+ *    upstream -- and both were caught by colliding with prior knowledge rather than by any
+ *    instrument. Naming the matching route makes a false positive visible to a reader who does
+ *    not already know the answer.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+export const WORKFLOW_DIR = '.github/workflows';
+
+/** npm subcommands that run a same-named script without the `run` keyword. */
+export const NPM_LIFECYCLES = ['test', 'start', 'stop', 'restart'];
+
+/** Routes by which a script can reach a workflow, in the order they are tried. */
+export const ROUTES = ['npm run', 'npm lifecycle', 'file path', 'transitive', 'equivalent command'];
+
+/**
+ * Split a script body into the commands it runs, dropping `npm run` delegations.
+ *
+ * @param {string} body Script body from `package.json`.
+ * @returns {string[]} Command segments.
+ */
+export function commandSegments(body) {
+  return body
+    .split(/&&|\|\||;/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0 && !s.startsWith('npm run'));
+}
+
+/**
+ * Decide whether a workflow runs the same command as a script, without going through the script.
+ *
+ * This is a distinct verdict from "reached", and keeping it distinct is the point. CI runs
+ * `npx eslint . --max-warnings 0 --cache ...` directly rather than `npm run lint`, so the script
+ * `lint` is genuinely unreached while the check it performs is genuinely enforced. An earlier hand
+ * census conflated those, treating an unreached script as an unenforced gate. **An unreached
+ * script does not imply an unenforced check, and a reached one does not imply a required one.**
+ *
+ * Matching is by prefix, because a workflow commonly appends flags the script omits.
+ *
+ * @param {string} body Script body.
+ * @param {string} corpus Concatenated workflow text.
+ * @returns {boolean} True when some command segment also runs directly in a workflow.
+ */
+export function runsEquivalentCommand(body, corpus) {
+  return commandSegments(body).some((segment) => corpus.includes(segment));
+}
+
+/**
+ * Extract file paths a script body executes, so a workflow calling the tool directly still counts.
+ *
+ * @param {string} body Script body from `package.json`.
+ * @returns {string[]} Referenced paths, e.g. `tools/check-x.mjs`.
+ */
+export function scriptPaths(body) {
+  return [...body.matchAll(/(?:^|\s)([\w./-]+\.(?:mjs|cjs|js|ts|sh))(?=\s|$)/g)].map((m) => m[1]);
+}
+
+/**
+ * Extract script names a script body invokes via `npm run`.
+ *
+ * @param {string} body Script body from `package.json`.
+ * @returns {string[]} Invoked script names.
+ */
+export function scriptDeps(body) {
+  return [...body.matchAll(/npm run ([\w:-]+)/g)].map((m) => m[1]);
+}
+
+/**
+ * Decide whether a workflow corpus invokes a script directly.
+ *
+ * Returns the name of the matching route rather than a boolean, so a "wired" verdict carries its
+ * own evidence and a wrong route is visible without knowing the right answer in advance.
+ *
+ * @param {string} name Script name.
+ * @param {string} body Script body.
+ * @param {string} corpus Concatenated workflow text.
+ * @returns {string | null} Matching route name, or `null` when none matched.
+ */
+export function directRoute(name, body, corpus) {
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  if (new RegExp(`npm run ${escaped}(?![\\w:-])`).test(corpus)) return 'npm run';
+  if (NPM_LIFECYCLES.includes(name) && new RegExp(`npm ${escaped}(?![\\w:-])`).test(corpus)) {
+    return 'npm lifecycle';
+  }
+  for (const p of scriptPaths(body)) {
+    if (corpus.includes(p)) return 'file path';
+  }
+  return null;
+}
+
+/**
+ * Resolve every script to the route that reaches a workflow, following transitive invocation.
+ *
+ * @param {Record<string, string>} scripts Script name to body.
+ * @param {string} corpus Concatenated workflow text.
+ * @returns {Record<string, string | null>} Script name to matching route, or `null`.
+ */
+export function resolveRoutes(scripts, corpus) {
+  const routes = {};
+  for (const [name, body] of Object.entries(scripts)) {
+    routes[name] = directRoute(name, body, corpus);
+  }
+  // A script invoked by a wired script is itself enforced. Iterate to a fixed point rather than a
+  // single pass, so a chain of any depth resolves and the result does not depend on key order.
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const [name, body] of Object.entries(scripts)) {
+      if (routes[name] !== null) continue;
+      for (const dep of Object.keys(scripts)) {
+        if (routes[dep] === null) continue;
+        if (scriptDeps(scripts[dep]).includes(name)) {
+          routes[name] = 'transitive';
+          changed = true;
+          break;
+        }
+      }
+      void body;
+    }
+  }
+  // Equivalent-command detection runs last so a direct or transitive route always wins the label.
+  for (const [name, body] of Object.entries(scripts)) {
+    if (routes[name] === null && runsEquivalentCommand(body, corpus)) {
+      routes[name] = 'equivalent command';
+    }
+  }
+  return routes;
+}
+
+/**
+ * Summarise a census.
+ *
+ * @param {Record<string, string | null>} routes Script name to matching route.
+ * @returns {string[]} Report lines.
+ */
+export function reportLines(routes) {
+  const names = Object.keys(routes);
+  const wired = names.filter((n) => routes[n] !== null);
+  const equivalent = names.filter((n) => routes[n] === 'equivalent command');
+  const invoked = wired.length - equivalent.length;
+  const lines = [
+    `scripts in package.json     ${names.length}`,
+    `  invoked by a workflow     ${invoked}`,
+    `  same command runs, but    ${equivalent.length}`,
+    `    not via the script`,
+    `  reached by nothing        ${names.length - wired.length}`,
+    '',
+  ];
+  for (const route of ROUTES) {
+    lines.push(`  via ${route.padEnd(20)}${wired.filter((n) => routes[n] === route).length}`);
+  }
+  return lines;
+}
+
+/**
+ * State what this census counted and by which routes, so its claim of absence carries its scope.
+ *
+ * @param {Record<string, string | null>} routes Script name to matching route.
+ * @param {number} workflowCount Number of workflow files read.
+ * @returns {string[]} Scope lines.
+ */
+export function scopeLines(routes, workflowCount) {
+  const total = Object.keys(routes).length;
+  return [
+    `Scope: all ${total} root scripts, not a suffix-filtered subset -- an earlier census counted`,
+    `  only names ending in ':check' and so excluded eng:citations, a gate.`,
+    `  Corpus: ${workflowCount} workflow file(s) under ${WORKFLOW_DIR}.`,
+    `  Routes tried: ${ROUTES.join(', ')}. A script reached by none is reported unreached,`,
+    `  which is a claim of absence bounded by exactly these ${ROUTES.length} routes.`,
+    `  An unreached script does not imply an unenforced check: the 'equivalent command' bucket`,
+    `  is where the workflow runs the same command without going through the script.`,
+  ];
+}
+
+/**
+ * Render the unreached list, naming each script.
+ *
+ * @param {Record<string, string | null>} routes Script name to matching route.
+ * @returns {string[]} Report lines, empty when everything is reached.
+ */
+export function unreachedLines(routes) {
+  const orphans = Object.keys(routes)
+    .filter((n) => routes[n] === null)
+    .sort();
+  if (orphans.length === 0) return [];
+  return ['', 'reached by no workflow:', ...orphans.map((n) => `  ${n}`)];
+}
+
+/**
+ * Read and concatenate the workflow corpus.
+ *
+ * @param {string} [dir] Workflow directory.
+ * @returns {{corpus: string, count: number}} Concatenated text and file count.
+ */
+export function readWorkflows(dir = WORKFLOW_DIR) {
+  const files = fs.readdirSync(dir).filter((f) => f.endsWith('.yml') || f.endsWith('.yaml'));
+  const corpus = files.map((f) => fs.readFileSync(path.join(dir, f), 'utf8')).join('\n');
+  return { corpus, count: files.length };
+}
+
+function main() {
+  const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+  const { corpus, count } = readWorkflows();
+  const routes = resolveRoutes(pkg.scripts ?? {}, corpus);
+  for (const line of reportLines(routes)) console.log(line);
+  console.log('');
+  for (const line of scopeLines(routes, count)) console.log(line);
+  for (const line of unreachedLines(routes)) console.log(line);
+}
+
+if (process.argv[1] && process.argv[1].endsWith('check-gate-enforcement.mjs')) {
+  main();
+}

--- a/tools/check-gate-enforcement.test.mjs
+++ b/tools/check-gate-enforcement.test.mjs
@@ -1,0 +1,176 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  NPM_LIFECYCLES,
+  ROUTES,
+  commandSegments,
+  directRoute,
+  reportLines,
+  resolveRoutes,
+  runsEquivalentCommand,
+  scopeLines,
+  scriptDeps,
+  scriptPaths,
+  unreachedLines,
+} from './check-gate-enforcement.mjs';
+
+test('scriptPaths finds a script file executed by the body', () => {
+  assert.deepEqual(scriptPaths('node tools/check-x.mjs --flag'), ['tools/check-x.mjs']);
+});
+
+test('scriptPaths finds several paths in one body', () => {
+  assert.deepEqual(scriptPaths('node a/b.mjs && bash c/d.sh'), ['a/b.mjs', 'c/d.sh']);
+});
+
+test('scriptPaths ignores bodies with no file reference', () => {
+  assert.deepEqual(scriptPaths('npx eslint . --max-warnings 0'), []);
+});
+
+test('scriptDeps finds delegated script names', () => {
+  assert.deepEqual(scriptDeps('npm run a && npm run b:c'), ['a', 'b:c']);
+});
+
+test('directRoute matches an npm run invocation', () => {
+  assert.equal(directRoute('lint', 'x', 'run: npm run lint\n'), 'npm run');
+});
+
+test('directRoute does not match a longer script name by prefix', () => {
+  assert.equal(directRoute('lint', 'x', 'run: npm run lint:fix\n'), null);
+});
+
+test('directRoute matches a bare npm lifecycle', () => {
+  assert.equal(directRoute('test', 'x', 'run: npm test -w apps/web\n'), 'npm lifecycle');
+});
+
+test('directRoute does not treat a non-lifecycle name as a bare invocation', () => {
+  assert.equal(directRoute('lint', 'x', 'run: npm lint\n'), null);
+});
+
+test('NPM_LIFECYCLES covers the subcommands that run a same-named script', () => {
+  assert.ok(NPM_LIFECYCLES.includes('test'));
+  assert.ok(!NPM_LIFECYCLES.includes('lint'));
+});
+
+test('directRoute matches a tool invoked by path', () => {
+  const corpus = 'run: node tools/check-x.mjs\n';
+  assert.equal(directRoute('x:check', 'node tools/check-x.mjs', corpus), 'file path');
+});
+
+test('directRoute prefers npm run over file path when both would match', () => {
+  const corpus = 'npm run x:check\nnode tools/check-x.mjs\n';
+  assert.equal(directRoute('x:check', 'node tools/check-x.mjs', corpus), 'npm run');
+});
+
+test('commandSegments drops npm run delegations', () => {
+  assert.deepEqual(commandSegments('npm run a && npx eslint .'), ['npx eslint .']);
+});
+
+test('commandSegments splits on every chaining operator', () => {
+  assert.equal(commandSegments('a && b || c; d').length, 4);
+});
+
+test('runsEquivalentCommand matches when a workflow appends flags', () => {
+  assert.equal(
+    runsEquivalentCommand('npx eslint . --max-warnings 0', 'npx eslint . --max-warnings 0 --cache'),
+    true,
+  );
+});
+
+test('runsEquivalentCommand is false when the command does not appear', () => {
+  assert.equal(runsEquivalentCommand('npx eslint .', 'npm ci'), false);
+});
+
+test('resolveRoutes follows a transitive invocation', () => {
+  const scripts = { outer: 'npm run inner', inner: 'node x.mjs' };
+  const routes = resolveRoutes(scripts, 'run: npm run outer\n');
+  assert.equal(routes.outer, 'npm run');
+  assert.equal(routes.inner, 'transitive');
+});
+
+test('resolveRoutes follows a chain deeper than one level', () => {
+  const scripts = { a: 'npm run b', b: 'npm run c', c: 'node x.mjs' };
+  const routes = resolveRoutes(scripts, 'run: npm run a\n');
+  assert.equal(routes.c, 'transitive');
+});
+
+test('resolveRoutes does not mark a script reachable through an unreached one', () => {
+  const scripts = { outer: 'npm run inner', inner: 'node x.mjs' };
+  const routes = resolveRoutes(scripts, 'run: npm ci\n');
+  assert.equal(routes.inner, null);
+});
+
+test('resolveRoutes labels an equivalent command distinctly from an invocation', () => {
+  const scripts = { lint: 'npx eslint .' };
+  const routes = resolveRoutes(scripts, 'run: npx eslint . --cache\n');
+  assert.equal(routes.lint, 'equivalent command');
+});
+
+test('resolveRoutes prefers a direct route over the equivalent-command label', () => {
+  const scripts = { lint: 'npx eslint .' };
+  const routes = resolveRoutes(scripts, 'run: npm run lint\nrun: npx eslint .\n');
+  assert.equal(routes.lint, 'npm run');
+});
+
+test('resolveRoutes returns null for a script nothing reaches', () => {
+  assert.equal(resolveRoutes({ solo: 'node x.mjs' }, 'run: npm ci\n').solo, null);
+});
+
+const routes = {
+  a: 'npm run',
+  b: 'transitive',
+  c: 'equivalent command',
+  d: null,
+  e: null,
+};
+
+test('reportLines separates invocation from equivalent command', () => {
+  const lines = reportLines(routes);
+  assert.ok(lines.some((l) => l.includes('invoked by a workflow     2')));
+  assert.ok(lines.some((l) => l.includes('same command runs, but    1')));
+  assert.ok(lines.some((l) => l.includes('reached by nothing        2')));
+});
+
+test('reportLines does not count an equivalent command as an invocation', () => {
+  const only = reportLines({ c: 'equivalent command' });
+  assert.ok(only.some((l) => l.includes('invoked by a workflow     0')));
+});
+
+test('reportLines states a per-route count for every route', () => {
+  const lines = reportLines(routes);
+  for (const route of ROUTES) {
+    assert.ok(
+      lines.some((l) => l.includes(`via ${route}`)),
+      `missing route line for ${route}`,
+    );
+  }
+});
+
+test('scopeLines names the population and rejects the suffix subset', () => {
+  const lines = scopeLines(routes, 31);
+  assert.ok(lines[0].includes('all 5 root scripts'));
+  assert.ok(lines.some((l) => l.includes('eng:citations')));
+});
+
+test('scopeLines states the corpus size by value', () => {
+  assert.ok(scopeLines(routes, 31).some((l) => l.includes('31 workflow file(s)')));
+});
+
+test('scopeLines bounds its claim of absence by the routes tried', () => {
+  const lines = scopeLines(routes, 31);
+  assert.ok(lines.some((l) => l.includes(`these ${ROUTES.length} routes`)));
+});
+
+test('scopeLines says an unreached script is not an unenforced check', () => {
+  assert.ok(scopeLines(routes, 31).some((l) => l.includes('does not imply an unenforced check')));
+});
+
+test('unreachedLines names each unreached script', () => {
+  const lines = unreachedLines(routes);
+  assert.ok(lines.includes('  d'));
+  assert.ok(lines.includes('  e'));
+});
+
+test('unreachedLines returns nothing when everything is reached', () => {
+  assert.deepEqual(unreachedLines({ a: 'npm run' }), []);
+});

--- a/tools/run-tool-tests.mjs
+++ b/tools/run-tool-tests.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+/**
+ * Run every tool test file, enumerating the population explicitly.
+ *
+ * This exists because tool tests were previously reachable only by individually registering each
+ * one as a `package.json` script *and* adding a matching workflow step. Under that scheme a new
+ * test file defaults to **unenforced**, and the default held: 270 of 472 tool tests were run by no
+ * workflow, including the suite for a checker that is itself a required gate. The gate was
+ * enforced; the gate's correctness was not.
+ *
+ * The population is enumerated from disk rather than passed as a shell glob, because a glob that
+ * matches nothing exits zero and produces a green step over an empty population -- a check that
+ * cannot fail is indistinguishable from one that passes. `assertPopulation` makes that state loud.
+ */
+
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+export const TOOLS_DIR = 'tools';
+
+/**
+ * List every tool test file.
+ *
+ * @param {string} [dir] Directory to scan.
+ * @param {{readdirSync: Function}} [fsImpl] Injectable fs for tests.
+ * @returns {string[]} Paths, sorted.
+ */
+export function testFiles(dir = TOOLS_DIR, fsImpl = fs) {
+  return fsImpl
+    .readdirSync(dir)
+    .filter((f) => f.endsWith('.test.mjs'))
+    .sort()
+    .map((f) => path.join(dir, f));
+}
+
+/**
+ * Refuse to report success over an empty population.
+ *
+ * @param {string[]} files Discovered test files.
+ * @throws {Error} When no test file was found.
+ */
+export function assertPopulation(files) {
+  if (files.length === 0) {
+    throw new Error(
+      `no *.test.mjs found under ${TOOLS_DIR}/ -- refusing to exit zero over an empty population`,
+    );
+  }
+}
+
+/**
+ * Describe the run.
+ *
+ * @param {string[]} files Discovered test files.
+ * @returns {string[]} Report lines.
+ */
+export function reportLines(files) {
+  return [
+    `tool test files discovered  ${files.length}`,
+    `  enumerated from ${TOOLS_DIR}/ on disk, not from a shell glob`,
+  ];
+}
+
+function main() {
+  const files = testFiles();
+  assertPopulation(files);
+  for (const line of reportLines(files)) console.log(line);
+  const result = spawnSync(process.execPath, ['--test', ...files], { stdio: 'inherit' });
+  process.exitCode = result.status ?? 1;
+}
+
+if (process.argv[1] && process.argv[1].endsWith('run-tool-tests.mjs')) {
+  main();
+}

--- a/tools/run-tool-tests.test.mjs
+++ b/tools/run-tool-tests.test.mjs
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { TOOLS_DIR, assertPopulation, reportLines, testFiles } from './run-tool-tests.mjs';
+
+test('testFiles selects only test files', () => {
+  const fake = { readdirSync: () => ['a.mjs', 'a.test.mjs', 'b.test.mjs'] };
+  const files = testFiles('tools', fake);
+  assert.equal(files.length, 2);
+  assert.ok(files.every((f) => f.endsWith('.test.mjs')));
+});
+
+test('testFiles returns a sorted list', () => {
+  const fake = { readdirSync: () => ['z.test.mjs', 'a.test.mjs'] };
+  const files = testFiles('tools', fake);
+  assert.ok(files[0].endsWith('a.test.mjs'));
+});
+
+test('testFiles finds this repository real suites', () => {
+  assert.ok(testFiles().length >= 10);
+});
+
+test('testFiles includes this very file, so the population contains its own checker', () => {
+  assert.ok(testFiles().some((f) => f.endsWith('run-tool-tests.test.mjs')));
+});
+
+test('assertPopulation throws rather than exiting zero over nothing', () => {
+  assert.throws(() => assertPopulation([]), /empty population/);
+});
+
+test('assertPopulation accepts a non-empty population', () => {
+  assert.doesNotThrow(() => assertPopulation(['tools/a.test.mjs']));
+});
+
+test('reportLines states the discovered count by value', () => {
+  assert.ok(reportLines(['a', 'b', 'c'])[0].includes('3'));
+});
+
+test('reportLines distinguishes counts that differ', () => {
+  assert.notEqual(reportLines(['a'])[0], reportLines(['a', 'b'])[0]);
+});
+
+test('reportLines records that the population came from disk', () => {
+  assert.ok(reportLines(['a'])[1].includes('not from a shell glob'));
+});
+
+test('TOOLS_DIR is the directory the census and the runner share', () => {
+  assert.equal(TOOLS_DIR, 'tools');
+});


### PR DESCRIPTION
Closes #4293

## Summary

A sibling session's orphan census found scripts that look like gates but are invoked by no
workflow. Reproducing that measurement here found three defects in finance's own published
census, and then a larger enforcement gap underneath it.

## Changes

- `tools/check-gate-enforcement.mjs` (+ 30 tests) - censuses all 62 root scripts against the
  31-workflow corpus, resolving five routes (`npm run`, npm lifecycle, file path, transitive,
  equivalent command) and **printing which route matched**. An orphan list is a claim of absence;
  a single-route matcher cannot distinguish "not wired" from "wired by a route I did not
  implement".
- `tools/run-tool-tests.mjs` (+ 10 tests) - runs every `tools/*.test.mjs` enumerated **from
  disk**, not from a shell glob. A glob matching nothing exits zero, producing a green step over
  an empty population; `assertPopulation` throws instead.
- Two `ci-lint.yml` steps: `Tool test suites` and `Every script is reachable, or reported
  unreached`.
- Guide: two sections recording the population-by-naming-convention error and the enforcement gap.

## Findings

- The published census counted the 14 scripts ending in `:check`. The documented gate list's
  first entry is `eng:citations`, which has no such suffix. Two populations were used
  interchangeably for six sections and never reconciled.
- **An unreached script is not an unenforced check.** CI runs `npx eslint .` and
  `npx prettier --check .` directly, never `npm run lint`. 62 scripts: 26 invoked,
  5 equivalent-command, 31 unreached.
- **270 of 472 tool tests were run by nothing** - including the 66 tests of
  `check-doc-links.mjs`, whose checker is a required gate. The gate was enforced; the gate's
  correctness was not. Individually-registered enforcement defaults to unenforced, so the fix is
  structural (one disk-enumerated step) rather than eight steps that restore the default tomorrow.

## Testing

- [x] `npm run format:check` / `npx eslint . --max-warnings 0` / `npm run type-check`
- [x] `npm run tools:test` - 512/512
- [x] All 13 gate scripts exit 0