### PR TITLE
fix(tools): check the 1,110 relative links the docs gate dropped before counting

### DIFF
--- a/docs/compliance/README.md
+++ b/docs/compliance/README.md
@@ -61,6 +61,6 @@ attestation.
 - [`docs/architecture/privacy-audit-v1.md`](../architecture/privacy-audit-v1.md) — Comprehensive GDPR/CCPA compliance gap analysis
 - [`docs/guides/privacy-security.md`](../guides/privacy-security.md) — User-facing privacy and security guide
 - [`docs/audits/security-checklist.md`](../audits/security-checklist.md) — Security posture checklist
-- [`services/api/supabase/functions/account-deletion/`](../../services/api/supabase/functions/account-deletion/) — GDPR Art. 17 Right to Erasure implementation
+- [`services/api/supabase/functions/account-delete/`](../../services/api/supabase/functions/account-delete/) — GDPR Art. 17 Right to Erasure implementation
 - [`services/api/supabase/functions/data-export/`](../../services/api/supabase/functions/data-export/) — GDPR Art. 20 Data Portability implementation
 - [`docs/guides/trust-and-manual-entry.md`](../guides/trust-and-manual-entry.md) — Manual-first trust messaging guide

--- a/docs/compliance/data-inventory.md
+++ b/docs/compliance/data-inventory.md
@@ -458,7 +458,7 @@ the [CCPA Rights Verification](ccpa-verification.md) for US-specific rights.
 | ----------------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------- |
 | **Right of access**           | Art. 15      | Server-side data export Edge Function ([`data-export/index.ts`](../../services/api/supabase/functions/data-export/index.ts)) exports 9 tables in JSON or CSV. Client-side export exists in KMP but covers only 5 entity types. | ⚠️ Partial — missing `household_invitations`, `audit_log`, `sync_health_logs`, `webauthn_challenges` from server export |
 | **Right to rectification**    | Art. 16      | All financial and profile data is editable in-app. Changes sync via the mutation queue.                                                                                                                                        | ✅ Implemented                                                                                                          |
-| **Right to erasure**          | Art. 17      | Account deletion Edge Function ([`account-deletion/index.ts`](../../services/api/supabase/functions/account-deletion/index.ts)) with crypto-shredding design and deletion certificate.                                         | ⚠️ Partial — crypto-shredding is placeholder; client-side deletion not wired on any platform                            |
+| **Right to erasure**          | Art. 17      | Account deletion Edge Function ([`account-delete/index.ts`](../../services/api/supabase/functions/account-delete/index.ts)) with crypto-shredding design and deletion certificate.                                             | ⚠️ Partial — crypto-shredding is placeholder; client-side deletion not wired on any platform                            |
 | **Right to restriction**      | Art. 18      | Not explicitly implemented. Soft-delete pattern (`deleted_at`) could serve as a mechanism.                                                                                                                                     | ❌ Not implemented                                                                                                      |
 | **Right to data portability** | Art. 20      | JSON and CSV export via data-export Edge Function.                                                                                                                                                                             | ⚠️ Partial — same coverage gaps as right of access                                                                      |
 | **Right to object**           | Art. 21      | No profiling or automated decision-making exists. No direct marketing.                                                                                                                                                         | ✅ Not applicable (no processing to object to)                                                                          |
@@ -467,11 +467,11 @@ the [CCPA Rights Verification](ccpa-verification.md) for US-specific rights.
 
 ### Implementation References
 
-| Right                | Primary Code Path                                                                                                              |
-| -------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| Access / Portability | [`services/api/supabase/functions/data-export/index.ts`](../../services/api/supabase/functions/data-export/index.ts)           |
-| Erasure              | [`services/api/supabase/functions/account-deletion/index.ts`](../../services/api/supabase/functions/account-deletion/index.ts) |
-| Rectification        | All repository CRUD operations in `apps/web/src/db/repositories/` and KMP model layer                                          |
+| Right                | Primary Code Path                                                                                                          |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| Access / Portability | [`services/api/supabase/functions/data-export/index.ts`](../../services/api/supabase/functions/data-export/index.ts)       |
+| Erasure              | [`services/api/supabase/functions/account-delete/index.ts`](../../services/api/supabase/functions/account-delete/index.ts) |
+| Rectification        | All repository CRUD operations in `apps/web/src/db/repositories/` and KMP model layer                                      |
 
 ---
 

--- a/docs/compliance/data-retention-schedule.md
+++ b/docs/compliance/data-retention-schedule.md
@@ -141,11 +141,11 @@ Quick reference for all retention periods:
 
 ### User-Initiated Deletion
 
-| Mechanism              | Scope                                                         | Implementation                                                                                                                                                                    |
-| ---------------------- | ------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| In-app record deletion | Individual accounts, transactions, budgets, goals, categories | Soft-delete via `deleted_at` timestamp; hard-delete after 30-day grace period                                                                                                     |
-| Account deletion       | All user data across all tables                               | [`account-deletion` Edge Function](../../services/api/supabase/functions/account-deletion/index.ts) — cascading soft-delete with crypto-shredding intent and deletion certificate |
-| Data export            | Full data portability before deletion                         | [`data-export` Edge Function](../../services/api/supabase/functions/data-export/index.ts) — JSON/CSV export of user data                                                          |
+| Mechanism              | Scope                                                         | Implementation                                                                                                                                                                  |
+| ---------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| In-app record deletion | Individual accounts, transactions, budgets, goals, categories | Soft-delete via `deleted_at` timestamp; hard-delete after 30-day grace period                                                                                                   |
+| Account deletion       | All user data across all tables                               | [`account-deletion` Edge Function](../../services/api/supabase/functions/account-delete/index.ts) — cascading soft-delete with crypto-shredding intent and deletion certificate |
+| Data export            | Full data portability before deletion                         | [`data-export` Edge Function](../../services/api/supabase/functions/data-export/index.ts) — JSON/CSV export of user data                                                        |
 
 ### Automated Purge Jobs
 

--- a/docs/design/accessibility-patterns.md
+++ b/docs/design/accessibility-patterns.md
@@ -42,7 +42,7 @@ leaving the container. When the modal closes, focus returns to the
 previously focused element.
 
 **Implemented in:**
-[`apps/web/src/accessibility/aria.ts` → `useFocusTrap`](../apps/web/src/accessibility/aria.ts)
+[`apps/web/src/accessibility/aria.ts` → `useFocusTrap`](../../apps/web/src/accessibility/aria.ts)
 
 #### React (Web)
 
@@ -132,7 +132,7 @@ When the user navigates between routes (pages), focus must move to the
 main content area and the new page title must be announced.
 
 **Implemented in:**
-[`apps/web/src/components/layout/FocusManager.tsx`](../apps/web/src/components/layout/FocusManager.tsx)
+[`apps/web/src/components/layout/FocusManager.tsx`](../../apps/web/src/components/layout/FocusManager.tsx)
 
 #### React (Web)
 
@@ -195,9 +195,9 @@ A skip link allows keyboard users to bypass the navigation and jump
 directly to the main content area.
 
 **Implemented in:**
-[`apps/web/src/components/layout/SkipToContent.tsx`](../apps/web/src/components/layout/SkipToContent.tsx)
+[`apps/web/src/components/layout/SkipToContent.tsx`](../../apps/web/src/components/layout/SkipToContent.tsx)
 and
-[`apps/web/src/components/layout/AppLayout.tsx`](../apps/web/src/components/layout/AppLayout.tsx)
+[`apps/web/src/components/layout/AppLayout.tsx`](../../apps/web/src/components/layout/AppLayout.tsx)
 
 #### React (Web)
 
@@ -261,7 +261,7 @@ Follow the natural DOM order. Never use positive `tabindex` values. Focus
 indicators must be visible on all interactive elements.
 
 **Implemented in:**
-[`apps/web/src/theme/tokens.css`](../apps/web/src/theme/tokens.css)
+[`apps/web/src/theme/tokens.css`](../../apps/web/src/theme/tokens.css)
 
 ```css
 /* From: apps/web/src/theme/tokens.css */
@@ -304,7 +304,7 @@ WAI-ARIA roving tabindex pattern: only one item has `tabindex="0"`, the
 rest have `tabindex="-1"`. Arrow keys move focus between items.
 
 **Implemented in:**
-[`apps/web/src/accessibility/aria.ts` → `useArrowKeyNavigation`](../apps/web/src/accessibility/aria.ts)
+[`apps/web/src/accessibility/aria.ts` → `useArrowKeyNavigation`](../../apps/web/src/accessibility/aria.ts)
 
 #### React (Web)
 
@@ -362,7 +362,7 @@ fields. Shortcuts are skipped when modifier keys are held or when the
 target is an editable field.
 
 **Implemented in:**
-[`apps/web/src/hooks/useKeyboardShortcuts.ts`](../apps/web/src/hooks/useKeyboardShortcuts.ts)
+[`apps/web/src/hooks/useKeyboardShortcuts.ts`](../../apps/web/src/hooks/useKeyboardShortcuts.ts)
 
 ```tsx
 // From: apps/web/src/hooks/useKeyboardShortcuts.ts
@@ -513,7 +513,7 @@ Live regions announce dynamic content changes (balance updates, sync
 status, navigation) to screen readers without moving focus.
 
 **Implemented in:**
-[`apps/web/src/accessibility/aria.ts` → `announce`](../apps/web/src/accessibility/aria.ts)
+[`apps/web/src/accessibility/aria.ts` → `announce`](../../apps/web/src/accessibility/aria.ts)
 
 #### React (Web)
 
@@ -619,7 +619,7 @@ Every form field must have a programmatically associated label via the
 `<label>` element's `htmlFor`/`for` attribute or via `aria-labelledby`.
 
 **Implemented in:**
-[`apps/web/src/components/forms/TransactionForm.tsx`](../apps/web/src/components/forms/TransactionForm.tsx)
+[`apps/web/src/components/forms/TransactionForm.tsx`](../../apps/web/src/components/forms/TransactionForm.tsx)
 
 ```tsx
 // From: apps/web/src/components/forms/TransactionForm.tsx
@@ -768,7 +768,7 @@ All text and UI components must meet WCAG AA contrast ratios:
 | Focus indicators   | 3.0:1         | WCAG 2.4.7 / 2.4.11 |
 
 **Implemented in:**
-[`apps/android/.../WcagCompliance.kt`](../apps/android/src/main/kotlin/com/finance/android/ui/accessibility/WcagCompliance.kt)
+[`apps/android/.../WcagCompliance.kt`](../../apps/android/src/main/kotlin/com/finance/android/ui/accessibility/WcagCompliance.kt)
 
 ```kotlin
 // From: apps/android/.../WcagCompliance.kt
@@ -795,7 +795,7 @@ All colours come from design tokens. Platform components reference semantic
 tokens — never raw hex values. The system provides three theme variants:
 
 **Implemented in:**
-[`apps/web/src/theme/tokens.css`](../apps/web/src/theme/tokens.css)
+[`apps/web/src/theme/tokens.css`](../../apps/web/src/theme/tokens.css)
 
 | Theme           | Activation                                            | Token Override Layer             |
 | --------------- | ----------------------------------------------------- | -------------------------------- |
@@ -816,7 +816,7 @@ tokens — never raw hex values. The system provides three theme variants:
 ```
 
 **Android high-contrast theme:**
-[`apps/android/.../HighContrastTheme.kt`](../apps/android/src/main/kotlin/com/finance/android/ui/accessibility/HighContrastTheme.kt)
+[`apps/android/.../HighContrastTheme.kt`](../../apps/android/src/main/kotlin/com/finance/android/ui/accessibility/HighContrastTheme.kt)
 
 Both light and dark high-contrast variants target WCAG AAA (7:1) ratios
 wherever feasible.
@@ -955,7 +955,7 @@ relying on a minus sign that may be skipped by AT.
 #### React (Web)
 
 **Implemented in:**
-[`apps/web/src/components/common/CurrencyDisplay.tsx`](../apps/web/src/components/common/CurrencyDisplay.tsx)
+[`apps/web/src/components/common/CurrencyDisplay.tsx`](../../apps/web/src/components/common/CurrencyDisplay.tsx)
 
 ```tsx
 // From: apps/web/src/components/common/CurrencyDisplay.tsx
@@ -1025,9 +1025,9 @@ strategies:
 #### Strategy 1: IBM CVD-Safe Color Palette
 
 **Implemented in:**
-[`apps/web/src/components/charts/chart-palette.ts`](../apps/web/src/components/charts/chart-palette.ts)
+[`apps/web/src/components/charts/chart-palette.ts`](../../apps/web/src/components/charts/chart-palette.ts)
 and
-[`apps/ios/Finance/Charts/ChartColorPalette.swift`](../apps/ios/Finance/Charts/ChartColorPalette.swift)
+[`apps/ios/Finance/Charts/ChartColorPalette.swift`](../../apps/ios/Finance/Charts/ChartColorPalette.swift)
 
 ```tsx
 // From: apps/web/src/components/charts/chart-palette.ts
@@ -1200,7 +1200,7 @@ All interactive elements must meet minimum touch target requirements:
 | Windows  | 32 × 32 px   | Fluent Design (44px preferred) |
 
 **Implemented in:**
-[`apps/android/.../WcagCompliance.kt`](../apps/android/src/main/kotlin/com/finance/android/ui/accessibility/WcagCompliance.kt)
+[`apps/android/.../WcagCompliance.kt`](../../apps/android/src/main/kotlin/com/finance/android/ui/accessibility/WcagCompliance.kt)
 
 ```kotlin
 // From: apps/android/.../WcagCompliance.kt

--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -8978,6 +8978,115 @@ were to drop it or record it; recording it cost one sentence and made this round
 recognisable within seconds instead of being greeted as new. **An intermittent failure you have
 written down is a different object from one you have not**, even while both remain unexplained.
 
+## A filter applied before the census is invisible to every number the census prints
+
+`check-doc-links.mjs` is a required check. Its link collector opened with:
+
+```js
+if (!target.endsWith('.md')) continue;
+```
+
+Every relative link to a non-markdown file was dropped **before it was counted**. Not excluded
+from resolution — excluded from the population. It appeared in no total, no scope line, no
+finding, and no disclaimer. Measured:
+
+```
+counted .md links (the reported total)   3353
+DROPPED non-.md relative links           1110
+  .kt 470   .swift 341   (dir/none) 126   .ts 68   .tsx 22
+  .yml 17   .sql 14   .example 10  .yaml 8   .xml 8   and eight more
+```
+
+**22 were broken.** The gate had never been able to see them, and had been green for months.
+
+The scope line is the part worth dwelling on. This tool prints its population deliberately, on
+both the passing and the failing path, because a control that reports its reach only when it
+passes cannot be distinguished from one that measured nothing. That machinery worked exactly as
+designed and reported `3353 markdown link(s)` — a true sentence about a population that a filter
+three functions upstream had already halved. **A scope line is computed from what the census
+saw, so it cannot disclose what was removed before the census began.** Every honest-reporting
+discipline in this file was downstream of the dishonesty.
+
+### The test asserted the defect, and its name is what did the damage
+
+```js
+test('non-markdown targets are out of scope', () => {
+  const { links } = collectLinks('[x](./a.png) [y](./b.ts)');
+  assert.equal(links.length, 0);
+});
+```
+
+Green from the day it was written. A test can only ever confirm that the code does what the code
+does, and this one did that faithfully.
+
+What made it harmful was the **name**. "Out of scope" is the vocabulary of a considered boundary
+— a decision someone weighed and recorded. Anyone asking whether the 470 `.kt` and 341 `.swift`
+links were checked would have found this test and read an authoritative no. It converted an
+unexamined `continue` into a documented policy, and it did so in the one artifact a reader trusts
+most, because a passing assertion sits next to it.
+
+The general form: **a test name is a claim about intent, and nothing checks it.** The assertion
+is verified continuously; the sentence describing why is verified never. When the two drift, the
+sentence wins every argument, because it is the one a human reads.
+
+### 62 reported, 22 real — and the 40 are why precision is not a nicety
+
+The first census said 62 broken. Forty of those were GitHub's repo-relative idiom:
+
+```
+[#2609](../../issues/2609)     [#44](../../pull/44)     ../../tree/main/apps
+```
+
+GitHub resolves these against the repository, not the file tree. They are correct as written, and
+reporting them would be a false accusation at a 65% rate.
+
+That is not merely noisy. The fix for a false positive is an exemption — a baseline entry, an
+annotation, an ignore comment — and an author who has learned the checker cries wolf writes the
+exemption without reading the finding. **A checker's precision is what keeps its own escape hatch
+meaningful**, so an over-reporting gate degrades into a rubber stamp and takes its true positives
+with it.
+
+### Moved, versus never true
+
+The 22 split three ways, and the third class is the interesting one:
+
+| class                                                                            | n   | fix      |
+| -------------------------------------------------------------------------------- | --- | -------- |
+| off by one `../` — target exists at repo root                                    | 16  | repoint  |
+| `account-deletion/` — removed in `087b812c` as deprecated, now `account-delete/` | 4   | repoint  |
+| `fire-calculator.ts` — **never existed**                                         | 2   | baseline |
+
+`fire-calculator.ts` reads exactly like a rename of the neighbouring `fire-planning.ts`, and
+repointing it there would have turned the gate green in one keystroke. It would also have been
+false: `calculateFINumber` and `calculateCoastFI`, the functions the citing tables describe, exist
+nowhere in this repository. The design document specifies a web reference implementation that was
+never built.
+
+Any resolver reports _moved_ and _never true_ identically, and only the first is a regression.
+The second is a claim that was false when written, which is a different defect with a different
+fix — and the tempting repair is the one that destroys the evidence. **A link that is red because
+the thing does not exist is doing its job**; the correct response is the baseline, which records
+the gap without pretending it is closed.
+
+### The disclaimer had to move with the reach
+
+The scope line ended with `Not measured: URL targets, links to non-markdown files, ...`. True
+when written, false the moment those 1,110 links were checked.
+
+A stale disclaimer fails toward **false assurance**: it under-claims, which reads as caution, so
+nothing about it invites a second look. That is the opposite polarity from a stale finding, and it
+is why the disclaimer is now asserted — a test fails if the sentence still disclaims a population
+the tool checks. Prose that describes coverage has to be edited in the same commit that changes
+coverage, and the only way to make that reliable is to let it fail the build.
+
+### Measured negative
+
+The upstream session found its own link probe skipped fenced blocks when collecting **headings**
+but not when collecting **links** — fence-blindness as a property of a _traversal_ rather than of
+a tool, with two traversals in one file and only one guarded. finance does not have this:
+`headingSlugs` and `collectLinks` both consume the shared `markFences`. Recorded as a negative
+rather than reshaped into a symmetric finding.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:

--- a/tools/check-doc-links.mjs
+++ b/tools/check-doc-links.mjs
@@ -27,6 +27,28 @@ const FENCE = /^\s*(?:```|~~~)/;
 const INLINE_CODE = /`[^`]*`/g;
 
 /**
+ * An explicit anchor a document offers outside its heading structure.
+ *
+ * `headingSlugs` once collected `#` headings and nothing else, which made every link to an
+ * `<a id>` target a reported stale anchor. finance's corpus contains zero of these, so the
+ * defect was invisible: the check was green because its population was empty, which reads
+ * in the output exactly like green because everything checked passed.
+ */
+const HTML_ANCHOR = /<a\s[^>]*?\b(?:id|name)\s*=\s*["']([^"']+)["']/gi;
+
+/**
+ * Link targets GitHub resolves against the *repository* rather than the file tree.
+ *
+ * `[#2609](../../issues/2609)` renders correctly and points at nothing on disk. Forty such
+ * links exist here, and an earlier census counted every one of them as broken -- 62 reported
+ * against 22 real. Reporting them would be a false accusation, and the cost of that is
+ * specific: it makes the exemption below a rubber stamp, so the next genuinely broken link
+ * gets waved through by an author who has learned the checker cries wolf.
+ */
+const GITHUB_REPO_RELATIVE =
+  /(?:^|\/)(?:issues|pull|discussions|commit|compare|releases|wiki|tree|blob|labels|milestone|projects)(?:\/|$)/;
+
+/**
  * Stale anchors this repository accepts. Empty, and it should stay that way: unlike
  * `UNRESOLVED_BASELINE`, a stale anchor is never a gap awaiting a document that does not
  * exist yet -- the target file is present and simply no longer has the heading. Every such
@@ -43,6 +65,15 @@ export const STALE_ANCHOR_BASELINE = [];
  * the docs rather than a stale path, so the fix is to write the document or drop the
  * reference -- neither of which this check should guess at. The list is a ratchet: it may
  * shrink, and any target not on it fails.
+ *
+ * The distinction this list encodes is between a target that *moved* and one that was
+ * *never true*, which any resolver reports identically and only the first of which is a
+ * regression. The last two entries are the second kind and are the reason it is worth
+ * stating: `fire-calculator.ts` reads like a rename of `fire-planning.ts`, and repointing
+ * it there would have turned the gate green while making the citing sentence false --
+ * `calculateFINumber` and `calculateCoastFI` exist nowhere in this repository. The design
+ * document specifies a web reference implementation that was never built. A link that is
+ * red because the thing does not exist is doing its job.
  */
 export const UNRESOLVED_BASELINE = [
   'docs/architecture/0005-design-system-approach.md -> ./0002-cross-platform-framework-selection.md',
@@ -53,6 +84,8 @@ export const UNRESOLVED_BASELINE = [
   'docs/business/marketing/marketing-plan-sprints-6-10.md -> growth-strategy-post-launch.md',
   'docs/business/marketing/marketing-plan-sprints-6-10.md -> launch-retrospective-week-1.md',
   'docs/business/marketing/marketing-plan-sprints-6-10.md -> review-strategy.md',
+  'docs/design/ios-fi-calculator-flow.md -> ../../apps/web/src/lib/investment/fire-calculator.ts',
+  'docs/design/ios-fire-results-goal-integration.md -> ../../apps/web/src/lib/investment/fire-calculator.ts',
   'docs/guides/release-process.md -> ../audits/accessibility-checklist.md',
 ];
 
@@ -94,7 +127,8 @@ export function slugify(heading) {
 }
 
 /**
- * Every anchor a document offers: one per heading, outside fenced blocks.
+ * Every anchor a document offers: one per heading outside fenced blocks, plus any explicit
+ * `<a id>` / `<a name>` target.
  *
  * @param {string} text
  * @returns {Set<string>}
@@ -105,8 +139,21 @@ export function headingSlugs(text) {
     if (fenced) continue;
     const match = line.match(/^#{1,6}\s+(.*?)\s*$/);
     if (match) slugs.add(slugify(match[1]));
+    // An explicit anchor is offered verbatim, not slugified: the author wrote the id the
+    // link has to match.
+    for (const anchor of line.matchAll(HTML_ANCHOR)) slugs.add(anchor[1]);
   }
   return slugs;
+}
+
+/**
+ * Whether a relative target is GitHub's repo-relative idiom rather than a filesystem path.
+ *
+ * @param {string} target
+ * @returns {boolean}
+ */
+export function isRepoRelative(target) {
+  return GITHUB_REPO_RELATIVE.test(target);
 }
 
 /**
@@ -134,7 +181,8 @@ export function markFences(text) {
 }
 
 /**
- * Collect markdown links from one document: relative `.md` targets, and same-file anchors.
+ * Collect markdown links from one document: relative targets of any kind, and same-file
+ * anchors.
  *
  * Same-file anchors (`[text](#section)`) were excluded here until they were counted. They
  * are the largest link class in this repository -- 2,799 against 246 cross-file fragments,
@@ -142,8 +190,15 @@ export function markFences(text) {
  * kind of link: a same-file anchor names a section and nothing else, so any rename or
  * renumber of that heading breaks it, with no path change to make the break visible.
  *
+ * Non-`.md` targets were excluded here too, by `if (!target.endsWith('.md')) continue`, and
+ * that exclusion was worse than the anchor one because it dropped links *before counting
+ * them*. 1,110 links -- 470 `.kt`, 341 `.swift`, 126 directory targets, 68 `.ts` -- appeared
+ * in no population, no scope line and no finding, while the scope line reported a total that
+ * silently excluded them. 22 were broken. A filter applied before the census is invisible to
+ * every number the census prints, including the ones whose purpose is to state its reach.
+ *
  * @param {string} text
- * @returns {{ links: {href: string, target: string, fragment: string, sameFile: boolean, line: number}[], skipped: number }}
+ * @returns {{ links: {href: string, target: string, fragment: string, sameFile: boolean, repoRelative: boolean, line: number}[], skipped: number }}
  */
 export function collectLinks(text) {
   const links = [];
@@ -164,6 +219,7 @@ export function collectLinks(text) {
           target: '',
           fragment: href.slice(1).trim(),
           sameFile: true,
+          repoRelative: false,
           line: i + 1,
         });
         continue;
@@ -171,13 +227,20 @@ export function collectLinks(text) {
       if (/^(?:[a-z][a-z0-9+.-]*:|\/\/)/i.test(href)) continue;
       const hash = href.indexOf('#');
       const target = (hash === -1 ? href : href.slice(0, hash)).trim();
-      if (!target.endsWith('.md')) continue;
+      if (!target) continue;
       if (marked[i].fenced) {
         skipped += 1;
         continue;
       }
       const fragment = hash === -1 ? '' : href.slice(hash + 1).trim();
-      links.push({ href, target, fragment, sameFile: false, line: i + 1 });
+      links.push({
+        href,
+        target,
+        fragment,
+        sameFile: false,
+        repoRelative: isRepoRelative(target),
+        line: i + 1,
+      });
     }
   }
   return { links, skipped };
@@ -191,7 +254,7 @@ export function collectLinks(text) {
  * @param {(p: string) => string} read
  * @returns {{files: number, total: number, fenced: number, broken: string[], staleAnchors: string[], fragmentless: number, checkedAnchors: number}}
  */
-export function census(git, exists, read) {
+export function census(git, exists, read, isDirectory = () => false) {
   const files = git(['ls-files', '*.md']).trim().split('\n').filter(Boolean);
   const broken = [];
   const staleAnchors = [];
@@ -201,6 +264,8 @@ export function census(git, exists, read) {
   let fragmentless = 0;
   let checkedAnchors = 0;
   let sameFileAnchors = 0;
+  let nonMarkdown = 0;
+  let repoRelative = 0;
 
   const anchorsOf = (p) => {
     if (!anchorCache.has(p)) anchorCache.set(p, headingSlugs(read(p)));
@@ -231,11 +296,25 @@ export function census(git, exists, read) {
         continue;
       }
 
+      if (link.repoRelative) {
+        // GitHub renders these against the repository. They point at nothing on disk and
+        // are correct as written, so they are counted and not resolved.
+        repoRelative += 1;
+        continue;
+      }
+
       const resolved = path.posix.normalize(
         path.posix.join(path.posix.dirname(file.split(path.sep).join('/')), link.target),
       );
       if (!exists(resolved)) {
         broken.push(`${file} -> ${link.href}`);
+        continue;
+      }
+      if (!link.target.endsWith('.md')) {
+        // Existence is the whole claim a link to source or to a directory can make. There
+        // is no heading structure to resolve a fragment against, so counting it as a
+        // checked anchor would overstate the anchor check's reach.
+        nonMarkdown += 1;
         continue;
       }
       if (!link.fragment) {
@@ -252,6 +331,13 @@ export function census(git, exists, read) {
         // A fragment that is not valid percent-encoding is compared as written rather
         // than reported as stale; the renderer does not decode it either.
       }
+      if (isDirectory(resolved)) {
+        // Unreachable for a `.md` target in practice, but `exists` passing does not imply
+        // `read` will succeed, and reading a directory throws EISDIR -- which would take
+        // the whole gate down rather than report a finding.
+        nonMarkdown += 1;
+        continue;
+      }
       if (!anchorsOf(resolved).has(slugify(decoded))) {
         staleAnchors.push(`${file}:${link.line} -> ${link.href}`);
       }
@@ -266,6 +352,8 @@ export function census(git, exists, read) {
     fragmentless,
     checkedAnchors,
     sameFileAnchors,
+    nonMarkdown,
+    repoRelative,
   };
 }
 
@@ -286,7 +374,13 @@ export function census(git, exists, read) {
  * would improve the ratio this paragraph exists to disclose -- a scope line that gets
  * flattered by a fix is not measuring what it claims to.
  *
- * @param {{files: number, total: number, fenced: number, fragmentless: number, checkedAnchors: number, sameFileAnchors?: number}} scope
+ * `Not measured` once read "links to non-markdown files". That sentence was true when
+ * written and became false the moment those 1,110 links were checked. A disclaimer is the
+ * one kind of prose that fails toward *false assurance* when it goes stale -- it under-claims,
+ * which reads as caution -- so it has to be edited in the same commit that widens the reach
+ * it disclaims.
+ *
+ * @param {{files: number, total: number, fenced: number, fragmentless: number, checkedAnchors: number, sameFileAnchors?: number, nonMarkdown?: number, repoRelative?: number}} scope
  * @returns {string[]}
  */
 export function scopeLines({
@@ -296,16 +390,18 @@ export function scopeLines({
   fragmentless,
   checkedAnchors,
   sameFileAnchors = 0,
+  nonMarkdown = 0,
+  repoRelative = 0,
 }) {
   const cross = total - sameFileAnchors;
   const share = cross === 0 ? '0.0' : ((100 * fragmentless) / cross).toFixed(1);
-  const unresolved = cross - fragmentless - checkedAnchors;
+  const unresolved = cross - fragmentless - checkedAnchors - nonMarkdown - repoRelative;
   return [
     `Scope: ${total} markdown link(s) across ${files} tracked file(s); ${fenced} inside fenced blocks were skipped.`,
-    `Specificity: of ${cross} cross-file link(s), ${fragmentless} name only a file (${share}%); ${checkedAnchors} name a section and had their anchor resolved; ${unresolved} point at a file that does not exist and were not classified.`,
+    `Specificity: of ${cross} cross-file link(s), ${fragmentless} name only a markdown file (${share}%); ${checkedAnchors} name a section and had their anchor resolved; ${nonMarkdown} point at source or a directory and were checked for existence only; ${repoRelative} are GitHub repo-relative (issues, pull requests) and resolve against the repository rather than the tree; ${unresolved} point at a file that does not exist and were not classified.`,
     `Same-file anchors: ${sameFileAnchors} link(s) of the form [text](#section), every one resolved against its own document's headings.`,
-    'Not measured: URL targets, links to non-markdown files, or whether a target still',
-    'contains the content the citing text claims. A file that keeps its name while its',
+    'Not measured: URL targets, the contents of a non-markdown target, or whether a target',
+    'still contains the content the citing text claims. A file that keeps its name while its',
     'content moves elsewhere stays green here unless the link named the section that moved.',
   ];
 }
@@ -403,8 +499,15 @@ function main() {
   const root = process.cwd();
   const exists = (p) => fs.existsSync(path.join(root, p));
   const read = (p) => fs.readFileSync(path.join(root, p), 'utf8');
+  const isDirectory = (p) => {
+    try {
+      return fs.statSync(path.join(root, p)).isDirectory();
+    } catch {
+      return false;
+    }
+  };
 
-  const result = census(git, exists, read);
+  const result = census(git, exists, read, isDirectory);
   const { lines, failed } = reportLines(result);
   const write = failed ? console.error : console.log;
   for (const line of lines) write(line);

--- a/tools/check-doc-links.test.mjs
+++ b/tools/check-doc-links.test.mjs
@@ -9,6 +9,7 @@ import {
   census,
   collectLinks,
   headingSlugs,
+  isRepoRelative,
   markFences,
   reportLines,
   scopeLines,
@@ -45,9 +46,20 @@ test('a bare fragment is collected as a same-file anchor', () => {
   assert.equal(links[0].fragment, 'anchor');
 });
 
-test('non-markdown targets are out of scope', () => {
+test('non-markdown targets are collected and checked for existence (#4301)', () => {
+  // This test previously asserted `links.length === 0` under the name "non-markdown targets
+  // are out of scope". The scope it described was real -- `collectLinks` dropped them -- so
+  // the test passed for as long as the defect existed and would have kept passing forever.
+  //
+  // A test can only ever confirm that the code does what the code does. What made this one
+  // harmful was the *name*: "out of scope" reads as a considered boundary, so anyone
+  // wondering whether .kt and .swift links were checked found an authoritative-sounding no.
+  // 1,110 links, 22 of them broken, sat behind that sentence.
   const { links } = collectLinks('[x](./a.png) [y](./b.ts)');
-  assert.equal(links.length, 0);
+  assert.deepEqual(
+    links.map((l) => l.target),
+    ['./a.png', './b.ts'],
+  );
 });
 
 test('links inside a fenced block are skipped and counted', () => {
@@ -151,6 +163,8 @@ test('census returns an empty result for a repository with no markdown', () => {
     fragmentless: 0,
     checkedAnchors: 0,
     sameFileAnchors: 0,
+    nonMarkdown: 0,
+    repoRelative: 0,
   });
 });
 
@@ -176,7 +190,11 @@ test('the baseline holds distinct entries only', () => {
 
 test('every baseline entry is in the file -> href form the census emits', () => {
   for (const entry of UNRESOLVED_BASELINE) {
-    assert.match(entry, /^[^ ]+\.md -> \S+\.md$/, `malformed baseline entry: ${entry}`);
+    // The target side is no longer restricted to `.md`. It was, for as long as the census
+    // dropped every non-markdown link before counting it -- so this assertion agreed with
+    // the defect rather than detecting it, which is what a test written against a filtered
+    // population always does.
+    assert.match(entry, /^[^ ]+\.md -> \S+$/, `malformed baseline entry: ${entry}`);
   }
 });
 
@@ -322,7 +340,7 @@ test('scopeLines states the specificity split on both paths', () => {
     checkedAnchors: 2,
   });
   const specificity = lines.find((l) => l.startsWith('Specificity:'));
-  assert.match(specificity, /of 10 cross-file link\(s\), 7 name only a file \(70\.0%\)/);
+  assert.match(specificity, /of 10 cross-file link\(s\), 7 name only a markdown file \(70\.0%\)/);
   assert.match(specificity, /2 name a section/);
   assert.match(specificity, /1 point at a file that does not exist/);
 });
@@ -603,7 +621,7 @@ test('the specificity share is taken over cross-file links only', () => {
   // 3 of 4 cross-file links, not 3 of 10. Both the share and the residual must use the
   // cross-file denominator: over `total` the share reads 30.0% and the residual reads 6,
   // and 6 unclassified links is a plausible-looking number that names nothing real.
-  assert.match(lines[1], /of 4 cross-file link\(s\), 3 name only a file \(75\.0%\)/);
+  assert.match(lines[1], /of 4 cross-file link\(s\), 3 name only a markdown file \(75\.0%\)/);
   assert.match(lines[1], /0 point at a file that does not exist/);
   assert.doesNotMatch(lines[1], /30\.0%/);
   assert.match(lines[2], /6 link\(s\) of the form/);
@@ -687,4 +705,200 @@ test('scopeLines tolerates a census taken before same-file anchors existed', () 
   const lines = scopeLines({ files: 1, total: 4, fenced: 0, fragmentless: 3, checkedAnchors: 1 });
   assert.match(lines[1], /of 4 cross-file link\(s\)/);
   assert.match(lines[2], /Same-file anchors: 0 link\(s\)/);
+});
+
+// --- non-markdown targets, previously dropped before being counted (#4301) ---
+
+test('a link to a source file is collected, not dropped (#4301)', () => {
+  const { links } = collectLinks('See [aria](../apps/web/src/accessibility/aria.ts) here.');
+  assert.equal(links.length, 1);
+  assert.equal(links[0].target, '../apps/web/src/accessibility/aria.ts');
+  assert.equal(links[0].sameFile, false);
+  assert.equal(links[0].repoRelative, false);
+});
+
+test('a link to a directory is collected (#4301)', () => {
+  const { links } = collectLinks('See [fn](../../services/api/supabase/functions/x/) here.');
+  assert.equal(links.length, 1);
+  assert.equal(links[0].target, '../../services/api/supabase/functions/x/');
+});
+
+test('every non-markdown extension present in the corpus is collected (#4301)', () => {
+  // The dropped population was 470 .kt, 341 .swift, 126 directory, 68 .ts, 22 .tsx and
+  // eleven further extensions. Enumerated rather than sampled: a filter that dropped all
+  // of them was invisible precisely because no single case was ever asserted.
+  const extensions = [
+    '.kt',
+    '.swift',
+    '.ts',
+    '.tsx',
+    '.yml',
+    '.sql',
+    '.example',
+    '.yaml',
+    '.xml',
+    '.json',
+    '.ps1',
+    '.sh',
+    '.css',
+    '.mjs',
+    '.kts',
+    '.txt',
+    '.js',
+  ];
+  for (const ext of extensions) {
+    const { links } = collectLinks(`[x](../a/b${ext})`);
+    assert.equal(links.length, 1, `a link to a ${ext} file must be collected`);
+    assert.equal(links[0].target, `../a/b${ext}`);
+  }
+});
+
+test('a broken link to a source file fails the census (#4301)', () => {
+  const result = census(
+    () => 'a.md',
+    (p) => p === 'ok.ts',
+    () => '# T\n\n[good](ok.ts) [bad](gone.ts)\n',
+  );
+  assert.deepEqual(result.broken, ['a.md -> gone.ts']);
+  assert.equal(result.nonMarkdown, 1);
+});
+
+test('a non-markdown target with a fragment is not resolved as an anchor (#4301)', () => {
+  // There is no heading structure in a .ts file, so counting it as a checked anchor would
+  // overstate the anchor check's reach -- the figure whose whole purpose is to be honest
+  // about how little of the corpus it reaches.
+  const result = census(
+    () => 'a.md',
+    () => true,
+    () => '# T\n\n[x](y.ts#L40)\n',
+  );
+  assert.equal(result.checkedAnchors, 0);
+  assert.equal(result.nonMarkdown, 1);
+  assert.deepEqual(result.staleAnchors, []);
+});
+
+test('a directory target never reaches read(), which would throw EISDIR (#4301)', () => {
+  // exists() passing does not imply read() will succeed. Reading a directory throws, and
+  // an uncaught throw takes the whole gate down rather than reporting a finding.
+  const result = census(
+    () => 'a.md',
+    () => true,
+    (p) => {
+      if (p === 'sub') throw Object.assign(new Error('EISDIR'), { code: 'EISDIR' });
+      return '# T\n\n[x](sub#frag)\n';
+    },
+    (p) => p === 'sub',
+  );
+  assert.deepEqual(result.broken, []);
+  assert.equal(result.nonMarkdown, 1);
+});
+
+// --- GitHub repo-relative idiom (#4301) ---
+
+test('GitHub repo-relative targets are recognised (#4301)', () => {
+  for (const t of [
+    '../../issues/2609',
+    '../../pull/44',
+    '../../discussions/7',
+    '../../tree/main/apps',
+    '../../blob/main/a.ts',
+    '../../releases/tag/v1',
+  ]) {
+    assert.equal(isRepoRelative(t), true, `${t} is GitHub repo-relative`);
+  }
+});
+
+test('a path that merely contains a repo word is not repo-relative (#4301)', () => {
+  // Over-reporting and under-reporting are both wrong; this guards the direction that
+  // silently excuses a real broken link.
+  for (const t of ['../issues.md', '../a/issuesx/b.ts', '../pullover.ts', '../my-issues.png']) {
+    assert.equal(isRepoRelative(t), false, `${t} is an ordinary path`);
+  }
+});
+
+test('a repo-relative link is counted but not resolved (#4301)', () => {
+  // 40 such links exist here and an earlier census reported every one as broken -- 62
+  // against 22 real. A checker that cries wolf makes its own exemption a rubber stamp.
+  const result = census(
+    () => 'a.md',
+    () => false,
+    () => '# T\n\n[#2609](../../issues/2609)\n',
+  );
+  assert.deepEqual(result.broken, []);
+  assert.equal(result.repoRelative, 1);
+});
+
+// --- explicit HTML anchors (#4301) ---
+
+test('an explicit <a id> anchor is offered by the document (#4301)', () => {
+  const slugs = headingSlugs('# T\n\n<a id="spot"></a>\n');
+  assert.ok(slugs.has('spot'));
+  assert.ok(slugs.has('t'));
+});
+
+test('an explicit <a name> anchor is offered too (#4301)', () => {
+  assert.ok(headingSlugs('<a name="legacy"></a>').has('legacy'));
+});
+
+test('an explicit anchor is matched verbatim, not slugified (#4301)', () => {
+  // The author wrote the id the link has to match; GitHub does not transform it.
+  const slugs = headingSlugs('<a id="Mixed_Case-42"></a>');
+  assert.ok(slugs.has('Mixed_Case-42'));
+  assert.equal(slugs.has('mixed_case-42'), false);
+});
+
+test('an explicit anchor inside a fenced block is not offered (#4301)', () => {
+  assert.equal(headingSlugs('```html\n<a id="shown"></a>\n```\n').has('shown'), false);
+});
+
+test('a link to an explicit anchor is not reported stale (#4301)', () => {
+  // finance's corpus contains zero explicit anchors, so this defect was green over an
+  // empty population -- indistinguishable in the output from green over a checked one.
+  const result = census(
+    () => 'a.md',
+    () => true,
+    () => '# T\n\n<a id="spot"></a>\n\n[x](#spot)\n',
+  );
+  assert.deepEqual(result.staleAnchors, []);
+  assert.equal(result.sameFileAnchors, 1);
+});
+
+// --- the scope line has to widen with the reach (#4301) ---
+
+test('the scope line names the newly-checked populations (#4301)', () => {
+  const lines = scopeLines({
+    files: 1,
+    total: 10,
+    fenced: 0,
+    fragmentless: 4,
+    checkedAnchors: 1,
+    sameFileAnchors: 2,
+    nonMarkdown: 2,
+    repoRelative: 1,
+  });
+  assert.match(lines[1], /2 point at source or a directory and were checked for existence only/);
+  assert.match(lines[1], /1 are GitHub repo-relative/);
+  // 8 cross-file - 4 fragmentless - 1 anchor - 2 non-markdown - 1 repo-relative = 0
+  assert.match(lines[1], /0 point at a file that does not exist/);
+});
+
+test('the disclaimer no longer claims non-markdown links are unmeasured (#4301)', () => {
+  // A disclaimer is the one kind of prose that fails toward false assurance when stale:
+  // it under-claims, which reads as caution, so nothing about it invites a second look.
+  const lines = scopeLines({ files: 1, total: 1, fenced: 0, fragmentless: 1, checkedAnchors: 0 });
+  const notMeasured = lines.slice(3).join(' ');
+  assert.equal(
+    /links to non-markdown files/.test(notMeasured),
+    false,
+    'the "Not measured" note must not still disclaim a population that is now checked',
+  );
+  assert.match(notMeasured, /the contents of a non-markdown target/);
+});
+
+test('the unresolved baseline separates never-true targets from moved ones (#4301)', () => {
+  // fire-calculator.ts reads like a rename of fire-planning.ts. Repointing it there would
+  // have turned the gate green while making the citing sentence false: calculateFINumber
+  // and calculateCoastFI exist nowhere in this repository.
+  const neverBuilt = UNRESOLVED_BASELINE.filter((e) => e.includes('fire-calculator.ts'));
+  assert.equal(neverBuilt.length, 2);
 });


### PR DESCRIPTION
## Summary

`tools/check-doc-links.mjs` is a required check. Its collector opened with:

```js
if (!target.endsWith('.md')) continue;
```

Every relative link to a non-markdown file was removed from the **population**, not from resolution — so it appeared in no total, no scope line, no finding and no disclaimer.

```
counted .md links (the reported total)   3353
DROPPED non-.md relative links           1110
  .kt 470   .swift 341   (dir/none) 126   .ts 68   .tsx 22
  .yml 17   .sql 14   .example 10  .yaml 8   .xml 8   and eight more
```

**22 were broken.** The gate had been green for months and could not see them.

The scope line is the sharp part. This tool prints its population deliberately, on both the passing and the failing path, because a control that states its reach only when it passes cannot be told apart from one that measured nothing. That machinery worked and reported `3353 markdown link(s)` — true about what the census saw, silent about what a filter three functions upstream had already halved. **A scope line is computed from the surviving population, so it cannot disclose an exclusion applied before the census began.**

## The test asserted the defect, and the name did the damage

```js
test('non-markdown targets are out of scope', () => {
  const { links } = collectLinks('[x](./a.png) [y](./b.ts)');
  assert.equal(links.length, 0);
});
```

Green from the day it was written, and accurate — a test can only confirm that the code does what the code does. The harm was the **name**. "Out of scope" is the vocabulary of a weighed decision, so anyone asking whether the 470 `.kt` and 341 `.swift` links were checked found an authoritative-sounding no. It turned an unexamined `continue` into documented policy, in the artifact a reader trusts most because a passing assertion sits beside it.

**A test name is a claim about intent, and nothing checks it.** The assertion is verified continuously; the sentence saying why is verified never, and when they drift the sentence wins, because it is the one a human reads.

## 62 reported, 22 real

Forty were GitHub's repo-relative idiom — `[#2609](../../issues/2609)`, `../../pull/N`, `../../tree/...` — which GitHub resolves against the repository. Correct as written; reporting them would be a false accusation at a 65% rate.

That is not just noise. The fix for a false positive is an exemption, and an author who has learned the checker cries wolf writes the exemption without reading the finding. **A checker's precision is what keeps its own escape hatch meaningful.** Now exempted and counted separately.

## Moved, versus never true

| class | n | fix |
| --- | --- | --- |
| off by one `../` — target exists at repo root | 16 | repointed |
| `account-deletion/` — removed in `087b812c` as deprecated, now `account-delete/` | 4 | repointed |
| `fire-calculator.ts` — **never existed** | 2 | baseline |

`fire-calculator.ts` reads exactly like a rename of the neighbouring `fire-planning.ts`, and repointing it would have gone green in one keystroke. It would also have been false: `calculateFINumber` and `calculateCoastFI`, the functions the citing tables describe, exist nowhere in the tree. The design doc specifies a web reference implementation that was never built.

Every resolver reports *moved* and *never true* identically and only the first is a regression — and here the tempting repair is the one that destroys the evidence. A link that is red because the thing does not exist is doing its job.

## Two further defects

- **Explicit anchors.** `headingSlugs` collected `#` headings only, so a link to `<a id="spot">` was reported stale. finance has **zero** explicit anchors, so this was green over an empty population — indistinguishable in the output from green over a checked one.
- **Directory targets.** `exists()` passing does not imply `read()` will succeed; reading a directory throws `EISDIR`, which takes the gate down rather than reporting a finding. Now guarded, with a test.

## The disclaimer had to move with the reach

`Not measured: ... links to non-markdown files` was true when written and false the moment those 1,110 links were checked. A stale disclaimer fails toward **false assurance** — it under-claims, which reads as caution, so nothing invites a second look. It is now asserted: a test fails if the note still disclaims a population the tool checks.

## Measured negative

The upstream session found its own probe skipped fences when collecting **headings** but not when collecting **links** — fence-blindness as a property of a *traversal*, not a tool. finance does not have this; `headingSlugs` and `collectLinks` both consume the shared `markFences`. Recorded as a negative rather than reshaped into a symmetric finding.

## Issues

Closes #4301

## Testing

- [x] `npm run format:check` — clean
- [x] `npx eslint . --max-warnings 0` — clean
- [x] `npm run type-check` — clean
- [x] `npm run tools:test` — **563/563** (546 before; +17 new)
- [x] All 15 gate scripts exit 0, run after `git add` so the `git ls-files`-based gates see the change
- [x] `docs:links:check` green with **1,068** previously-invisible links now checked

## Residual, not in scope

`docs/design/ios-fi-fire-calculator.md` carries 20 further prose references to `fire-calculator.ts` with specific line numbers. That is a design document written around a file that was never built; correcting it is a content decision for its owner, not a link fix.