### PR TITLE
fix(tools): gate the citation corpus on file content, not an extension list (#4300)

### DIFF
--- a/tools/check-ai-manifest.js
+++ b/tools/check-ai-manifest.js
@@ -686,8 +686,32 @@ function citationFindings(text, citations = CANON_CITATIONS, isLocallyOwned = ()
 // backbone tomorrow is scanned tomorrow, with nothing to update (#4270).
 const BACKBONE_CLAIM =
   /(sync\/lib\/|copier\.mjs|provenance\.mjs|basemerge\.mjs|lock\.mjs|jrmoulckers\/\.github)/;
-const CITATION_TEXT = /\.(?:md|js|mjs|cjs|ts|json|ya?ml|toml)$/;
+// The corpus gate is a PROPERTY OF THE FILE, not an extension allowlist. An allowlist is a
+// second hand-written population beside the pattern, and fixing one never touches the other: the
+// #4270 cross-check filtered git's index through this same constant, so narrowing it shrank both
+// sides together and the subset assertion still passed. Measured: narrowing to `.mdx?` dropped 8
+// real claimants, left 64 -- above the floor -- and the suite stayed 90/90 green (#4300).
+//
+// It also needed a hand-cased exception (`.gitattributes`), which is the transcription shape
+// fixed in #4287. Reading every non-binary file under the cap costs 6.5s against 7.2s for the
+// allowlist walk, so the narrowing bought nothing it was blamed on.
 const MAX_CITATION_BYTES = 400000;
+
+/**
+ * True when a file's bytes are prose this rule can read, i.e. it carries no NUL byte.
+ *
+ * Size is deliberately NOT checked here. The cap has one owner -- the fstat gate in
+ * `citationCorpus`, which decides before the read rather than after it, so a huge blob is never
+ * pulled into memory. A buffer-length arm here duplicated that decision and could never fire:
+ * mutating it away killed nothing even with a real 400001-byte claimant constructed in the tree
+ * (#4300). Two guards on one property means one of them is untestable.
+ *
+ * @param {Buffer} buf Raw file contents, already known to be under the cap.
+ * @returns {boolean} Whether the bytes are readable prose rather than a binary blob.
+ */
+function isReadableText(buf) {
+  return !buf.includes(0);
+}
 
 /**
  * Files whose prose makes a claim about the backbone, and which are therefore subject to the
@@ -699,7 +723,6 @@ function citationCorpus() {
   const corpus = [];
   for (const file of walkFiles(ROOT)) {
     const relPath = path.relative(ROOT, file).split(path.sep).join('/');
-    if (!CITATION_TEXT.test(relPath) && relPath !== '.gitattributes') continue;
     let text;
     let fd;
     try {
@@ -707,7 +730,9 @@ function citationCorpus() {
       // TOCTOU race (CodeQL js/file-system-race) and the guard exists only to skip large blobs.
       fd = fs.openSync(file, 'r');
       if (fs.fstatSync(fd).size > MAX_CITATION_BYTES) continue;
-      text = fs.readFileSync(fd, 'utf8');
+      const buf = fs.readFileSync(fd);
+      if (!isReadableText(buf)) continue;
+      text = buf.toString('utf8');
     } catch {
       continue;
     } finally {
@@ -1791,7 +1816,6 @@ module.exports = {
   citationCoverage,
   validateCitationCoverage,
   BACKBONE_CLAIM,
-  CITATION_TEXT,
   MAX_CITATION_BYTES,
   COORDINATE,
   exemptionMatches,

--- a/tools/check-ai-manifest.test.mjs
+++ b/tools/check-ai-manifest.test.mjs
@@ -59,7 +59,6 @@ const {
   citationCorpus,
   validateCitationCoverage,
   BACKBONE_CLAIM,
-  CITATION_TEXT,
   MAX_CITATION_BYTES,
   exemptionMatches,
   sourceDisclosureLines,
@@ -1283,18 +1282,26 @@ test('the scanned population is derived from the surface, not narrowed to a samp
   // The one-line fix -- widen the pattern -- leaves the corpus free to shrink to anything
   // non-empty, which is the guard shape that is indistinguishable from no guard. So the
   // population is cross-checked against an INDEPENDENT enumeration: git's index, not the walk.
+  //
+  // "Independent" now means it shares NO NARROWING with the walk, not merely a different
+  // directory source. This filter used to apply the walk's own CITATION_TEXT, so narrowing that
+  // constant shrank both sides together and this assertion still passed: `/\.mdx?$/` dropped 8
+  // real claimants, left 64 -- above the floor -- and the suite stayed green (#4300). Only the
+  // claim predicate is shared now, because that predicate IS the rule: a claimant is a file that
+  // mentions the backbone. Everything else here is a property of the bytes.
   const tracked = execFileSync('git', ['ls-files'], { cwd: ROOT, encoding: 'utf8' })
     .split('\n')
     .filter(Boolean);
   const expected = tracked.filter((relPath) => {
-    if (!CITATION_TEXT.test(relPath) && relPath !== '.gitattributes') return false;
     // Same single-descriptor discipline as the production walk: stat-then-read is a TOCTOU race.
     let fd;
     try {
       fd = fs.openSync(path.join(ROOT, relPath), 'r');
       const stat = fs.fstatSync(fd);
       if (!stat.isFile() || stat.size > MAX_CITATION_BYTES) return false;
-      return BACKBONE_CLAIM.test(fs.readFileSync(fd, 'utf8'));
+      const buf = fs.readFileSync(fd);
+      if (buf.includes(0)) return false;
+      return BACKBONE_CLAIM.test(buf.toString('utf8'));
     } catch {
       return false;
     } finally {
@@ -1307,6 +1314,86 @@ test('the scanned population is derived from the surface, not narrowed to a samp
   assert.ok(expected.length > 5, 'PREMISE: git sees a non-trivial claimant population');
   for (const relPath of expected) {
     assert.ok(scanned.has(relPath), `citationCorpus omits a claimant file: ${relPath}`);
+  }
+  // The extension-less claimant the old allowlist reached only by a hand-cased exception. Named
+  // because it is the one file proving the gate is not an extension list; if it stops making a
+  // backbone claim this premise fails rather than the coverage assertion silently weakening.
+  assert.ok(
+    expected.includes('.prettierignore'),
+    'PREMISE: an extension-less claimant exists to prove the gate is not an allowlist',
+  );
+});
+
+test('the gate excludes bytes it cannot read as prose, and only those (#4300)', () => {
+  // Dropping the binary check changed no result: nothing binary in this tree happens to carry a
+  // backbone claim, so that guard was LATENT -- dead by an impoverished corpus, not by an
+  // invariant (.github#880). Pinning "no blob makes a claim" would freeze an accident, so the
+  // corpus is enriched instead: three probes with the SAME coordinate and the SAME extension,
+  // differing only in the property under test. The text probe is the control that makes the two
+  // absences mean something rather than reading as a bare zero.
+  //
+  // The oversize arm is here for a different reason. Dropping the size check ALSO changed no
+  // result -- but it survived this enrichment too, with a real 400001-byte claimant present. That
+  // is the diagnostic: a latent guard dies once the corpus can reach it, an equivalent one cannot.
+  // The size cap had two implementations and the fstat gate in citationCorpus always decided
+  // first, so the second could never fire. It was removed; this arm now mutation-covers the
+  // remaining owner.
+  const coordinate = at('sync/lib/copier.mjs', 410);
+  const text = path.join(ROOT, 'PROBE-4300-text.md');
+  const binary = path.join(ROOT, 'PROBE-4300-binary.md');
+  const oversize = path.join(ROOT, 'PROBE-4300-oversize.md');
+  fs.writeFileSync(text, `see ${coordinate}\n`, { flag: 'wx' });
+  fs.writeFileSync(
+    binary,
+    Buffer.concat([Buffer.from(`see ${coordinate}\n`), Buffer.from([0]), Buffer.from('tail\n')]),
+    { flag: 'wx' },
+  );
+  fs.writeFileSync(oversize, `see ${coordinate}\n`.padEnd(MAX_CITATION_BYTES + 1, 'x'), {
+    flag: 'wx',
+  });
+  try {
+    let out;
+    try {
+      out = execFileSync(process.execPath, [TOOL], { encoding: 'utf8' });
+    } catch (error) {
+      out = String(error.stdout || '');
+    }
+    assert.match(
+      out,
+      /PROBE-4300-text\.md: cites a file this repository does not own/,
+      'CONTROL: the same coordinate in readable prose must be reported',
+    );
+    assert.ok(!out.includes('PROBE-4300-binary.md'), 'a NUL-bearing blob is not prose');
+    assert.ok(!out.includes('PROBE-4300-oversize.md'), 'a file over the cap is not scanned');
+  } finally {
+    fs.unlinkSync(text);
+    fs.unlinkSync(binary);
+    fs.unlinkSync(oversize);
+  }
+});
+
+test('a claimant is scanned for what it contains, not for its extension (#4300)', () => {
+  // Behavioural arm. The enumeration above proves the corpus covers git's claimants; this proves
+  // the gate itself admits a file type the old allowlist excluded, by driving the whole tool.
+  // `.kt` is delivered into this repo by the backbone and was never in CITATION_TEXT.
+  const probe = path.join(ROOT, 'PROBE-4300.kt');
+  fs.writeFileSync(probe, `// engine detail at ${at('sync/lib/copier.mjs', 410)}\n`, {
+    flag: 'wx',
+  });
+  try {
+    let out;
+    try {
+      out = execFileSync(process.execPath, [TOOL], { encoding: 'utf8' });
+    } catch (error) {
+      out = String(error.stdout || '');
+    }
+    assert.match(
+      out,
+      /\[DRIFT\] PROBE-4300\.kt: cites a file this repository does not own/,
+      'a claimant with an excluded extension must still reach the report',
+    );
+  } finally {
+    fs.unlinkSync(probe);
   }
 });
 


### PR DESCRIPTION
Fixes a blind spot in the citation-coverage rule: the population it scanned was
defined by a hand-written extension allowlist, and the cross-check meant to prove
that population complete filtered git's index through the same constant.

## The defect, measured rather than argued

`citationCorpus()` gated candidates on `CITATION_TEXT` -- an extension allowlist
plus a hand-cased `.gitattributes` exception (the transcription shape fixed in
#4287, sitting inside the corpus fix from #4270). The #4270 cross-check filtered
`git ls-files` through that same constant, so a narrowing shrank **both sides
together** and the subset assertion still held.

Three narrowings were killed by the existing suite -- but each collapsed the
corpus below the `> 5` floor, so the floor fired, not independence. A **size
accident, not a check**:

| mutant | corpus | result |
| --- | --- | --- |
| X1 `CITATION_TEXT` -> `.mjs` only | collapsed | KILLED (floor) |
| X2 cap -> 1 | collapsed | KILLED (floor) |
| X3 claim regex -> never matches | collapsed | KILLED (floor) |
| **X4 `CITATION_TEXT` -> `/\.mdx?$/`** | **64, above the floor** | **SURVIVED, 90/90 green** |

X4 silently dropped **8 real claimants** with the suite green. A narrowed corpus
is internally consistent: a floor passes, a non-empty premise passes, a subset
assertion passes. Every check that reads the corpus *through* the corpus survives
the narrowing it exists to catch.

## Enumeration and cost

Enumerating claimants by **content** across all 5551 tracked files finds **73**,
against 72 under the extension gate. The extra is `.prettierignore` (line 26
mentions the backbone) and it carries **no violating coordinate**, so widening
surfaces **zero live violations**. That null is the point: the number didn't
change, but it now carries information, because previously it could not have been
anything else.

Cost: **6.5s** for the full content scan against **7.2s** for the allowlist walk.
The narrowing bought nothing it was blamed on.

## The fix

- The gate is a property of the bytes: under the size cap, no NUL byte. No
  extension list, no hand-cased exception.
- The #4270 cross-check filters git's index by the rule's own definition
  (`BACKBONE_CLAIM`, size, binary) and by nothing the walk invented.
- New behavioural test drives the whole tool against a `.kt` probe -- a type the
  backbone delivers here and the old allowlist never included.

## Verification

Firing control first (`assert.ok(false)` -> `fail=1`), anchors asserted unique,
sources restored and compared against the in-memory original.

| mutant | result |
| --- | --- |
| Y1 extension gate reintroduced (`.mdx?`) -- **the X4 survivor** | KILLED x2 by name |
| Y2 the exact pre-change production gate restored | KILLED x2 by name |
| Z1 size-cap owner removed | KILLED x5 by name |
| Z2 size cap widened past the probe | KILLED x5 by name |
| Z3 binary check no-op'd | KILLED by name |
| Z4 readability gate unwired | KILLED by name |

## A disclosed survivor, and what it turned out to mean

Two guards initially survived: the binary check and the size check. Both looked
**latent** -- dead by an impoverished corpus rather than by an invariant -- which
is repaired by enriching the corpus, never by pinning the accident.

So the corpus was enriched: three probes with the **same coordinate** and the
**same extension**, differing only in the property under test, plus a readable
control so the two absences are differential rather than a bare zero.

The binary guard then died by name. **The size guard survived the enrichment even
with a real 400001-byte claimant in the tree** -- and that is diagnostic. A latent
guard dies once the corpus can reach it; an equivalent one cannot. The size cap
had **two implementations**, and the `fstat` gate always decided first, so the
buffer-length arm could never fire. It was removed, giving the property one owner
-- which Z1/Z2 now mutation-cover.

An enrichment probe distinguishes latent from equivalent empirically, before you
commit to a treatment.

## Validation

- suite **92 passing, 0 failing** (90 before)
- `node tools/check-ai-manifest.js` exit 0; report now states 73 claimants
- `npx eslint` on both files, `--max-warnings 0`, exit 0
- `npx prettier --check` on both files: unchanged
- `.studio-sync.lock.json` untouched; `packages/design-tokens` untouched; no
  workflow modified

Closes #4300


---

**Correction (post-merge, measured).** The line "suite **92 passing, 0 failing** (90 before)"
was measured on this branch *before* the final rebase. `d56ce9e1` (#4298) landed one test
underneath it, so the true figures on `main` are **91 before, 93 after**. The contribution of
this PR is unchanged at **+2 tests**; only the base moved. Counted with
`git show <sha>:tools/check-ai-manifest.test.mjs` at `d56ce9e1~1` (90), `d56ce9e1` (91) and
`4f8f3f1a` (93), and confirmed by `node --test` on merged `main`: **93 passing, 0 failing**.