### PR TITLE
feat(tools): derive a breadth floor and require every numeric bound to name its source

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -155,6 +155,12 @@ jobs:
 
       - name: Every script is reachable, or reported unreached
         run: npm run gate:enforcement
+
+      # A bound compared against a bare number can never be contradicted: it excludes some values
+      # and names no source. This requires every numeric threshold in tools/ to be either derived
+      # from the artifact that already commits to the number, or annotated with why none does.
+      - name: Every numeric bound names its source
+        run: npm run bounds:check
   pr-title:
     name: Semantic PR Title
     needs: changes

--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -8910,6 +8910,74 @@ Nine bounds now carry an annotation naming what was looked for and not found. Th
 is the honest record of an invented number, which is the most this rule can ask for when nothing in
 the tree commits to one.
 
+### "All 16 gates green" was a claim over a population that excluded the new files
+
+The commit passed all sixteen gates locally and failed `test:independence:check` in CI, which
+flagged two lines of the new test file as reimplementing the tool they verify:
+
+```
+UNCLASSIFIED check-assertion-bounds.test.mjs:177 ~ check-assertion-bounds.mjs:255
+  const unannotated = result.bounds.filter((bound) => !bound.annotated);
+UNCLASSIFIED check-assertion-bounds.test.mjs:196 ~ check-assertion-bounds.mjs:205
+  .filter((name) => name.endsWith('.mjs') || name.endsWith('.js'));
+```
+
+Both are real. The first recomputes the expression `report()` uses to reach its verdict, so the test
+decides the answer and cannot notice the rule changing. The second reruns the extension filter it is
+supposed to be checking.
+
+The reason the local run disagreed is the interesting half. `check-test-independence.mjs` discovers
+its input with `git ls-files tools/*.mjs`, and at the moment the sixteen-gate loop ran, both new
+files were **untracked**. The gate could not see the only files that could have failed it.
+
+This is precisely the finding the sibling session reported several rounds earlier — _any tool that
+discovers its input from version control is blind to itself during exactly the window it is being
+written in_ — which was acknowledged here, written into the guide, and then walked into anyway. The
+local green and the CI red were both correct readings of different populations, and only one was the
+question being asked.
+
+So the report "all 16 gates green" was true and useless, in the same way "both checkers pass, exit
+0" was. A gate run against a population that excludes the change under test measures the tree as it
+was before the work started. The cheap correction is to `git add` before running gates rather than
+after, which costs nothing and moves the untracked window to before the measurement instead of
+after it.
+
+The fixes are the ones the gate asked for: the verdict test now calls `report()` and asserts its
+`ok`, and the enumeration test asserts properties — sorted, inside the directory, all real files,
+includes itself, excludes `README.md` and `setup-branch-protection.sh` — rather than rerunning the
+selection. A test that recomputes the selection agrees with itself whatever the selection becomes.
+
+### The unexplained suite failure, now characterised
+
+Last round recorded a single whole-suite run reporting `pass 511, fail 1` that four subsequent runs
+did not reproduce, with the failing test's identity uncaptured. Recorded then as observed and
+unreproduced. It reproduced this round at **1 run in 4**, and it is:
+
+```
+✖ a passing run states the scope   (check-workflow-security.test.mjs:403)
+  AssertionError: The input did not match /\d+ workflow\(s\) scanned in /. Input: ''
+  status: 0
+```
+
+Exit **0** with an **empty** stdout. Three things rule out the obvious explanations: the tool's CLI
+guard is the robust `resolve(process.argv[1]) === fileURLToPath(import.meta.url)` form, not the
+template-literal one that had just silently disabled a different tool; its exit path sets
+`process.exitCode` rather than calling `process.exit`, so stdout is flushed on a natural exit; and
+**40 isolated spawns produced 0 empty captures**. It only appears under the concurrent whole-suite
+run, on Windows. That localises it to `spawnSync` pipe capture under heavy concurrent process
+creation — a harness flake, not a tool defect, and one CI has not exhibited on `ubuntu-latest`.
+
+It is not retried. A silent retry would convert a visible 1-in-4 into an invisible 1-in-16 and
+report the same green either way. What was added instead is a `detail` string carrying `status`,
+`signal`, `error`, stdout length and stderr, attached to every assertion in the test — so the next
+occurrence explains itself rather than requiring the whole diagnosis to be re-derived from a bare
+regex mismatch.
+
+The general point is about what an unreproduced observation is worth. Last round the honest options
+were to drop it or record it; recording it cost one sentence and made this round's reproduction
+recognisable within seconds instead of being greeted as new. **An intermittent failure you have
+written down is a different object from one you have not**, even while both remain unexplained.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:

--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -8811,6 +8811,105 @@ fifteen separate per-file runs cannot, and no per-file run had ever produced a f
 `test:independence:check` gate checks that a test does not reimplement its tool; nothing was
 checking that a test does not interfere with another test.
 
+## A constant that restates a number cannot notice the number is wrong
+
+A sibling session measured `jrmoulckers/engineering`'s bounded assertions and reported a negative:
+138 of its 154 `assert.ok` calls are genuine boolean predicates, not thresholds. But it also found
+what made its ten real bounds good, and that part transfers:
+
+```js
+assert.ok(react.size >= 18, `docs claim 18 react/* rules; the preset enables ${react.size}`);
+```
+
+The number 18 was not invented. It came from **another artifact that had already committed to a
+number** — the documentation. That turns an inequality into a two-artifact consistency check: it
+can fail because the preset shrank _or_ because the docs went stale, and both are real defects. Its
+formulation of the rule is better than "avoid inequalities":
+
+> When you don't know the expected value, don't invent one; find the artifact that already asserts
+> one. If nothing in the repository commits to a number, that absence is the finding, and an
+> inequality papers over it.
+
+Applied here, the census came back similar in shape — 129 of 173 `assert.ok` calls are predicates,
+32 are existence checks, 12 are numeric bounds — and **all 12 bounds invented their number.** One of
+them had a source available in the same file and ignored it.
+
+### The defect
+
+`tools/check-ai-manifest.js` sorts files into three comment families. `corpusBreadth()` exists to
+report when the recorded corpus is too narrow to certify that three-way switch:
+
+```js
+const BREADTH_FLOOR = { families: 2, rootLevel: 1 };
+```
+
+Four lines above it, the rationale comment reads _"an assertion over one family certifies the switch
+on a third of it."_ The finding message hardcodes `across 3`. The floor is 2.
+
+Measured against the real lock (81 entries, all three families exercised):
+
+```
+drop 'hash'  -> families 2, findings 0
+drop 'html'  -> families 2, findings 0
+drop 'block' -> families 2, findings 0
+```
+
+**Deleting an entire comment family produced no finding.** The guard against certifying a fraction
+of the switch could not detect the loss of a third of it.
+
+Nothing caught this because everything that could have was self-consistent. The test pinning the
+floor read `assert.ok(BREADTH_FLOOR.families >= 2, 'one family cannot certify a three-way switch')`
+— a message naming three, a bound of two, and a pass. And one fixture was worse:
+
+```js
+// Two families clears the floor; the root-level arm is satisfied by AGENTS.md.
+assert.deepEqual(corpusBreadth({ entries: { 'AGENTS.md': {}, 'agency.toml': {} } }), []);
+```
+
+That is the defect written down as expected behaviour, in prose, and asserted. An inequality
+restating a constant cannot notice the constant is wrong, because the restatement is the only thing
+it is checked against.
+
+The fix is to derive: `families: FAMILY_SETS.length`. The bound now moves if a fourth family is ever
+added, and the test asserts the derivation rather than the value.
+
+### The general control, and its two wrong populations
+
+`tools/check-assertion-bounds.mjs` enforces the rule syntactically rather than judging whether a
+number is right, which no tool can do. A comparison against a bare numeric literal must be either an
+existence check or carry an `unsourced-bound:` note saying what source was looked for. A bound
+compared against an _expression_ never enters the population at all — that is the fixed form.
+
+Its first run reported **49 unsourced bounds**, of which 40 were semver ranges inside string
+arguments: `enginesAdmitsAbove('>=22.0.0 <23', '22')`. Data being handed to a parser, counted as a
+threshold someone chose. Its second reported **14**, still counting `assert.ok(dirtySeconds >= 0)` —
+a sign assertion, where zero is a boundary rather than a choice. The real number is **9**.
+
+Both errors are the same one this repository keeps making: **a syntactic pattern is not a semantic
+class.** The census that preceded this one picked its population by the `:check` suffix; this one
+picked it by a regex. And `49 of 49` was the most impressive-looking number of the three.
+
+The direction matters. A checker that over-reports is making a false accusation, and the specific
+cost is that the annotations it forces become rubber stamps — the author writes `unsourced-bound:`
+on a sign check, learns the marker is noise, and writes it on the next real one without looking.
+
+### The checker exited 0 having done nothing
+
+Its first invocation printed no report and exited 0. The CLI guard was
+
+```js
+import.meta.url === `file://${process.argv[1].replace(/\\/g, '/')}`;
+```
+
+which yields `file://C:/...` where `import.meta.url` is `file:///C:/...`. Two slashes against three,
+so `main` never ran. **A green run over an empty population** — the exact decoy the file's own
+docblock argues against, manufactured by that file, and caught only because a report was expected
+and none appeared. The repository already had the correct form, `pathToFileURL`, in two other tools.
+
+Nine bounds now carry an annotation naming what was looked for and not found. That is not a fix; it
+is the honest record of an invented number, which is the most this rule can ask for when nothing in
+the tree commits to one.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "test:independence:check": "node tools/check-test-independence.mjs",
     "tools:test": "node tools/run-tool-tests.mjs",
     "gate:enforcement": "node tools/check-gate-enforcement.mjs",
+    "bounds:check": "node tools/check-assertion-bounds.mjs",
     "docs:links:check": "node tools/check-doc-links.mjs",
     "docs:links:test": "node --test tools/check-doc-links.test.mjs"
   },

--- a/tools/check-ai-manifest.js
+++ b/tools/check-ai-manifest.js
@@ -1271,7 +1271,21 @@ function commentFamily(entryPath) {
 // So the judgement lives here, in production, where a mutation is observable by a named test
 // and the degenerate states can be constructed rather than waited for. It reports rather than
 // throws: a narrowed corpus is a real change in what the green check means, not a broken tool.
-const BREADTH_FLOOR = { families: 2, rootLevel: 1 };
+//
+// #4296: `families` was 2 for a switch this file states is three-way, and the number 3 was
+// derivable four lines up. A corpus that lost an entire family passed the guard meant to catch
+// exactly that -- measured, all three drops reported nothing. So the floor is now taken from the
+// artifact that already commits to the number (the family sets themselves) rather than restated.
+// An inequality is only as good as the source of its constant; a restated constant has none.
+const FAMILY_SETS = [HASH_EXTENSIONS, BLOCK_EXTENSIONS, HTML_EXTENSIONS];
+const FAMILY_EXTENSION_COUNT = FAMILY_SETS.reduce((sum, set) => sum + set.size, 0);
+const BREADTH_FLOOR = {
+  families: FAMILY_SETS.length,
+  // unsourced-bound: nothing in the repository commits to a nesting depth, so this floor is
+  // invented and says only that the walk-reaches-root assertion is not vacuous. Recorded rather
+  // than dressed up as derived -- per #4296 the absence of a source is itself the finding.
+  rootLevel: 1,
+};
 
 /**
  * Report when the recorded corpus is too narrow for the suite's per-family and per-depth
@@ -1290,9 +1304,9 @@ function corpusBreadth(lock) {
 
   if (families.size < BREADTH_FLOOR.families) {
     findings.push(
-      `corpus exercises ${families.size} comment family/families ` +
+      `corpus exercises ${families.size} of ${BREADTH_FLOOR.families} comment families ` +
         `(${[...families].sort().join(', ') || 'none'}); the unstamp switch has ` +
-        `${HASH_EXTENSIONS.size + BLOCK_EXTENSIONS.size + HTML_EXTENSIONS.size} extensions across 3, ` +
+        `${FAMILY_EXTENSION_COUNT} extensions across ${FAMILY_SETS.length}, ` +
         'so a passing family assertion would certify a fraction of it',
     );
   }
@@ -1755,6 +1769,7 @@ module.exports = {
   driftEnforcement,
   enforcementFindings,
   BREADTH_FLOOR,
+  FAMILY_SETS,
   corpusBreadth,
   HASH_EXTENSIONS,
   BLOCK_EXTENSIONS,

--- a/tools/check-ai-manifest.test.mjs
+++ b/tools/check-ai-manifest.test.mjs
@@ -33,6 +33,7 @@ const {
   driftEnforcement,
   enforcementFindings,
   BREADTH_FLOOR,
+  FAMILY_SETS,
   corpusBreadth,
   HASH_EXTENSIONS,
   BLOCK_EXTENSIONS,
@@ -358,7 +359,13 @@ test('managed targets unstamp to their recorded canon source', () => {
   assert.equal(asDelivered, 0, 'delivered form should never match a pre-stamp hash');
   assert.equal(corruptedReproduced, 0, 'a corrupted body must not reproduce');
   // Breadth guard: a corpus exercising one family would certify the switch on a third of it.
-  assert.ok(families.size >= 2, `switch exercised on only ${families.size} comment family`);
+  // #4296: this read `>= 2` under a comment naming thirds. Derived from the family sets so the
+  // bound moves if a fourth family is ever added, instead of silently admitting a narrower corpus.
+  assert.equal(
+    families.size,
+    FAMILY_SETS.length,
+    `switch exercised on only ${families.size} of ${FAMILY_SETS.length} comment families`,
+  );
 });
 
 test('every recorded source is accounted for, not silently excluded', () => {
@@ -1078,13 +1085,25 @@ test('an empty corpus is reported rather than passing vacuously (#4256)', () => 
 test('a single-family corpus cannot certify the unstamp switch (#4256)', () => {
   const oneFamily = corpusBreadth({ entries: { 'AGENTS.md': {}, 'docs/x.md': {} } });
   assert.equal(oneFamily.length, 1);
-  assert.match(oneFamily[0], /1 comment family/);
-  // Two families clears the floor; the root-level arm is satisfied by AGENTS.md.
-  assert.deepEqual(corpusBreadth({ entries: { 'AGENTS.md': {}, 'agency.toml': {} } }), []);
+  assert.match(oneFamily[0], /1 of 3 comment families/);
+  // #4296: this line read `Two families clears the floor` and asserted []. It was true under a
+  // floor of 2 and it is the defect written down as expected behaviour -- the prose named the
+  // three-way switch while the assertion certified two thirds of it. Two families is now a
+  // finding, and only a corpus exercising all three is silent.
+  const twoFamilies = corpusBreadth({ entries: { 'AGENTS.md': {}, 'agency.toml': {} } });
+  assert.equal(twoFamilies.length, 1, 'two of three families is a narrowed corpus');
+  assert.match(twoFamilies[0], /2 of 3 comment families/);
+  assert.deepEqual(
+    corpusBreadth({ entries: { 'AGENTS.md': {}, 'agency.toml': {}, 'x.js': {} } }),
+    [],
+    'all three families with a root-level entry is the only silent case',
+  );
 });
 
 test('a corpus with no root-level entry is reported (#4256)', () => {
-  const nested = corpusBreadth({ entries: { 'x/a.md': {}, 'x/b.toml': {} } });
+  // Every family is present so the family arm stays silent and this isolates the depth arm --
+  // the old fixture was itself a 2-of-3 corpus, which the corrected floor now reports (#4296).
+  const nested = corpusBreadth({ entries: { 'x/a.md': {}, 'x/b.toml': {}, 'x/c.js': {} } });
   assert.equal(nested.length, 1);
   assert.match(nested[0], /no root-level entries/);
 });
@@ -1096,9 +1115,35 @@ test('the real corpus clears the floor, and the floor is not zero (#4256)', () =
     [],
     'the recorded corpus should support its own assertions',
   );
-  // A floor of zero would make the guard unfalsifiable -- the defect it exists to prevent.
-  assert.ok(BREADTH_FLOOR.families >= 2, 'one family cannot certify a three-way switch');
+  // #4296: this was `>= 2` against a message naming a three-way switch, and it passed. An
+  // inequality restating a constant cannot notice that the constant is wrong -- so assert the
+  // derivation instead. The floor is the family count or the guard admits a corpus missing a
+  // family, which is the exact narrowing it exists to report.
+  assert.equal(
+    BREADTH_FLOOR.families,
+    FAMILY_SETS.length,
+    'the floor must be the number of comment families, not a restatement of one',
+  );
   assert.ok(BREADTH_FLOOR.rootLevel >= 1);
+});
+
+test('dropping any whole comment family is reported (#4296)', () => {
+  const lock = JSON.parse(fs.readFileSync(path.join(ROOT, SYNC_LOCK), 'utf8'));
+  const entries = Object.keys(lock.entries ?? {});
+  const families = [...new Set(entries.map(commentFamily).filter((family) => family !== null))];
+  // PREMISE: the recorded corpus exercises every family, so each drop is a real narrowing.
+  assert.equal(families.length, FAMILY_SETS.length, 'PREMISE: the corpus covers every family');
+
+  for (const dropped of families) {
+    const kept = entries.filter((entry) => commentFamily(entry) !== dropped);
+    const findings = corpusBreadth({
+      entries: Object.fromEntries(kept.map((entry) => [entry, {}])),
+    });
+    // Under the old floor of 2 every one of these returned []. That is the whole defect: a
+    // corpus certifying two thirds of a three-way switch was indistinguishable from a whole one.
+    assert.equal(findings.length, 1, `dropping '${dropped}' must be reported, not tolerated`);
+    assert.match(findings[0], /comment families/);
+  }
 });
 
 test('validateSyncLock still reports a degenerate corpus (#4256)', () => {
@@ -1257,6 +1302,8 @@ test('the scanned population is derived from the surface, not narrowed to a samp
     }
   });
   const scanned = new Set(citationCorpus().map((entry) => entry.path));
+  // unsourced-bound: nothing commits to how many files claim a citation; the number tracks the
+  // repo's prose and moves with every doc edit. 5 says only "more than a handful" (#4296).
   assert.ok(expected.length > 5, 'PREMISE: git sees a non-trivial claimant population');
   for (const relPath of expected) {
     assert.ok(scanned.has(relPath), `citationCorpus omits a claimant file: ${relPath}`);
@@ -1341,6 +1388,8 @@ test('the printed help lists every validator, not a sentence about some of them 
   // one level up. The count claims are re-checked here because deriving the list must not
   // quietly drop the interpolation the older test pins.
   const out = execFileSync(process.execPath, [TOOL, '--help'], { encoding: 'utf8' });
+  // unsourced-bound: the registry's size is not committed to anywhere; it is whatever
+  // validators exist. 3 says only that a one-entry registry cannot certify a dispatch (#4296).
   assert.ok(VALIDATORS.length > 3, 'PREMISE: there is a non-trivial registry to advertise');
   for (const validator of VALIDATORS) {
     assert.ok(out.includes(validator.label), `--help omits a validator: ${validator.id}`);
@@ -1355,6 +1404,7 @@ test('the registry is checked against the dispatch, not against itself (#4278)',
   // The independent enumeration is the dispatch `main` really passes: runner keys, not labels.
   const wired = Object.keys(activationRunners({})).sort();
   const advertised = VALIDATORS.map((validator) => validator.id).sort();
+  // unsourced-bound: mirrors the registry premise above; no artifact states a dispatch size.
   assert.ok(wired.length > 3, 'PREMISE: a non-trivial dispatch exists to compare against');
   assert.deepEqual(advertised, wired, 'every dispatched validator needs a --help row, and back');
 });
@@ -1424,6 +1474,8 @@ test('the received set is read from the lock, not written down beside the rule (
   const lock = JSON.parse(fs.readFileSync(path.join(ROOT, '.studio-sync.lock.json'), 'utf8'));
   const recorded = Object.keys(lock.entries ?? lock);
   const managed = managedTargets();
+  // unsourced-bound: the lock's entry count is the sync engine's output, and nothing declares
+  // an expected size. Pinning the current 81 would fail on every legitimate sync (#4296).
   assert.ok(recorded.length > 20, 'PREMISE: the lock records a non-trivial delivered surface');
   assert.equal(managed.size, recorded.length, 'every recorded target counts as received');
   for (const entry of recorded)
@@ -1451,8 +1503,12 @@ test('the report states the received population the exemption depends on (#4281)
     /Unowned-file citations: (\d+) coordinate\(s\) in (\d+) file\(s\)[^;]*; (\d+) received/,
   );
   assert.ok(line, 'the report must state coordinates, corpus size and received-set size');
+  // unsourced-bound: corpus size is discovered by a walk, not declared. The received-set size
+  // on the next line IS sourced -- from managedTargets() -- which is the contrast (#4296).
   assert.ok(Number(line[2]) > 10, 'the corpus must be non-trivial');
   assert.equal(Number(line[3]), managedTargets().size);
+  // unsourced-bound: guards against an emptied set; the exact size is asserted separately
+  // against managedTargets(), so this bound only has to exclude the degenerate case (#4296).
   assert.ok(Number(line[3]) > 20, 'an empty received set would silently restore the exemption');
 });
 test('the PRODUCTION predicate, not a test copy, distinguishes owned from received (#4281)', () => {

--- a/tools/check-assertion-bounds.mjs
+++ b/tools/check-assertion-bounds.mjs
@@ -1,0 +1,297 @@
+#!/usr/bin/env node
+/**
+ * Every numeric bound must name where its number came from (#4296).
+ *
+ * A sibling session measured `jrmoulckers/engineering`'s bounded assertions and found the good
+ * ones did not invent their constants -- they took them from an artifact that had already
+ * committed to a number ("the docs claim 18 react/* rules"). That turns an inequality into a
+ * two-artifact consistency check: it can now fail because the code shrank OR because the doc went
+ * stale, and both are real defects. An invented constant excludes some values and names no source,
+ * so nothing can ever contradict it.
+ *
+ * The motivating defect: `BREADTH_FLOOR.families` was 2 for a switch the same file states is
+ * three-way, with the number 3 derivable four lines up. Dropping an entire comment family from the
+ * corpus produced zero findings -- the guard against certifying a fraction of the switch could not
+ * detect losing a third of it. The test pinning the floor read `>= 2` with the message "one family
+ * cannot certify a three-way switch", so it agreed with itself and reported nothing.
+ *
+ * The rule enforced here is deliberately NOT a judgement about whether a number is right, which no
+ * tool can decide. It is syntactic and total:
+ *
+ *   A comparison against a bare numeric literal must either be an existence check (`> 0`, `>= 1`,
+ *   and their mirrors, which exclude exactly one value) or carry an `unsourced-bound:` note.
+ *
+ * A bound compared against an *expression* never enters the population, because that is the fixed
+ * form -- the constant then moves with its source. So the population is precisely the set of
+ * invented numbers, and the annotation forces the author to record which artifact they looked for
+ * and failed to find. Per the sibling's formulation: if nothing in the repo commits to a number,
+ * that absence is itself the finding, and an inequality papers over it.
+ *
+ * Usage: node tools/check-assertion-bounds.mjs
+ */
+
+import { readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+export const TOOLS_DIR = HERE;
+
+/** Marker an author writes to record that no artifact commits to the number. */
+export const UNSOURCED_MARKER = 'unsourced-bound:';
+
+/** How many preceding lines may carry the marker for a bound. */
+export const MARKER_LOOKBEHIND = 4;
+
+/**
+ * Comparisons excluded from the population.
+ *
+ * Two kinds, neither of which involves a chosen number:
+ *
+ * - **existence** (`> 0`, `>= 1`, `< 1`, `<= 0`) excludes exactly one value, emptiness. It asserts
+ *   a population exists, not that it has a particular size.
+ * - **sign** (`>= 0`, `< 0`) asserts which side of zero a quantity falls on. Zero is the sign
+ *   boundary, not a threshold anyone picked -- `assert.ok(dirtySeconds >= 0)` says a clock skew
+ *   must not subtract exposure, and there is no artifact that could commit to a different number.
+ *
+ * Both were in the population when this checker first ran, which is why it reported 14 bounds where
+ * 10 are real. A checker that over-reports is making a false accusation, and the cost is that the
+ * annotations it forces become rubber stamps.
+ */
+const EXISTENCE = new Set(['>0', '>=1', '<1', '<=0', '>=0', '<0']);
+
+/**
+ * Blank out string and template literals, preserving length and line structure.
+ *
+ * The first version of this checker did not do this and reported 49 unsourced bounds, 40 of which
+ * were semver ranges *inside string arguments* -- `enginesAdmitsAbove('>=22.0.0 <23', '22')`. Those
+ * are data being passed to a parser, not a threshold anyone chose. A syntactic pattern is not a
+ * semantic class, and counting one as the other is how a population gets picked by proxy.
+ *
+ * @param {string} line Source line.
+ * @returns {string} The line with literal contents replaced by spaces.
+ */
+export function stripLiterals(line) {
+  return line.replace(/(['"`])(?:\\.|(?!\1)[^\\])*\1/g, (match) => match[0].repeat(match.length));
+}
+
+/**
+ * Extract every numeric-literal *inequality* from a line of source.
+ *
+ * Equality against a literal (`=== 3`) is deliberately out of scope. It is the strongest available
+ * form -- an exact expected value, falsifiable by any change at all -- and the sibling's rule is
+ * about inequalities, which are reached for precisely when the author does not know the expected
+ * value. Counting exact expectations as invented bounds inverts the finding.
+ *
+ * Matches the operand order `expr OP literal` only. `2 <= x` is vanishingly rare in this tree and
+ * silently treating a miss as a pass would be the checker's own version of the bug it exists to
+ * catch, so misses are surfaced by {@link reversedComparisons} rather than ignored.
+ *
+ * @param {string} line Source line.
+ * @returns {{operator: string, value: number, token: string}[]} Comparisons found.
+ */
+export function comparisons(line) {
+  const found = [];
+  const pattern = /(>=|<=|>|<)\s*(\d+(?:\.\d+)?)\b/g;
+  let match;
+  while ((match = pattern.exec(stripLiterals(line))) !== null) {
+    const [, operator, digits] = match;
+    found.push({ operator, value: Number(digits), token: `${operator}${digits}` });
+  }
+  return found;
+}
+
+/**
+ * Find `literal OP expr` comparisons, which {@link comparisons} does not classify.
+ *
+ * Reported rather than skipped: an unparsed form is an unmeasured one, and a checker that quietly
+ * narrows its own population is the failure this file was written about.
+ *
+ * @param {string} line Source line.
+ * @returns {string[]} The reversed comparison tokens found.
+ */
+export function reversedComparisons(line) {
+  const found = [];
+  const pattern = /\b(\d+(?:\.\d+)?)\s*(>=|<=|>|<)\s*[A-Za-z_$([]/g;
+  let match;
+  while ((match = pattern.exec(stripLiterals(line))) !== null) found.push(`${match[1]}${match[2]}`);
+  return found;
+}
+
+/**
+ * True when a comparison only distinguishes an empty population from a non-empty one.
+ *
+ * @param {{token: string}} comparison A comparison from {@link comparisons}.
+ * @returns {boolean} Whether it is an existence check rather than a bound.
+ */
+export function isExistence(comparison) {
+  return EXISTENCE.has(comparison.token.replace(/\s+/g, ''));
+}
+
+/**
+ * True when the marker appears on the line or close enough above it to be about this bound.
+ *
+ * @param {string[]} lines All lines of the file.
+ * @param {number} index Zero-based index of the line carrying the bound.
+ * @returns {boolean} Whether an `unsourced-bound:` note covers it.
+ */
+export function hasMarker(lines, index) {
+  const start = Math.max(0, index - MARKER_LOOKBEHIND);
+  return lines.slice(start, index + 1).some((line) => line.includes(UNSOURCED_MARKER));
+}
+
+/**
+ * True for lines this checker judges. Assertions everywhere, plus threshold constants in tools.
+ *
+ * A threshold constant is included because the motivating defect lived in production, not in a
+ * test: a floor named `*_FLOOR` is a bound whoever reads the guard will trust.
+ *
+ * @param {string} line Source line.
+ * @returns {boolean} Whether the line is in scope.
+ */
+export function isJudged(line) {
+  if (/\bassert\.\w+\(/.test(line)) return true;
+  return /\b[A-Z][A-Z0-9_]*(?:FLOOR|MINIMUM|THRESHOLD|CEILING|LIMIT)\b\s*[:=]/.test(line);
+}
+
+/**
+ * Census the bounds in one file.
+ *
+ * @param {string} file Path to the file.
+ * @param {string} source Its contents.
+ * @returns {{bounds: object[], existence: number, reversed: object[]}} What the file contains.
+ */
+export function censusFile(file, source) {
+  const lines = source.split('\n');
+  const bounds = [];
+  const reversed = [];
+  let existence = 0;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.trimStart().startsWith('*') || line.trimStart().startsWith('//')) continue;
+    if (!isJudged(line)) continue;
+
+    for (const token of reversedComparisons(line)) {
+      reversed.push({ file, line: i + 1, token, text: lines[i].trim() });
+    }
+    for (const comparison of comparisons(line)) {
+      if (isExistence(comparison)) {
+        existence += 1;
+        continue;
+      }
+      bounds.push({
+        file,
+        line: i + 1,
+        token: comparison.token,
+        annotated: hasMarker(lines, i),
+        text: lines[i].trim(),
+      });
+    }
+  }
+  return { bounds, existence, reversed };
+}
+
+/**
+ * Files this checker reads, enumerated from disk.
+ *
+ * From disk rather than a shell glob: a glob matching nothing exits zero and produces a green run
+ * over an empty population, which is a decoy rather than a check.
+ *
+ * @returns {string[]} Absolute paths.
+ */
+export function sourceFiles() {
+  return readdirSync(TOOLS_DIR)
+    .filter((name) => name.endsWith('.mjs') || name.endsWith('.js'))
+    .sort()
+    .map((name) => path.join(TOOLS_DIR, name));
+}
+
+/**
+ * Refuse to pass over nothing.
+ *
+ * @param {unknown[]} population The thing being checked.
+ * @param {string} what A description for the failure message.
+ * @returns {unknown[]} The population, when it is non-empty.
+ */
+export function assertPopulation(population, what) {
+  if (!Array.isArray(population) || population.length === 0) {
+    throw new Error(`refusing to pass over an empty population: ${what}`);
+  }
+  return population;
+}
+
+/**
+ * Run the census across every source file.
+ *
+ * @param {string[]} [files] Override for tests.
+ * @returns {{bounds: object[], existence: number, reversed: object[], files: number}} The census.
+ */
+export function census(files = sourceFiles()) {
+  assertPopulation(files, 'no tool sources found to scan for bounds');
+  const bounds = [];
+  const reversed = [];
+  let existence = 0;
+  for (const file of files) {
+    const result = censusFile(path.basename(file), readFileSync(file, 'utf8'));
+    bounds.push(...result.bounds);
+    reversed.push(...result.reversed);
+    existence += result.existence;
+  }
+  return { bounds, existence, reversed, files: files.length };
+}
+
+/**
+ * Render the report.
+ *
+ * Every number printed here is interpolated from the census rather than restated, and the scope
+ * line is emitted on both the passing and failing paths -- a scope line only on the green path
+ * describes the run nobody needs described.
+ *
+ * @param {ReturnType<typeof census>} result The census.
+ * @returns {{lines: string[], ok: boolean}} Report lines and the verdict.
+ */
+export function report(result) {
+  const unannotated = result.bounds.filter((bound) => !bound.annotated);
+  const lines = [
+    `Scanned ${result.files} tool source file(s): ` +
+      `${result.bounds.length} numeric bound(s), ${result.existence} existence check(s), ` +
+      `${result.reversed.length} reversed comparison(s).`,
+  ];
+
+  for (const item of result.reversed) {
+    lines.push(`  unparsed (literal on the left): ${item.file}:${item.line}  ${item.token}`);
+  }
+
+  if (unannotated.length === 0) {
+    lines.push(
+      `Every bound is annotated or derived. ${result.bounds.length} annotated invented ` +
+        `constant(s); a bound compared against an expression never enters this population.`,
+    );
+    return { lines, ok: true };
+  }
+
+  lines.push(
+    `${unannotated.length} of ${result.bounds.length} bound(s) invent a number with no source:`,
+  );
+  for (const bound of unannotated) {
+    lines.push(`  ${bound.file}:${bound.line}  ${bound.token}  ${bound.text.slice(0, 100)}`);
+  }
+  lines.push(
+    `Fix by comparing against the artifact that already commits to the number, or record ` +
+      `\`${UNSOURCED_MARKER} <why nothing commits to one>\` within ${MARKER_LOOKBEHIND} lines above.`,
+  );
+  return { lines, ok: false };
+}
+
+// Use `pathToFileURL`, not a template literal. `file://${path}` yields two slashes where
+// `import.meta.url` has three on Windows, so the guard never fires and the tool exits 0 having
+// printed nothing -- a green run over an empty population, which is the decoy this file argues
+// against, manufactured by this file. Caught only because the first run printed no report.
+const invokedDirectly = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (invokedDirectly) {
+  const result = report(census());
+  for (const line of result.lines) console.log(line);
+  process.exit(result.ok ? 0 : 1);
+}

--- a/tools/check-assertion-bounds.test.mjs
+++ b/tools/check-assertion-bounds.test.mjs
@@ -173,12 +173,11 @@ test('an empty population is refused rather than passed', () => {
 // --- the real tree -----------------------------------------------------------------------------
 
 test('every bound in this repository is annotated or derived', () => {
-  const result = census();
-  const unannotated = result.bounds.filter((bound) => !bound.annotated);
-  assert.deepEqual(
-    unannotated.map((bound) => `${bound.file}:${bound.line} ${bound.token}`),
-    [],
-  );
+  // Ask the tool for its verdict rather than recomputing it. The first version of this test
+  // filtered `!bound.annotated` itself, which is the same expression `report()` uses -- a test
+  // that decides the answer cannot notice the rule changing, and the independence gate said so.
+  const verdict = report(census());
+  assert.equal(verdict.ok, true, verdict.lines.join('\n'));
 });
 
 test('PREMISE: the population is not empty, or the check proves nothing', () => {
@@ -190,12 +189,20 @@ test('PREMISE: the population is not empty, or the check proves nothing', () => 
 });
 
 test('sourceFiles enumerates from disk, not from a glob', () => {
-  const listed = sourceFiles().map((file) => path.basename(file));
-  const onDisk = fs
-    .readdirSync(TOOLS_DIR)
-    .filter((name) => name.endsWith('.mjs') || name.endsWith('.js'));
-  assert.equal(listed.length, onDisk.length);
-  assert.ok(listed.includes('check-assertion-bounds.mjs'), 'the checker must scan itself');
+  // Asserted by properties rather than by rerunning the same extension filter: a test that
+  // recomputes the selection agrees with itself whatever the selection becomes.
+  const listed = sourceFiles();
+  assert.ok(listed.length > 0, 'PREMISE: the directory is not empty');
+  assert.deepEqual(listed, [...listed].sort(), 'a stable order, so reports are diffable');
+  for (const file of listed) {
+    assert.equal(path.dirname(file), TOOLS_DIR, `escaped the tools directory: ${file}`);
+    assert.ok(fs.statSync(file).isFile(), `not a file: ${file}`);
+  }
+  const names = listed.map((file) => path.basename(file));
+  assert.ok(names.includes('check-assertion-bounds.mjs'), 'the checker must scan itself');
+  // Real negatives that live in this directory: neither is JavaScript.
+  assert.ok(!names.includes('README.md'));
+  assert.ok(!names.includes('setup-branch-protection.sh'));
 });
 
 // --- the verdict actually refuses --------------------------------------------------------------

--- a/tools/check-assertion-bounds.test.mjs
+++ b/tools/check-assertion-bounds.test.mjs
@@ -1,0 +1,274 @@
+/**
+ * Tests for the numeric-bound source checker (#4296).
+ *
+ * The checker's own first two runs were wrong in opposite directions, and both are pinned here:
+ * it reported 49 bounds by counting semver strings inside string arguments, then 14 by counting
+ * sign assertions. Over-reporting is a false accusation whose cost is that the annotations it
+ * forces become rubber stamps, so the exclusions carry tests rather than a comment.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
+
+import {
+  comparisons,
+  reversedComparisons,
+  stripLiterals,
+  isExistence,
+  hasMarker,
+  isJudged,
+  censusFile,
+  census,
+  sourceFiles,
+  report,
+  assertPopulation,
+  UNSOURCED_MARKER,
+  MARKER_LOOKBEHIND,
+  TOOLS_DIR,
+} from './check-assertion-bounds.mjs';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const TOOL = path.join(HERE, 'check-assertion-bounds.mjs');
+
+// --- literal stripping: the first run's defect ---------------------------------------------
+
+test('a semver range inside a string argument is not a bound', () => {
+  const line = "assert.equal(enginesAdmitsAbove('>=22.0.0 <23', '22'), true);";
+  assert.deepEqual(comparisons(line), []);
+});
+
+test('stripLiterals preserves length so column positions survive', () => {
+  const line = "const a = 'hello' + `w${x}d`;";
+  assert.equal(stripLiterals(line).length, line.length);
+});
+
+test('stripLiterals blanks single, double and template literals', () => {
+  // Derived, not counted: the replacement is the quote character repeated to the literal's own
+  // length. Writing `'{6}` here would be an invented constant in the suite about those (#4296).
+  for (const [source, quote] of [
+    ["f('>=5')", "'"],
+    ['f(">=5")', '"'],
+    ['f(`>=5`)', '`'],
+  ]) {
+    const literal = source.slice(2, -1);
+    assert.equal(stripLiterals(source), `f(${quote.repeat(literal.length)})`);
+  }
+});
+
+test('an escaped quote does not end the literal early', () => {
+  assert.deepEqual(comparisons("assert.ok(x, 'it\\'s >= 5 here');"), []);
+});
+
+test('a real bound outside a literal is still found beside one inside', () => {
+  const line = "assert.ok(list.length >= 7, 'range >=22.0.0 is irrelevant');";
+  assert.deepEqual(
+    comparisons(line).map((c) => c.token),
+    ['>=7'],
+  );
+});
+
+// --- equality is out of scope ----------------------------------------------------------------
+
+test('equality against a literal is not a bound', () => {
+  // An exact expected value is the strongest form, not an invented one. Counting it would
+  // invert the finding: the checker would push authors from `=== 3` toward `>= 3`.
+  assert.deepEqual(comparisons('assert.ok(match.testLine === 3);'), []);
+  assert.deepEqual(comparisons('assert.ok(x !== 4);'), []);
+});
+
+// --- existence and sign ------------------------------------------------------------------------
+
+test('existence checks are excluded', () => {
+  for (const token of ['>0', '>=1', '<1', '<=0']) {
+    assert.equal(isExistence({ token }), true, token);
+  }
+});
+
+test('sign assertions are excluded because zero is a boundary, not a choice', () => {
+  assert.equal(isExistence({ token: '>=0' }), true);
+  assert.equal(isExistence({ token: '<0' }), true);
+});
+
+test('a genuine threshold is not excluded', () => {
+  for (const token of ['>=2', '>5', '<10', '>=11', '>20']) {
+    assert.equal(isExistence({ token }), false, token);
+  }
+});
+
+test('whitespace between operator and literal does not change the class', () => {
+  assert.deepEqual(
+    comparisons('assert.ok(x >   0);').map((c) => c.token),
+    ['>0'],
+  );
+  assert.equal(isExistence(comparisons('assert.ok(x >   0);')[0]), true);
+});
+
+// --- scope ---------------------------------------------------------------------------------
+
+test('assertions are judged', () => {
+  assert.equal(isJudged('  assert.ok(x >= 5);'), true);
+  assert.equal(isJudged('  assert.deepEqual(a, b);'), true);
+});
+
+test('a named threshold constant is judged even outside a test', () => {
+  // The motivating defect lived in production, not in a test file.
+  assert.equal(isJudged('const BREADTH_FLOOR = { families: 2 };'), true);
+  assert.equal(isJudged('const MANAGED_MINIMUM = 4;'), true);
+  assert.equal(isJudged('const RETRY_LIMIT = 3;'), true);
+});
+
+test('ordinary code is not judged', () => {
+  assert.equal(isJudged('  if (index > 5) return null;'), false);
+  assert.equal(isJudged('  const slice = list.slice(0, 5);'), false);
+});
+
+test('a comment line is never judged', () => {
+  const census = censusFile('x.mjs', '// assert.ok(x >= 5);\n * assert.ok(y >= 6);\n');
+  assert.deepEqual(census.bounds, []);
+});
+
+// --- the marker ----------------------------------------------------------------------------
+
+test('a marker on the same line covers the bound', () => {
+  const lines = [`assert.ok(x >= 5); // ${UNSOURCED_MARKER} nothing declares it`];
+  assert.equal(hasMarker(lines, 0), true);
+});
+
+test('a marker within the lookbehind covers the bound', () => {
+  const lines = [`// ${UNSOURCED_MARKER} why`, '// filler', 'assert.ok(x >= 5);'];
+  assert.equal(hasMarker(lines, 2), true);
+});
+
+test('a marker beyond the lookbehind does not cover the bound', () => {
+  const lines = [`// ${UNSOURCED_MARKER} why`, ...Array(MARKER_LOOKBEHIND).fill('// filler'), 'a'];
+  assert.equal(hasMarker(lines, lines.length - 1), false);
+});
+
+test('a marker below the bound does not cover it', () => {
+  const lines = ['assert.ok(x >= 5);', `// ${UNSOURCED_MARKER} why`];
+  assert.equal(hasMarker(lines, 0), false);
+});
+
+// --- reversed comparisons are reported, not skipped ------------------------------------------
+
+test('a literal on the left is surfaced rather than silently unparsed', () => {
+  assert.deepEqual(reversedComparisons('assert.ok(5 <= list.length);'), ['5<=']);
+});
+
+test('a reversed comparison inside a string is not surfaced', () => {
+  assert.deepEqual(reversedComparisons("assert.equal(parse('5 < x'), null);"), []);
+});
+
+// --- population refusal ----------------------------------------------------------------------
+
+test('an empty population is refused rather than passed', () => {
+  assert.throws(() => assertPopulation([], 'nothing'), /empty population/);
+  assert.throws(() => census([]), /empty population/);
+});
+
+// --- the real tree -----------------------------------------------------------------------------
+
+test('every bound in this repository is annotated or derived', () => {
+  const result = census();
+  const unannotated = result.bounds.filter((bound) => !bound.annotated);
+  assert.deepEqual(
+    unannotated.map((bound) => `${bound.file}:${bound.line} ${bound.token}`),
+    [],
+  );
+});
+
+test('PREMISE: the population is not empty, or the check proves nothing', () => {
+  const result = census();
+  // The whole point of the exercise: a checker whose population is empty exits 0 and looks
+  // identical to one that verified something.
+  assert.ok(result.bounds.length > 0, 'no bounds found; the checker would pass over nothing');
+  assert.ok(result.files > 0);
+});
+
+test('sourceFiles enumerates from disk, not from a glob', () => {
+  const listed = sourceFiles().map((file) => path.basename(file));
+  const onDisk = fs
+    .readdirSync(TOOLS_DIR)
+    .filter((name) => name.endsWith('.mjs') || name.endsWith('.js'));
+  assert.equal(listed.length, onDisk.length);
+  assert.ok(listed.includes('check-assertion-bounds.mjs'), 'the checker must scan itself');
+});
+
+// --- the verdict actually refuses --------------------------------------------------------------
+
+test('an unannotated bound fails the run, and the report names it', () => {
+  const result = report({
+    files: 1,
+    existence: 0,
+    reversed: [],
+    bounds: [{ file: 'x.test.mjs', line: 9, token: '>=7', annotated: false, text: 'assert' }],
+  });
+  assert.equal(result.ok, false);
+  assert.ok(result.lines.some((line) => line.includes('x.test.mjs:9')));
+  assert.ok(result.lines.some((line) => line.includes(UNSOURCED_MARKER)));
+});
+
+test('the scope line is printed on both the passing and the failing path', () => {
+  const bound = { file: 'a', line: 1, token: '>=7', text: 't' };
+  const pass = report({ files: 2, existence: 3, reversed: [], bounds: [] });
+  const fail = report({
+    files: 2,
+    existence: 3,
+    reversed: [],
+    bounds: [{ ...bound, annotated: false }],
+  });
+  assert.match(pass.lines[0], /Scanned 2 tool source file\(s\)/);
+  assert.match(fail.lines[0], /Scanned 2 tool source file\(s\)/);
+});
+
+test('the report interpolates its counts rather than restating them', () => {
+  const result = report({ files: 7, existence: 4, reversed: [], bounds: [] });
+  assert.match(result.lines[0], /Scanned 7 .*: 0 numeric bound\(s\), 4 existence check\(s\)/);
+});
+
+test('a reversed comparison is listed on the passing path too', () => {
+  const result = report({
+    files: 1,
+    existence: 0,
+    bounds: [],
+    reversed: [{ file: 'a.mjs', line: 3, token: '5<=' }],
+  });
+  assert.equal(result.ok, true, 'an unparsed form is a disclosure, not a failure');
+  assert.ok(result.lines.some((line) => line.includes('a.mjs:3')));
+});
+
+// --- end to end, against a real removal --------------------------------------------------------
+
+test('removing an annotation from the tree makes the CLI exit non-zero (#4296)', () => {
+  // Mutation rather than a fixture: the assertion above proves the tree is clean, which is
+  // exactly the state in which a broken checker is indistinguishable from a working one.
+  const victim = path.join(TOOLS_DIR, 'run-tool-tests.test.mjs');
+  const original = fs.readFileSync(victim, 'utf8');
+  assert.ok(original.includes(UNSOURCED_MARKER), 'PREMISE: the victim carries an annotation');
+  try {
+    fs.writeFileSync(
+      victim,
+      original
+        .split('\n')
+        .filter((line) => !line.includes(UNSOURCED_MARKER))
+        .join('\n'),
+    );
+    assert.throws(
+      () => execFileSync(process.execPath, [TOOL], { encoding: 'utf8', stdio: 'pipe' }),
+      /Command failed/,
+      'the checker must refuse a tree with an unannotated bound',
+    );
+  } finally {
+    fs.writeFileSync(victim, original);
+  }
+  assert.equal(fs.readFileSync(victim, 'utf8'), original, 'the mutation must be restored');
+});
+
+test('the CLI exits zero on the clean tree', () => {
+  const out = execFileSync(process.execPath, [TOOL], { encoding: 'utf8' });
+  assert.match(out, /Every bound is annotated or derived/);
+});

--- a/tools/check-test-independence.test.mjs
+++ b/tools/check-test-independence.test.mjs
@@ -64,6 +64,8 @@ test('a very short shape still reaches a match', () => {
   // comparator alone is what let the filter hide.
   const impl = 'const a = rows\n  .sort()\n  .filter((r) => r.ok);';
   const spec = "test('x', () => {\n  const b = rows\n    .sort()\n    .filter((r) => r.ok);\n});";
+  // unsourced-bound: asserts the shape is a short normalised token rather than the input; no
+  // artifact states a length, and the exact value would pin an implementation detail (#4296).
   assert.ok(shapeOf('  .sort()').length < 10);
   const matches = censusPair(impl, spec);
   assert.ok(
@@ -212,6 +214,8 @@ test('every live match is input construction', () => {
   // `census()` enumerates with `git ls-files`, and both new files were still
   // untracked: the instrument was outside its own population until committed.
   const result = census((file) => readFileSync(file, 'utf8'));
+  // unsourced-bound: pair count grows with the fixture; nothing declares it. 11 was the count
+  // when written and is a floor so adding a case does not fail the test (#4296).
   assert.ok(result.pairs >= 11, `pairs: ${result.pairs}`);
   const { lines } = reportLines(result);
   assert.ok(

--- a/tools/check-workflow-security.test.mjs
+++ b/tools/check-workflow-security.test.mjs
@@ -402,10 +402,21 @@ const SECURITY_TOOL = resolve(testRoot, 'tools', 'check-workflow-security.mjs');
 
 test('a passing run states the scope', () => {
   const result = spawnSync(process.execPath, [SECURITY_TOOL], { encoding: 'utf8' });
-  assert.equal(result.status, 0);
-  assert.match(result.stdout, /\d+ workflow\(s\) scanned in /);
-  assert.match(result.stdout, /\d+ of \d+ named assertion target\(s\) present/);
-  assert.match(result.stdout, /\d+ covered by the universal checks only/);
+  // Diagnostics, not decoration (#4296): under the concurrent whole-suite run this assertion
+  // failed roughly 1 run in 4 on Windows with status 0 and an EMPTY stdout, while 40 isolated
+  // spawns produced 0 empty captures. The tool's CLI guard is the robust resolve/fileURLToPath
+  // form and its exit path uses process.exitCode, so stdout is flushed on a natural exit. That
+  // points at spawnSync pipe capture under heavy concurrent process creation -- a harness flake
+  // rather than a tool defect. Not silently retried: a retry would hide it. These fields make
+  // the next occurrence self-describing instead of a mystery to re-derive.
+  const detail =
+    `status=${result.status} signal=${result.signal} error=${result.error} ` +
+    `stdout=${result.stdout.length}b stderr=${JSON.stringify(String(result.stderr).slice(0, 200))}`;
+  assert.equal(result.error, undefined, detail);
+  assert.equal(result.status, 0, detail);
+  assert.match(result.stdout, /\d+ workflow\(s\) scanned in /, detail);
+  assert.match(result.stdout, /\d+ of \d+ named assertion target\(s\) present/, detail);
+  assert.match(result.stdout, /\d+ covered by the universal checks only/, detail);
 });
 
 test('the failure branch emits the scope before returning', () => {

--- a/tools/run-tool-tests.test.mjs
+++ b/tools/run-tool-tests.test.mjs
@@ -17,6 +17,8 @@ test('testFiles returns a sorted list', () => {
 });
 
 test('testFiles finds this repository real suites', () => {
+  // unsourced-bound: no artifact commits to how many tool test files exist -- that is the
+  // point of enumerating from disk. A floor only excludes a silently emptied glob (#4296).
   assert.ok(testFiles().length >= 10);
 });
 


### PR DESCRIPTION
Closes #4296

## Summary

A sibling session measured its own bounded assertions and reported a negative — 138 of 154 `assert.ok` calls are genuine predicates — but found what made its ten real bounds good:

```js
assert.ok(react.size >= 18, `docs claim 18 react/* rules; the preset enables ${react.size}`);
```

The constant came from **an artifact that had already committed to a number**. That makes the inequality a two-artifact consistency check: it can fail because the code shrank *or* because the doc went stale. Its rule — *when you don't know the expected value, don't invent one; find the artifact that already asserts one; if nothing commits to a number, that absence is the finding* — applied here found a bound whose source was derivable in the same file.

## The defect

`corpusBreadth()` reports when the recorded corpus is too narrow to certify a **three-way** comment-family switch. The floor was `2`. Measured against the real lock (81 entries, all three families):

```
drop 'hash'  -> families 2, findings 0
drop 'html'  -> families 2, findings 0
drop 'block' -> families 2, findings 0
```

**Deleting an entire family produced no finding.** Everything that could have caught it restated the same constant — the pinning test read `>= 2` under the message *"one family cannot certify a three-way switch"*, and one fixture asserted `[]` under the comment *"Two families clears the floor"*: the defect written down as expected behaviour, and asserted.

Now derived: `families: FAMILY_SETS.length`, with a test that drops each family and requires a finding.

## The general control

`tools/check-assertion-bounds.mjs` (+ 30 tests) enforces the rule syntactically rather than judging whether a number is right. A comparison against a bare numeric literal must be an existence check (`> 0`), a sign check (`>= 0`), or carry an `unsourced-bound:` note. A bound compared against an *expression* never enters the population — that is the fixed form.

## Its own two wrong populations

- First run: **49** bounds, 40 of them semver ranges inside string arguments (`enginesAdmitsAbove('>=22.0.0 <23', '22')`) — data handed to a parser, counted as a chosen threshold.
- Second run: **14**, still counting `assert.ok(dirtySeconds >= 0)`, where zero is a boundary rather than a choice.
- Real number: **9**.

Same error as the census before it: **a syntactic pattern is not a semantic class.** And `49 of 49` was the most impressive-looking of the three. Over-reporting matters in a specific way here — the cost of a false accusation is that the annotation it forces becomes a rubber stamp.

## The checker exited 0 having done nothing

Its first invocation printed no report and exited 0: the CLI guard built `file://C:/…` where `import.meta.url` is `file:///C:/…`. A green run over an empty population, in the file whose docblock argues against exactly that, caught only because a report was expected and none appeared. The repo already had the correct `pathToFileURL` form in two other tools.

## Testing

- [x] `npm run format:check` / `npx eslint . --max-warnings 0` / `npm run type-check`
- [x] `npm run tools:test` — **546/546** (up from 515; the new suite is picked up by disk enumeration with no wiring)
- [x] All **16** gates exit 0