### PR TITLE
fix(tools): assert two required gates' reports and cross wiring against assertion (#4303)

### DIFF
--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -9087,6 +9087,57 @@ a tool, with two traversals in one file and only one guarded. finance does not h
 `headingSlugs` and `collectLinks` both consume the shared `markFences`. Recorded as a negative
 rather than reshaped into a symmetric finding.
 
+## Whether a check runs and whether its report is checked are independent properties
+
+A sentinel mutation sweep over the 15 tools in `tools/` that have a colocated test file — replace
+each interpolated value in a report line with a sentinel, re-run that tool's tests, record whether
+anything fails — scored **103 of 305 interpolation sites asserted**. Crossed against whether a
+workflow invokes the tool, all four quadrants are populated:
+
+|                | asserted (>=50%)                                                                                                  | unasserted (<50%)                                                                                                                                                                                                                          |
+| -------------- | ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **runs in CI** | `check-doc-links` 100%, `check-test-independence` 71%, `check-gate-enforcement` 64%, `check-assertion-bounds` 50% | `check-workflow-security` 35%, `run-tool-tests` 33%, `check-tool-imports` 25%, `check-node-version-consistency` 18%, `check-gradle-prefetch` 18%, `check-upstream-refs` 14%, `verify-required-checks` 0%, `check-citation-enumerations` 0% |
+| **inert**      | `citations-context` 100%, `check-report-assertions` 81%                                                           | `check-workflow-pin-history` 9%                                                                                                                                                                                                            |
+
+The two best-asserted tools in the repository are both unwired. Two required gates score zero. So
+"inert" — which this repository has used as a single summary judgement — is two claims wearing one
+word, and they have different remedies: an unwired tool needs a workflow step, an unasserted one
+needs a callable report surface. `gate:enforcement` measures the first axis and nothing measured
+the second, so a tool could be fixed on the axis that was watched and stay broken on the axis that
+was not.
+
+### The tool that measures this withheld the data that shows it
+
+`check-report-assertions.mjs` printed an aggregate ratio and a flat list of survivors. It did not
+print the caught list — so **its own output could not be decomposed per tool**, and building the
+table above required a bespoke probe against the exported `measure()`. The aggregate 34% is
+compatible with every tool sitting near 34% and with the actual distribution, which is bimodal and
+has two zeroes in it. A report that publishes a ratio while withholding its components cannot
+support the finding it exists to produce, and here the specific finding it suppressed was that the
+two axes do not correlate.
+
+This is the scope-line rule turned one notch further. A scope line discloses the population a
+number was computed over. It does not disclose that the number is an average over a population
+whose _variance_ is the whole story.
+
+### Both zeroes were structural, and neither was a weak test
+
+`verify-required-checks.mjs` exported two predicates and built all 35 of its sentences inline in an
+async polling loop that reaches the GitHub API. `check-citation-enumerations.mjs` exported its
+predicates and wrote its report straight to `process.stdout` from a function that walks the real
+tree. Neither scored 0% because someone wrote a lax assertion — they scored 0% because **there was
+no callable surface to assert**. Extraction is the precondition for assertion; the earlier note in
+this guide that extraction is not itself a remedy remains true, and both halves are needed: the
+extraction here bought nothing until a test read the interpolated values.
+
+Both are worth asserting for the same reason. `verify-required-checks` is the deploy gate: its
+lines are the durable record of _why_ a SHA was promoted or refused, and an unasserted report can
+degrade to naming the wrong SHA or the wrong conclusion while the exit code stays correct.
+`check-citation-enumerations` reports a three-bucket partition whose third bucket — exempted lines
+— is the only one that can hide a violation.
+
+Cites `ENG-TEST-004`, `ENG-OBS-005`.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:

--- a/tools/check-citation-enumerations.mjs
+++ b/tools/check-citation-enumerations.mjs
@@ -146,6 +146,64 @@ async function* walk(directory) {
   }
 }
 
+/*
+ * Report builders.
+ *
+ * Extracted from `main()` (issue #4303). A sentinel mutation sweep found 0 of this tool's 7
+ * interpolation sites asserted, because `main()` walks a real directory tree and writes straight
+ * to stdout -- no test could obtain a sentence to compare. The predicates below it were already
+ * well covered; the report was not covered at all, and the two facts were indistinguishable from
+ * the outside because the suite was green either way.
+ */
+
+/**
+ * Build the failing report for restated enumerations.
+ *
+ * The exemption count appears on this path as well as the green one. A failure reporting
+ * "1 across 3161 scanned file(s)" states two of three buckets, and the missing one is the only
+ * bucket that can hide a violation -- an exempted line is one this check chose not to see. A
+ * partition has to sum, or one of its parts is invisible.
+ *
+ * @param {{file: string, line: number, id: string, enumeration: string, text: string}[]} violations Findings.
+ * @param {number} scanned Files read.
+ * @param {number} exempted Lines skipped via the exemption marker.
+ * @returns {string[]} Report lines, newline-free.
+ */
+export function violationLines(violations, scanned, exempted) {
+  const lines = [
+    `Restated principle enumeration(s) — ${violations.length} across ${scanned} scanned ` +
+      `file(s), with ${exempted} line(s) exempted via the "${EXEMPTION}" marker:`,
+  ];
+  for (const v of violations) {
+    lines.push(
+      `  ${v.file}:${v.line}  ${v.id}`,
+      `    enumerates: ${v.enumeration}`,
+      `    ${v.text}`,
+    );
+  }
+  lines.push(
+    'An enumeration copied from a principle drifts by losing an item while every',
+    'remaining word stays true. Cite the ID and describe what finance does; let the',
+    'principle state what it requires. See ADR-0003 (four-authority topology).',
+  );
+  return lines;
+}
+
+/**
+ * Build the passing report.
+ *
+ * @param {number} scanned Files read.
+ * @param {number} exempted Lines skipped via the exemption marker.
+ * @returns {string} The clean-result sentence.
+ */
+export function cleanLine(scanned, exempted) {
+  return (
+    `No principle enumeration is restated as an obligation. ${scanned} file(s) scanned, ` +
+    `${exempted} line(s) exempted via the "${EXEMPTION}" marker. Read one line at a ` +
+    'time, so a list wrapped across a line break is not seen.'
+  );
+}
+
 export async function main(root) {
   const violations = [];
   let scanned = 0;
@@ -160,34 +218,12 @@ export async function main(root) {
   }
 
   if (violations.length > 0) {
-    process.stdout.write(
-      // The exemption count belongs here, not only on the green path. A failure
-      // reporting "1 across 3161 scanned file(s)" states two of three buckets,
-      // and the missing one is the only bucket that can HIDE a violation --
-      // an exempted line is one this check chose not to see. A partition has
-      // to sum, or one of its parts is invisible.
-      `\nRestated principle enumeration(s) — ${violations.length} across ${scanned} scanned ` +
-        `file(s), with ${exempted} line(s) exempted via the "${EXEMPTION}" marker:\n\n`,
-    );
-    for (const v of violations) {
-      process.stdout.write(`  ${v.file}:${v.line}  ${v.id}\n`);
-      process.stdout.write(`    enumerates: ${v.enumeration}\n`);
-      process.stdout.write(`    ${v.text}\n\n`);
-    }
-    process.stdout.write(
-      'An enumeration copied from a principle drifts by losing an item while every\n' +
-        'remaining word stays true. Cite the ID and describe what finance does; let the\n' +
-        'principle state what it requires. See ADR-0003 (four-authority topology).\n',
-    );
+    process.stdout.write(`\n${violationLines(violations, scanned, exempted).join('\n')}\n`);
     process.exitCode = 1;
     return;
   }
 
-  process.stdout.write(
-    `No principle enumeration is restated as an obligation. ${scanned} file(s) scanned, ` +
-      `${exempted} line(s) exempted via the "${EXEMPTION}" marker. Read one line at a ` +
-      'time, so a list wrapped across a line break is not seen.\n',
-  );
+  process.stdout.write(`${cleanLine(scanned, exempted)}\n`);
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/tools/check-citation-enumerations.test.mjs
+++ b/tools/check-citation-enumerations.test.mjs
@@ -11,10 +11,76 @@ import {
   ENUMERATION,
   OBLIGATION,
   SCANNED_EXTENSIONS,
+  cleanLine,
   countExemptions,
   findRestatedEnumerations,
   isScannedFile,
+  violationLines,
 } from './check-citation-enumerations.mjs';
+
+// Report-line tests (#4303).
+//
+// The predicates above were well covered while the report was not covered at all, and from the
+// outside the two states were indistinguishable: the suite was green either way. A sentinel sweep
+// scored this tool 0/7. The tests below read the interpolated counts, because the counts are the
+// whole content -- a report that names the right violation with the wrong denominator is worse
+// than no report, since the denominator is what a reader uses to judge whether the scan was broad.
+
+const VIOLATION = {
+  file: 'docs/guides/x.md',
+  line: 42,
+  id: 'ENG-SEC-008',
+  enumeration: 'accounts, balances, and transactions',
+  text: 'finance requires accounts, balances, and transactions to be redacted.',
+};
+
+test('violationLines states all three buckets of the partition', () => {
+  const [header] = violationLines([VIOLATION], 3161, 4);
+  assert.match(header, /— 1 across 3161 scanned file\(s\)/);
+  assert.match(header, /with 4 line\(s\) exempted/);
+  assert.ok(header.includes(`"${EXEMPTION}"`), 'the marker name must be named, not described');
+});
+
+test('violationLines counts violations, not scanned files, in the first bucket', () => {
+  const [header] = violationLines([VIOLATION, { ...VIOLATION, line: 43 }], 10, 0);
+  assert.match(header, /— 2 across 10 scanned file\(s\)/);
+});
+
+test('violationLines emits file, line, id, enumeration and source text per finding', () => {
+  const lines = violationLines([VIOLATION], 1, 0);
+  assert.ok(lines.includes('  docs/guides/x.md:42  ENG-SEC-008'), lines.join('\n'));
+  assert.ok(lines.includes('    enumerates: accounts, balances, and transactions'));
+  assert.ok(lines.some((l) => l.includes(VIOLATION.text)));
+});
+
+test('violationLines closes with the remedy and cites ADR-0003', () => {
+  const lines = violationLines([VIOLATION], 1, 0);
+  assert.match(lines.at(-1), /ADR-0003 \(four-authority topology\)/);
+  assert.ok(lines.some((l) => l.includes('drifts by losing an item')));
+});
+
+test('violationLines line count scales by three per finding', () => {
+  const one = violationLines([VIOLATION], 1, 0).length;
+  const two = violationLines([VIOLATION, VIOLATION], 1, 0).length;
+  assert.equal(two - one, 3);
+});
+
+test('cleanLine reports both the scanned and exempted counts', () => {
+  const line = cleanLine(3161, 4);
+  assert.match(line, /3161 file\(s\) scanned/);
+  assert.match(line, /4 line\(s\) exempted/);
+  assert.match(line, /No principle enumeration is restated as an obligation\./);
+});
+
+test('cleanLine discloses the line-at-a-time limitation that makes a wrapped list invisible', () => {
+  assert.match(cleanLine(1, 0), /Read one line at a time, so a list wrapped across a line break/);
+});
+
+test('a zero-exemption green result still names the exemption bucket', () => {
+  // Omitting the bucket when it is empty would make "0 exempted" and "not measured"
+  // render identically -- the failure mode this tool's own comment warns about.
+  assert.match(cleanLine(3161, 0), /0 line\(s\) exempted/);
+});
 
 test('the defect this was written for is caught', () => {
   const text =

--- a/tools/check-report-assertions.mjs
+++ b/tools/check-report-assertions.mjs
@@ -252,6 +252,93 @@ export function refuseReason() {
 }
 
 /**
+ * Determine which tools are invoked by a workflow, directly or via an npm script.
+ *
+ * Wiring and assertion coverage are independent properties (#4303). Measured across finance's 15
+ * tested tools, all four quadrants of the cross are populated: the two best-asserted tools are
+ * both unwired, and two required gates score 0%. Treating "inert" as a single summary judgement
+ * covering both conflates a tool nothing runs with a tool nothing checks, and the remedies differ
+ * -- the first needs a workflow step, the second needs a callable report surface.
+ *
+ * @param {typeof fs} [fsImpl] Injectable filesystem.
+ * @returns {Set<string>} Tool filenames referenced by at least one workflow.
+ */
+export function wiredTools(fsImpl = fs) {
+  const scripts = JSON.parse(fsImpl.readFileSync('package.json', 'utf8')).scripts ?? {};
+  const dir = '.github/workflows';
+  const workflows = fsImpl
+    .readdirSync(dir)
+    .map((f) => fsImpl.readFileSync(path.join(dir, f), 'utf8'))
+    .join('\n');
+  const wired = new Set();
+  for (const [name, body] of Object.entries(scripts)) {
+    if (!workflows.includes(`npm run ${name}`)) continue;
+    for (const match of body.matchAll(/tools\/([\w.-]+\.(?:mjs|js))/g)) wired.add(match[1]);
+  }
+  for (const match of workflows.matchAll(/tools\/([\w.-]+\.(?:mjs|js))/g)) wired.add(match[1]);
+  return wired;
+}
+
+/**
+ * Render the per-tool breakdown, crossed against gate wiring.
+ *
+ * An earlier version of this report printed the aggregate ratio and the survivor list only. It
+ * withheld the caught list, so its own output could not be decomposed per tool -- producing the
+ * table below required a bespoke probe against `measure()`. A report that publishes a ratio while
+ * withholding its components cannot support the finding it exists to produce, and the specific
+ * finding it suppressed was that wiring and assertion do not correlate.
+ *
+ * @param {{caught: string[], survivors: string[]}} result Measurement.
+ * @param {Set<string>} wired Tools invoked by a workflow.
+ * @returns {string[]} Report lines.
+ */
+export function perToolLines(result, wired) {
+  const per = new Map();
+  const tally = (labels, key) => {
+    for (const label of labels) {
+      const tool = label.split(':')[0];
+      const entry = per.get(tool) ?? { asserted: 0, total: 0 };
+      entry.total += 1;
+      if (key === 'asserted') entry.asserted += 1;
+      per.set(tool, entry);
+    }
+  };
+  tally(result.caught, 'asserted');
+  tally(result.survivors, 'unasserted');
+
+  const rows = [...per.entries()]
+    .map(([tool, c]) => ({
+      tool,
+      ...c,
+      pct: Math.round((c.asserted / c.total) * 100),
+      wired: wired.has(tool),
+    }))
+    .sort((a, b) => b.pct - a.pct || b.total - a.total);
+
+  const lines = ['', 'per tool:', `  ${'tool'.padEnd(38)}${'asserted'.padEnd(11)}rate   gate`];
+  for (const r of rows) {
+    lines.push(
+      `  ${r.tool.padEnd(38)}${`${r.asserted}/${r.total}`.padEnd(11)}${`${r.pct}%`.padEnd(7)}${
+        r.wired ? 'yes' : 'no'
+      }`,
+    );
+  }
+  const quadrant = (isWired, isAsserted) =>
+    rows.filter((r) => r.wired === isWired && r.pct >= 50 === isAsserted).length;
+  lines.push(
+    '',
+    'wiring x assertion (asserted = >=50% of sites):',
+    `  gate,  asserted    ${quadrant(true, true)}`,
+    `  gate,  unasserted  ${quadrant(true, false)}`,
+    `  inert, asserted    ${quadrant(false, true)}`,
+    `  inert, unasserted  ${quadrant(false, false)}`,
+    'A populated off-diagonal means these are independent properties, not one judgement:',
+    'a tool can be well-tested and never run, or run on every push and assert nothing.',
+  );
+  return lines;
+}
+
+/**
  * Render the unasserted-site list.
  *
  * @param {string[]} survivors Site labels.
@@ -297,6 +384,7 @@ function main() {
   for (const line of scopeLines(result)) console.log(line);
   console.log('');
   console.log(elapsedLine(Date.now() - started));
+  for (const line of perToolLines(result, wiredTools())) console.log(line);
   for (const line of survivorLines(result.survivors)) console.log(line);
 }
 

--- a/tools/check-report-assertions.test.mjs
+++ b/tools/check-report-assertions.test.mjs
@@ -5,6 +5,7 @@ import {
   DEFAULT_SENTINEL,
   measure,
   mutateSite,
+  perToolLines,
   reportLines,
   elapsedLine,
   refusalLine,
@@ -12,7 +13,92 @@ import {
   scopeLines,
   survivorLines,
   toolsWithTests,
+  wiredTools,
 } from './check-report-assertions.mjs';
+
+// Cross-reporting tests (#4303).
+
+const CROSS = {
+  caught: ['a.mjs:1 ${x}', 'a.mjs:2 ${y}', 'b.mjs:1 ${z}'],
+  survivors: ['b.mjs:2 ${w}', 'b.mjs:3 ${v}', 'b.mjs:4 ${u}', 'c.mjs:1 ${t}'],
+};
+
+test('perToolLines decomposes the aggregate the survivor list alone cannot', () => {
+  const lines = perToolLines(CROSS, new Set(['a.mjs'])).join('\n');
+  // a: 2 caught / 0 survivors = 2/2. b: 1 caught / 3 survivors = 1/4. c: 0/1.
+  assert.match(lines, /a\.mjs\s+2\/2\s+100%/);
+  assert.match(lines, /b\.mjs\s+1\/4\s+25%/);
+  assert.match(lines, /c\.mjs\s+0\/1\s+0%/);
+});
+
+test('perToolLines marks only tools present in the wired set as gates', () => {
+  const lines = perToolLines(CROSS, new Set(['a.mjs'])).join('\n');
+  assert.match(lines, /a\.mjs.*\byes$/m);
+  assert.match(lines, /b\.mjs.*\bno$/m);
+  assert.match(lines, /c\.mjs.*\bno$/m);
+});
+
+test('perToolLines counts all four quadrants and they sum to the tool count', () => {
+  const lines = perToolLines(CROSS, new Set(['a.mjs', 'c.mjs']));
+  const read = (label) => Number(lines.find((l) => l.includes(label)).match(/(\d+)$/)[1]);
+  assert.equal(read('gate,  asserted'), 1); // a: wired, 100%
+  assert.equal(read('gate,  unasserted'), 1); // c: wired, 0%
+  assert.equal(read('inert, asserted'), 0);
+  assert.equal(read('inert, unasserted'), 1); // b: inert, 25%
+  const total =
+    read('gate,  asserted') +
+    read('gate,  unasserted') +
+    read('inert, asserted') +
+    read('inert, unasserted');
+  assert.equal(total, 3, 'every tool lands in exactly one quadrant');
+});
+
+test('perToolLines places a tool at exactly the 50% boundary on the asserted side', () => {
+  const half = { caught: ['h.mjs:1 ${a}'], survivors: ['h.mjs:2 ${b}'] };
+  const lines = perToolLines(half, new Set()).join('\n');
+  assert.match(lines, /h\.mjs\s+1\/2\s+50%/);
+  assert.match(lines, /inert, asserted {4}1/);
+});
+
+test('perToolLines sorts by rate so the worst-asserted tools are last', () => {
+  const rows = perToolLines(CROSS, new Set())
+    .filter((l) => /\.mjs/.test(l))
+    .map((l) => l.trim().split(/\s+/)[0]);
+  assert.deepEqual(rows, ['a.mjs', 'b.mjs', 'c.mjs']);
+});
+
+test('wiredTools discriminates: it must not return every tool in the directory', () => {
+  const wired = wiredTools();
+  assert.ok(wired.size > 0, 'at least one tool is invoked by a workflow');
+  const all = toolsWithTests('tools');
+  const unwired = all.filter((t) => !wired.has(t));
+  // A detector that reports everything as wired would make the cross vacuous and the
+  // off-diagonal empty by construction rather than by measurement.
+  assert.ok(unwired.length > 0, `expected some unwired tools; got ${JSON.stringify(all)}`);
+});
+
+test('wiredTools resolves a tool reached indirectly through an npm script', () => {
+  const fake = {
+    readFileSync: (p) =>
+      String(p).endsWith('package.json')
+        ? JSON.stringify({ scripts: { 'x:check': 'node tools/check-x.mjs --strict' } })
+        : 'jobs:\n  a:\n    steps:\n      - run: npm run x:check\n',
+    readdirSync: () => ['ci.yml'],
+  };
+  const wired = wiredTools(fake);
+  assert.ok(wired.has('check-x.mjs'), [...wired].join(','));
+});
+
+test('wiredTools does not mark a script that no workflow invokes', () => {
+  const fake = {
+    readFileSync: (p) =>
+      String(p).endsWith('package.json')
+        ? JSON.stringify({ scripts: { 'y:check': 'node tools/check-y.mjs' } })
+        : 'jobs:\n  a:\n    steps:\n      - run: npm test\n',
+    readdirSync: () => ['ci.yml'],
+  };
+  assert.equal(wiredTools(fake).has('check-y.mjs'), false);
+});
 
 test('reportSites finds interpolations in console calls', () => {
   const src = ['console.log(`count ${n}`);'].join('\n');

--- a/tools/verify-required-checks.mjs
+++ b/tools/verify-required-checks.mjs
@@ -188,6 +188,100 @@ async function fetchCheckRuns({ repo, sha, token }) {
 
 const sleep = (seconds) => new Promise((done) => setTimeout(done, seconds * 1000));
 
+/*
+ * Report builders.
+ *
+ * These were inline template literals inside `run()`. A sentinel mutation sweep (issue #4303)
+ * found 0 of this tool's 35 interpolation sites asserted by any test -- not because the tests
+ * were weak, but because `run()` is an async polling loop that reaches the network, so no test
+ * could call the code that produces the sentences. Extraction is the precondition for assertion;
+ * it does not by itself supply one, so each builder below has a test that reads its values.
+ *
+ * These sentences are the durable record of why a deploy was permitted or refused. An unasserted
+ * deploy-gate report can degrade to naming the wrong SHA, the wrong check, or the wrong
+ * conclusion while the gate still exits with the correct status.
+ */
+
+/**
+ * Build the three startup lines describing what the gate is about to wait for.
+ *
+ * @param {{checkName: string, repo: string, sha: string, allowed: string[],
+ *   timeoutSeconds: number, intervalSeconds: number}} config Resolved configuration.
+ * @returns {string[]} Startup lines.
+ */
+export function startupLines(config) {
+  return [
+    `Verifying required check "${config.checkName}" on ${config.repo}@${config.sha.slice(0, 12)}`,
+    `Allowed conclusions: ${config.allowed.join(', ')}`,
+    `Wait budget: ${config.timeoutSeconds}s, poll interval: ${config.intervalSeconds}s`,
+  ];
+}
+
+/**
+ * Build the terminal line for a completed gatekeeper run.
+ *
+ * @param {'pass' | 'fail'} decision Classification from `classifyGatekeeper`.
+ * @param {{checkName: string, conclusion: string | null, sha: string}} context Reporting context.
+ * @returns {string} The pass or fail sentence.
+ */
+export function decisionLine(decision, context) {
+  if (decision === 'pass') {
+    return `✅ "${context.checkName}" completed with conclusion "${context.conclusion}" — gate passed.`;
+  }
+  return (
+    `❌ "${context.checkName}" completed with disallowed conclusion "${context.conclusion}" — ` +
+    `refusing to deploy ${context.sha.slice(0, 12)}.`
+  );
+}
+
+/**
+ * Build the line printed on each poll while the gate is still undecided.
+ *
+ * @param {{decision: string, checkName: string, status: string | null,
+ *   conclusion: string | null, total: number, intervalSeconds: number,
+ *   remainingSeconds: number}} state Poll state.
+ * @returns {string} The waiting sentence.
+ */
+export function waitingLine(state) {
+  const tail = `Retrying in ${state.intervalSeconds}s (${state.remainingSeconds}s left).`;
+  if (state.decision === 'missing') {
+    return (
+      `⏳ "${state.checkName}" check-run not created yet (it is produced after the ` +
+      `security/CodeQL jobs). ${state.total} check-run(s) on SHA so far. ${tail}`
+    );
+  }
+  const conclusion = state.conclusion ? ` (${state.conclusion})` : '';
+  return `⏳ "${state.checkName}" is ${state.status}${conclusion} — waiting for completion. ${tail}`;
+}
+
+/**
+ * Build the fail-closed line printed when the wait budget is exhausted.
+ *
+ * The three branches are distinguished because they call for different actions: a gatekeeper that
+ * never appeared alongside other checks points at the producing workflow, no check-runs at all
+ * points at CI not running, and a found-but-incomplete gatekeeper points at a stuck job.
+ *
+ * @param {{everSawGatekeeper: boolean, sawAnyCheckRuns: boolean, checkName: string,
+ *   sha: string, timeoutSeconds: number}} state Terminal state.
+ * @returns {string} The timeout sentence.
+ */
+export function timeoutLine(state) {
+  const prefix = `❌ Timed out after ${state.timeoutSeconds}s: "${state.checkName}"`;
+  const shaShort = state.sha.slice(0, 12);
+  if (state.everSawGatekeeper) {
+    return (
+      `${prefix} was found but never completed on ${shaShort}. ` +
+      'Refusing to deploy an ungated commit.'
+    );
+  }
+  return (
+    `${prefix} check-run was never found on ${shaShort}. ` +
+    (state.sawAnyCheckRuns
+      ? 'Other checks ran but the required gatekeeper did not — did ci-security.yml execute for this commit?'
+      : 'No check-runs were found at all — CI may not have run for this commit.')
+  );
+}
+
 async function run() {
   const opts = parseArgs(process.argv.slice(2));
   if (opts.help) {
@@ -200,11 +294,8 @@ async function run() {
 
   const config = resolveConfig(opts);
   const deadline = Date.now() + config.timeoutSeconds * 1000;
-  const shaShort = config.sha.slice(0, 12);
 
-  console.log(`Verifying required check "${config.checkName}" on ${config.repo}@${shaShort}`);
-  console.log(`Allowed conclusions: ${config.allowed.join(', ')}`);
-  console.log(`Wait budget: ${config.timeoutSeconds}s, poll interval: ${config.intervalSeconds}s`);
+  for (const line of startupLines(config)) console.log(line);
 
   let everSawGatekeeper = false;
   let sawAnyCheckRuns = false;
@@ -227,15 +318,11 @@ async function run() {
     const { decision, conclusion } = classifyGatekeeper(gatekeeper, config.allowed);
 
     if (decision === 'pass') {
-      console.log(
-        `✅ "${config.checkName}" completed with conclusion "${conclusion}" — gate passed.`,
-      );
+      console.log(decisionLine('pass', { ...config, conclusion }));
       return 0;
     }
     if (decision === 'fail') {
-      console.error(
-        `❌ "${config.checkName}" completed with disallowed conclusion "${conclusion}" — refusing to deploy ${shaShort}.`,
-      );
+      console.error(decisionLine('fail', { ...config, conclusion }));
       return 1;
     }
 
@@ -244,35 +331,22 @@ async function run() {
     }
 
     const remaining = Math.round((deadline - Date.now()) / 1000);
-    if (decision === 'missing') {
-      const total = allRuns.length;
-      console.log(
-        `⏳ "${config.checkName}" check-run not created yet (it is produced after the security/CodeQL jobs). ` +
-          `${total} check-run(s) on SHA so far. Retrying in ${config.intervalSeconds}s (${remaining}s left).`,
-      );
-    } else {
-      console.log(
-        `⏳ "${config.checkName}" is ${gatekeeper.status}${conclusion ? ` (${conclusion})` : ''} — waiting for completion. ` +
-          `Retrying in ${config.intervalSeconds}s (${remaining}s left).`,
-      );
-    }
+    console.log(
+      waitingLine({
+        decision,
+        checkName: config.checkName,
+        status: gatekeeper?.status ?? null,
+        conclusion,
+        total: allRuns.length,
+        intervalSeconds: config.intervalSeconds,
+        remainingSeconds: remaining,
+      }),
+    );
     await sleep(config.intervalSeconds);
   }
 
   // Fail closed: never promote a SHA whose required gate did not demonstrably pass.
-  if (!everSawGatekeeper) {
-    console.error(
-      `❌ Timed out after ${config.timeoutSeconds}s: "${config.checkName}" check-run was never found on ${shaShort}. ` +
-        (sawAnyCheckRuns
-          ? 'Other checks ran but the required gatekeeper did not — did ci-security.yml execute for this commit?'
-          : 'No check-runs were found at all — CI may not have run for this commit.'),
-    );
-  } else {
-    console.error(
-      `❌ Timed out after ${config.timeoutSeconds}s: "${config.checkName}" was found but never completed on ${shaShort}. ` +
-        'Refusing to deploy an ungated commit.',
-    );
-  }
+  console.error(timeoutLine({ ...config, everSawGatekeeper, sawAnyCheckRuns }));
   return 1;
 }
 

--- a/tools/verify-required-checks.test.mjs
+++ b/tools/verify-required-checks.test.mjs
@@ -6,7 +6,138 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
-import { classifyGatekeeper, selectLatestCheckRun } from './verify-required-checks.mjs';
+import {
+  classifyGatekeeper,
+  decisionLine,
+  selectLatestCheckRun,
+  startupLines,
+  timeoutLine,
+  waitingLine,
+} from './verify-required-checks.mjs';
+
+// Report-line tests (#4303).
+//
+// A sentinel mutation sweep found 0 of this tool's 35 interpolation sites asserted. The cause was
+// structural: every sentence was inline in an async polling loop that reaches the network, so no
+// test could reach them. The tests below read the interpolated *values*, not just a static label
+// -- an assertion that only checks the emoji or the word "Timed out" survives any mutation of the
+// SHA, check name, or conclusion, which are the three things a deploy-gate report exists to state.
+
+const CONFIG = {
+  checkName: 'Required Checks Gatekeeper',
+  repo: 'jrmoulckers/finance',
+  sha: '3cac6b52aaaabbbbccccddddeeeeffff00001111',
+  allowed: ['success', 'skipped'],
+  timeoutSeconds: 1800,
+  intervalSeconds: 20,
+};
+
+test('startupLines names the check, repo, short SHA, allowed conclusions and both budgets', () => {
+  const lines = startupLines(CONFIG);
+  assert.equal(lines.length, 3);
+  assert.match(lines[0], /"Required Checks Gatekeeper"/);
+  assert.match(lines[0], /jrmoulckers\/finance@3cac6b52aaaa$/);
+  assert.equal(lines[1], 'Allowed conclusions: success, skipped');
+  assert.equal(lines[2], 'Wait budget: 1800s, poll interval: 20s');
+});
+
+test('startupLines truncates the SHA to 12 characters, not the full 40', () => {
+  const [first] = startupLines(CONFIG);
+  assert.ok(first.includes('3cac6b52aaaa'), first);
+  assert.ok(!first.includes(CONFIG.sha), 'full SHA must not be printed');
+});
+
+test('decisionLine reports the conclusion that caused a pass', () => {
+  const line = decisionLine('pass', { ...CONFIG, conclusion: 'skipped' });
+  assert.match(line, /^✅/);
+  assert.match(line, /conclusion "skipped"/);
+  assert.match(line, /gate passed\.$/);
+});
+
+test('decisionLine names the disallowed conclusion and the SHA it refuses', () => {
+  const line = decisionLine('fail', { ...CONFIG, conclusion: 'failure' });
+  assert.match(line, /^❌/);
+  assert.match(line, /disallowed conclusion "failure"/);
+  assert.match(line, /refusing to deploy 3cac6b52aaaa\.$/);
+});
+
+test('waitingLine for a missing gatekeeper reports the check-run count seen so far', () => {
+  const line = waitingLine({
+    decision: 'missing',
+    checkName: CONFIG.checkName,
+    status: null,
+    conclusion: null,
+    total: 7,
+    intervalSeconds: 20,
+    remainingSeconds: 940,
+  });
+  assert.match(line, /not created yet/);
+  assert.match(line, /\b7 check-run\(s\) on SHA so far/);
+  assert.match(line, /Retrying in 20s \(940s left\)\.$/);
+});
+
+test('waitingLine for a pending gatekeeper reports its status and omits a null conclusion', () => {
+  const line = waitingLine({
+    decision: 'pending',
+    checkName: CONFIG.checkName,
+    status: 'in_progress',
+    conclusion: null,
+    total: 7,
+    intervalSeconds: 20,
+    remainingSeconds: 940,
+  });
+  assert.match(line, /is in_progress — waiting for completion/);
+  assert.ok(!line.includes('()'), 'a null conclusion must not render empty parentheses');
+});
+
+test('waitingLine renders a non-null conclusion in parentheses after the status', () => {
+  const line = waitingLine({
+    decision: 'pending',
+    checkName: CONFIG.checkName,
+    status: 'completed',
+    conclusion: 'neutral',
+    total: 7,
+    intervalSeconds: 20,
+    remainingSeconds: 940,
+  });
+  assert.match(line, /is completed \(neutral\) — waiting/);
+});
+
+test('timeoutLine distinguishes never-found-with-other-checks from no-checks-at-all', () => {
+  const withOthers = timeoutLine({
+    ...CONFIG,
+    everSawGatekeeper: false,
+    sawAnyCheckRuns: true,
+  });
+  const withNone = timeoutLine({
+    ...CONFIG,
+    everSawGatekeeper: false,
+    sawAnyCheckRuns: false,
+  });
+  assert.match(withOthers, /did ci-security\.yml execute/);
+  assert.match(withNone, /No check-runs were found at all/);
+  assert.notEqual(withOthers, withNone);
+  for (const line of [withOthers, withNone]) {
+    assert.match(line, /Timed out after 1800s/);
+    assert.match(line, /never found on 3cac6b52aaaa/);
+  }
+});
+
+test('timeoutLine reports found-but-incomplete separately from never-found', () => {
+  const line = timeoutLine({ ...CONFIG, everSawGatekeeper: true, sawAnyCheckRuns: true });
+  assert.match(line, /was found but never completed on 3cac6b52aaaa/);
+  assert.match(line, /Refusing to deploy an ungated commit\.$/);
+  assert.ok(!line.includes('never found'), 'must not claim the gatekeeper was never found');
+});
+
+test('every terminal line is a refusal, so none may be mistaken for a pass', () => {
+  const lines = [
+    decisionLine('fail', { ...CONFIG, conclusion: 'failure' }),
+    timeoutLine({ ...CONFIG, everSawGatekeeper: true, sawAnyCheckRuns: true }),
+    timeoutLine({ ...CONFIG, everSawGatekeeper: false, sawAnyCheckRuns: false }),
+  ];
+  for (const line of lines) assert.match(line, /^❌/, line);
+});
 
 test('selectLatestCheckRun picks the newest matching run by started_at', () => {
   const runs = [


### PR DESCRIPTION
## Summary

A sentinel mutation sweep over the 15 tools in `tools/` with a colocated test file — replace each
interpolated value in a report line with a sentinel, re-run that tool's tests, record whether
anything fails — scored **103 of 305 sites asserted**. Crossing that against whether a workflow
invokes the tool populates **all four quadrants**:

| | asserted (>=50%) | unasserted (<50%) |
| --- | --- | --- |
| **runs in CI** | `check-doc-links` 100%, `check-test-independence` 71%, `check-gate-enforcement` 64%, `check-assertion-bounds` 50% | `check-workflow-security` 35%, `run-tool-tests` 33%, `check-tool-imports` 25%, `check-node-version-consistency` 18%, `check-gradle-prefetch` 18%, `check-upstream-refs` 14%, **`verify-required-checks` 0%**, **`check-citation-enumerations` 0%** |
| **inert** | `citations-context` 100%, `check-report-assertions` 81% | `check-workflow-pin-history` 9% |

The two best-asserted tools are unwired; two required gates score zero. finance has used "inert" as
a single word for both properties, and `gate:enforcement` measures only the first — so a tool could
be fixed on the watched axis and stay broken on the unwatched one.

## Defect 1 — the measuring tool withheld the data that shows this

`check-report-assertions.mjs` printed an aggregate plus a flat survivor list, and **not** the caught
list, so its own output could not be decomposed per tool; the table above required a bespoke probe
against the exported `measure()`. The aggregate 34% is equally compatible with every tool sitting
near 34% and with the real distribution, which is bimodal with two zeroes in it.

Fixed by adding `wiredTools()` and `perToolLines()`, so the cross is a property of the output.

## Defect 2 — both zeroes were structural, not lax assertions

`verify-required-checks.mjs` exported two predicates and built all 35 sentences inline in an async
polling loop that reaches the GitHub API. `check-citation-enumerations.mjs` wrote its report
straight to `process.stdout` from a function that walks the real tree. Neither had a weak test —
neither had a **callable surface to assert**. Extracted `startupLines`/`decisionLine`/`waitingLine`/
`timeoutLine` and `violationLines`/`cleanLine` respectively, then asserted the interpolated values.

## Result, measured after the change

```
interpolation sites 314   asserted 139 (44%, was 103/305 = 34%)
check-citation-enumerations.mjs   0%  ->  92%
verify-required-checks.mjs        0%  ->  55%
gate,asserted 6   gate,unasserted 6   inert,asserted 2   inert,unasserted 1
```

**Caveat on those two figures:** the denominators moved as well as the numerators —
`verify-required-checks` went 0/35 to 17/31 because extraction merged the two timeout branches into
one builder. It is not a clean 0→17 over a fixed population, and the off-diagonal remaining
populated (2 inert-asserted, 6 gate-unasserted) is the part that shows independence is measured
rather than an artifact of these two fixes.

## Changes

- `tools/check-report-assertions.mjs` — `wiredTools()`, `perToolLines()`; main prints the cross.
- `tools/verify-required-checks.mjs` — 4 report builders extracted and exported; `run()` calls them.
- `tools/check-citation-enumerations.mjs` — 2 report builders extracted and exported.
- 3 test files, **+26 tests (563 → 589)**, each reading interpolated values rather than static labels.
- `docs/guides/engineering-practice-adoption.md` — new section.

## Issues

Closes #4303

## Testing

- [x] `npm run format:check`, `npx eslint . --max-warnings 0`, `npm run type-check` — clean
- [x] `run-tool-tests.mjs` — **589/589**
- [x] All 15 gate scripts exit 0 (run after `git add`)
- [x] `citations:enumerations:check` real output byte-identical to before extraction