### PR TITLE
test(tools): state non-vacuity premises per member, not per aggregate (#4297)

### DIFF
--- a/tools/check-ai-manifest.js
+++ b/tools/check-ai-manifest.js
@@ -1401,11 +1401,16 @@ function exemptionMatches(entry, recordedSource, digest) {
 // The disclosure the prose promises: one line per path, never a count. Returned rather than
 // written so the promise is assertable -- as a loop inside main() it was reachable by no test,
 // and emptying it left the suite green (#4222). A count cannot grow unnoticed into a set.
-function sourceDisclosureLines(knownUnreproduced) {
+// The register is a parameter, not a closed-over constant, for the reason stated above about
+// conjunctions: this function took the population as an argument and read its CONTENT from the
+// module constant, so a test could vary WHICH paths are disclosed and never WHAT they disclose.
+// The live register holds one row and is designed to drain -- an exemption register succeeds by
+// emptying -- so a property proved only against it stops being proved on the day it works (#4297).
+function sourceDisclosureLines(knownUnreproduced, register = KNOWN_UNREPRODUCED) {
   return knownUnreproduced.map(
     (entry) =>
       `  [source] not reproducible from delivered bytes: ${entry} ` +
-      `(${KNOWN_UNREPRODUCED[entry].issue}, known and pinned)`,
+      `(${register[entry].issue}, known and pinned)`,
   );
 }
 

--- a/tools/check-ai-manifest.test.mjs
+++ b/tools/check-ai-manifest.test.mjs
@@ -521,9 +521,36 @@ test('the disclosure names every path and never collapses to a count', () => {
   // The prose at KNOWN_UNREPRODUCED promises "listing each path means the set cannot grow
   // unnoticed, which is the property a bare count lacks". As a loop inside main() that promise
   // was unreachable by any test, and emptying it left the suite green (#4222).
-  const lines = sourceDisclosureLines(Object.keys(KNOWN_UNREPRODUCED));
-  assert.equal(lines.length, Object.keys(KNOWN_UNREPRODUCED).length, 'one line per exemption');
-  for (const entry of Object.keys(KNOWN_UNREPRODUCED)) {
+  //
+  // The population is a CONSTRUCTED register, not the live one. Driven from KNOWN_UNREPRODUCED
+  // both sides of `lines.length === keys.length` moved together, so the assertion could not fail
+  // by that register emptying -- and it is designed to empty, since an exemption register succeeds
+  // by draining. The five tests that currently catch an empty register are fixtures built on
+  // `Object.keys(KNOWN_UNREPRODUCED)[0]`, so they get repaired in the same edit that drains it:
+  // the cover and the covered fail together (#4297).
+  const register = {
+    'a/first.css': { issue: '#1111' },
+    'b/second.md': { issue: '#2222' },
+  };
+  const built = sourceDisclosureLines(Object.keys(register), register);
+  assert.equal(built.length, 2, 'one line per exemption, never a single summarising count');
+  for (const [entry, meta] of Object.entries(register)) {
+    assert.ok(
+      built.some((l) => l.includes(entry) && l.includes(meta.issue)),
+      `every exemption must be disclosed by path and issue; ${entry} was not`,
+    );
+  }
+  assert.ok(
+    !built.some((l) => /\b2 (exemptions|entries|paths)\b/.test(l)),
+    'a count is exactly what this disclosure must not collapse to',
+  );
+
+  // The live register too, with its premise stated: it may legitimately be empty, and on that day
+  // this arm proves nothing and the constructed arm above is what still holds the property.
+  const live = Object.keys(KNOWN_UNREPRODUCED);
+  const lines = sourceDisclosureLines(live);
+  assert.equal(lines.length, live.length, 'one line per exemption');
+  for (const entry of live) {
     assert.ok(
       lines.some((l) => l.includes(entry) && l.includes(KNOWN_UNREPRODUCED[entry].issue)),
       `every exemption must be disclosed by path and issue; ${entry} was not`,
@@ -1140,6 +1167,19 @@ test('every classified extension starts with a dot, which is why the first opera
   // only while every classified extension is dot-led, so that invariant is what gets pinned.
   // Add an extension-less name (`Caddyfile`) to any family and this test fires, which is the
   // signal that the operand has become load-bearing and now needs a behavioural test.
+  // The premise is stated PER FAMILY, not over the union. `[...A, ...B, ...C].length > 0` is
+  // satisfied while any one family is empty, so it cannot see a member go to zero and the
+  // invariant silently stops covering it. Measured: emptying each family in turn left this test
+  // green 3 of 3, and the state was caught only by bystanders (#4297). Non-emptiness of a family
+  // is a corpus fact, so this asserts only that each family HAS members -- never which ones.
+  const families = {
+    HASH_EXTENSIONS,
+    BLOCK_EXTENSIONS,
+    HTML_EXTENSIONS,
+  };
+  for (const [name, family] of Object.entries(families)) {
+    assert.ok(family.size > 0, `PREMISE: ${name} must be non-empty or its members go unchecked`);
+  }
   const all = [...HASH_EXTENSIONS, ...BLOCK_EXTENSIONS, ...HTML_EXTENSIONS];
   assert.ok(all.length > 0);
   for (const extension of all) {


### PR DESCRIPTION
## Summary

Two `PREMISE:` assertions were stated over an **aggregate**. An aggregate premise is satisfied while any one member is empty, so it cannot see a member go to zero — the guard stops covering that member silently.

Per jrmoulckers/.github#880 this is the **latent** case, not the equivalent one. The two score identically (`SURVIVED`) and take opposite repairs: an equivalence is fixed by pinning the invariant that makes it dead; a latent guard must **not** be pinned, because family membership and register size are corpus accidents and pinning them freezes the accident.

## Measured before the fix

Firing control first (`fail=1 FIRES`). Four states constructed against the real source, restored byte-identical:

| state | pass/fail | did the premise''s own test fire? |
| --- | --- | --- |
| baseline | 90 / 0 | — |
| `HTML_EXTENSIONS` emptied | 84 / 6 | **no** |
| `BLOCK_EXTENSIONS` emptied | 86 / 4 | **no** |
| `HASH_EXTENSIONS` emptied | 83 / 7 | **no** |
| `KNOWN_UNREPRODUCED` emptied | 85 / 5 | **no** |

**Every state was caught, so this was never a live silent hole.** All the killing was done by *bystanders*. A bystander kill scored as coverage is one of the four ways a green suite misleads.

For the register the bystanders are the weaker kind: five fixtures built on `KNOWN_ENTRY = Object.keys(KNOWN_UNREPRODUCED)[0]`. `KNOWN_UNREPRODUCED` holds one row and is *designed* to drain — an exemption register succeeds by emptying (#4190). The edit that drains it repairs those five fixtures too, so the cover and the covered fail together.

## Underneath

`sourceDisclosureLines(knownUnreproduced)` took its population as a parameter but read its content from the module constant (`KNOWN_UNREPRODUCED[entry].issue`). A test could vary *which* paths are disclosed and never *what* they disclose — the same half-injectable shape this file already names fifteen lines above it: *"a conjunction whose second conjunct no test can vary is a conjunction in name only."* The register is now a parameter defaulting to the live one.

## Measured after the fix

| mutant | result | killed by |
| --- | --- | --- |
| W1 `HTML_EXTENSIONS` emptied | KILLED (7) | now includes `every classified extension starts with a dot … (#4264)` |
| W2 `BLOCK_EXTENSIONS` emptied | KILLED (5) | same test, by name |
| W3 `HASH_EXTENSIONS` emptied | KILLED (8) | same test, by name |
| W4 register parameter ignored | KILLED (1) | `the disclosure names every path…` **alone** |
| W5 disclosure collapses to a count | KILLED (1) | `the disclosure names every path…` **alone** |

W1–W3: the previously-blind test was **absent** from those exact failure lists before and is present now. W4/W5 are killed by the disclosure test on its own, which is what makes the injected register load-bearing rather than decorative.

## Issues

Closes #4297

## Testing

- [x] `node --test tools/check-ai-manifest.test.mjs` — 90 passing, 0 failing (count unchanged; both repairs strengthen existing tests rather than adding new ones)
- [x] `node tools/check-ai-manifest.js` — exit 0
- [x] `npx eslint … --max-warnings 0` — exit 0
- [x] `npx prettier --check` both files — unchanged
- [x] sources restored byte-identical after both sweeps; `.studio-sync.lock.json` untouched

## Out of scope

`packages/design-tokens`, workflow files, and `vendor/@jrm/tokens/css/default/tokens.css` — all untouched.