### PR TITLE
fix(tools): enumerate every environment input --help claims to describe (#4306)

### DIFF
--- a/tools/check-ai-manifest.js
+++ b/tools/check-ai-manifest.js
@@ -93,6 +93,14 @@ const MANAGED_COUNTS = {
 // test pins the two counts and says nothing about the capability list. Measured before the fix:
 // 7 advertised phrases, 7 validators wired into the report, 3 of them unadvertised.
 //
+// And THAT reasoning covered the Validates list and not the Usage block three lines above it, in
+// the same template literal. The tool read two environment variables and advertised one:
+// GITHUB_STEP_SUMMARY, which decides whether a run publishes a summary at all, appeared nowhere.
+// Reachability was never the protective property -- `--help` is executed by a test, exits 0, and
+// is read daily. Exhaustiveness over the WHOLE claim is, and each guard here was exhaustive over
+// a proper part of the text. A neighbouring rigorous check is the strongest available disguise
+// for an unchecked claim: the diligence is visible, its scope is not (#4306, .github#936).
+//
 // So the list is DERIVED from the same registry `main` dispatches over. The advertisement and
 // the behaviour are now one object: a validator with no row is reported, a row with no validator
 // is reported, and neither can be added silently (#4278).
@@ -114,6 +122,10 @@ const VALIDATORS = [
   { id: 'enforcementDoc', label: 'the CI drift-enforcement mode against the prose describing it' },
   { id: 'triggerCoverage', label: "this check's own trigger coverage" },
   { id: 'citations', label: 'cross-repo citation of another repository by line number' },
+  {
+    id: 'envInputs',
+    label: "this tool's environment inputs against the ones --help advertises",
+  },
 ];
 
 /**
@@ -171,7 +183,92 @@ function activationRunners(context) {
     enforcementDoc: () => validateEnforcementDoc(),
     triggerCoverage: () => validateTriggerCoverage(),
     citations: () => context.citations.findings,
+    envInputs: () => validateEnvInputs(),
   };
+}
+
+/**
+ * Environment variables this entry point reads, as a named registry with the purpose of each.
+ *
+ * Declared here and rendered into `--help` below, then checked in both directions against an
+ * INDEPENDENT enumeration derived by walking the import closure (`reachableEnvVars`). A variable
+ * the tool reads but does not declare is reported; a variable it declares but never reads is
+ * reported. Neither can be added silently (#4306).
+ *
+ * @type {{name: string, purpose: string}[]}
+ */
+const ENV_INPUTS = [
+  { name: 'STRICT', purpose: 'set to 1 to make drift blocking, as --strict does' },
+  { name: 'GITHUB_STEP_SUMMARY', purpose: 'when set, the run appends its report to that file' },
+];
+
+/**
+ * Environment variables reachable from an entry point, derived by walking its require closure.
+ *
+ * The population property is *reachable from this entry point*, not *present in the repository*.
+ * Widening it would be a second defect wearing the fix's clothes: 20 sibling tools under `tools/`
+ * read 30+ variables this file cannot reach, including `SUPABASE_DB_PASSWORD` and `GITHUB_TOKEN`,
+ * and a rule built on the wider population would demand this help text advertise them.
+ *
+ * Takes the entry path so a test can point it at a constructed tree rather than asserting a
+ * premise about this one. A dynamic `process.env[name]` read is out of reach of this scan and is
+ * therefore out of reach of the rule.
+ *
+ * @param {string} entryFile Absolute path to the entry module.
+ * @returns {string[]} Sorted variable names read anywhere in the closure.
+ */
+function reachableEnvVars(entryFile) {
+  const seen = new Set();
+  const names = new Set();
+  const stack = [path.resolve(entryFile)];
+  while (stack.length > 0) {
+    const file = stack.pop();
+    if (seen.has(file)) continue;
+    seen.add(file);
+    let source;
+    try {
+      source = fs.readFileSync(file, 'utf8');
+    } catch {
+      continue;
+    }
+    for (const match of source.matchAll(/process\.env\.([A-Z0-9_]+)/g)) names.add(match[1]);
+    for (const match of source.matchAll(/require\(\s*['"](\.[^'"]+)['"]\s*\)/g)) {
+      let resolved = path.resolve(path.dirname(file), match[1]);
+      if (!fs.existsSync(resolved)) {
+        for (const extension of ['.js', '.mjs', '.cjs', '.json']) {
+          if (fs.existsSync(resolved + extension)) {
+            resolved += extension;
+            break;
+          }
+        }
+      }
+      if (fs.existsSync(resolved) && fs.statSync(resolved).isFile()) stack.push(resolved);
+    }
+  }
+  return [...names].sort();
+}
+
+/**
+ * Report any disagreement between the declared environment inputs and the ones actually read.
+ *
+ * @param {string[]} [declared] Names advertised by `--help`.
+ * @param {string[]} [reached] Names derived from the import closure.
+ * @returns {string[]} Findings, one per undocumented or unread variable.
+ */
+function validateEnvInputs(
+  declared = ENV_INPUTS.map((input) => input.name),
+  reached = reachableEnvVars(__filename),
+) {
+  const findings = [];
+  for (const name of reached) {
+    if (!declared.includes(name))
+      findings.push(`environment variable read but --help never mentions it: ${name}`);
+  }
+  for (const name of declared) {
+    if (!reached.includes(name))
+      findings.push(`environment variable advertised by --help but never read: ${name}`);
+  }
+  return findings;
 }
 
 const HELP_TEXT = `
@@ -181,6 +278,9 @@ Usage:
   node tools/check-ai-manifest.js            # warn-only (exit 0)
   node tools/check-ai-manifest.js --strict   # blocking (exit 1 on drift)
   STRICT=1 node tools/check-ai-manifest.js   # blocking (exit 1 on drift)
+
+Environment:
+${ENV_INPUTS.map((input) => `  ${input.name.padEnd(20)} ${input.purpose}`).join('\n')}
 
 Validates:
 ${VALIDATORS.map((validator) => `  - ${validator.label}`).join('\n')}
@@ -1769,6 +1869,9 @@ if (require.main === module) {
 
 module.exports = {
   toLF,
+  ENV_INPUTS,
+  reachableEnvVars,
+  validateEnvInputs,
   PROVENANCE_LINE,
   PROVENANCE_HINT,
   DOC_FILES,

--- a/tools/check-ai-manifest.test.mjs
+++ b/tools/check-ai-manifest.test.mjs
@@ -10,6 +10,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
 import crypto from 'node:crypto';
+import os from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { createRequire } from 'node:module';
 import { execFileSync } from 'node:child_process';
@@ -17,6 +18,8 @@ import { execFileSync } from 'node:child_process';
 const require = createRequire(import.meta.url);
 const {
   toLF,
+  reachableEnvVars,
+  validateEnvInputs,
   PROVENANCE_LINE,
   managedRegion,
   managedDigest,
@@ -1483,6 +1486,77 @@ test('the printed help lists every validator, not a sentence about some of them 
   }
   assert.match(out, /23-agent/);
   assert.match(out, /81-entry/);
+});
+
+test('the printed help enumerates every environment input the tool reads (#4306)', () => {
+  // The three guards on this template literal all covered the Validates list. The Usage block
+  // three lines above it enumerated invocation modes and was covered by none of them, so
+  // GITHUB_STEP_SUMMARY -- which decides whether a run publishes a summary at all -- was read and
+  // never advertised. Asserted by EXECUTION against the derived set, not over the constant.
+  const out = execFileSync(process.execPath, [TOOL, '--help'], { encoding: 'utf8' });
+  const reached = reachableEnvVars(TOOL);
+  // unsourced-bound: no artifact commits to how many variables this entry point reads; 1 says
+  // only that a scan returning nothing cannot certify an enumeration.
+  assert.ok(reached.length > 1, 'PREMISE: the closure scan found variables to advertise');
+  for (const name of reached) {
+    assert.ok(out.includes(name), `--help omits an environment variable the tool reads: ${name}`);
+  }
+  assert.match(out, /^Environment:$/m, 'the enumeration needs a heading a reader can find');
+});
+
+test('the environment enumeration is checked in both directions, by construction (#4306)', () => {
+  // Both controls construct the violating state rather than asserting the healthy tree lacks it.
+  // The reverse direction needs this MORE: a healthy tree contains no advertised-but-unread
+  // variable, so that half has nothing keeping it honest and can be weakened to a no-op with
+  // nothing changing colour. Neither control re-implements the comparison it controls -- each
+  // passes a population to the production predicate and reads the production finding (.github#941).
+  assert.deepEqual(
+    validateEnvInputs(),
+    [],
+    'this tree is consistent, so the controls mean something',
+  );
+
+  const undocumented = validateEnvInputs(['STRICT'], ['STRICT', 'GITHUB_STEP_SUMMARY']);
+  assert.equal(undocumented.length, 1, 'a variable read but not advertised must be reported');
+  assert.match(undocumented[0], /read but --help never mentions it: GITHUB_STEP_SUMMARY/);
+
+  const unread = validateEnvInputs(['STRICT', 'CI'], ['STRICT']);
+  assert.equal(unread.length, 1, 'a variable advertised but never read must be reported');
+  assert.match(unread[0], /advertised by --help but never read: CI/);
+});
+
+test('the environment population is derived from reachability, not from the repository (#4306)', () => {
+  // NEGATIVE CONTROL on the derivation, not on the list. 20 sibling tools under tools/ read 30+
+  // variables this entry point cannot reach, including SUPABASE_DB_PASSWORD and GITHUB_TOKEN.
+  // Widening the population to "present in the repository" would demand this help text advertise
+  // them -- a second defect wearing the fix's clothes. Pinned so a widened walk fails here.
+  const reached = reachableEnvVars(TOOL);
+  for (const unreachable of ['SUPABASE_DB_PASSWORD', 'GITHUB_TOKEN', 'JAVA_HOME', 'NO_COLOR']) {
+    assert.ok(
+      !reached.includes(unreachable),
+      `the closure must not reach a sibling tool's variable: ${unreachable}`,
+    );
+  }
+
+  // The walk itself, proved on a constructed tree rather than on a premise about this one: it
+  // must follow a require edge, and collect from the file it lands on.
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'envscan-'));
+  try {
+    fs.writeFileSync(path.join(dir, 'leaf.js'), 'process.env.DEEP_ONLY;\n');
+    fs.writeFileSync(path.join(dir, 'root.js'), "require('./leaf');\nprocess.env.ROOT_ONLY;\n");
+    assert.deepEqual(
+      reachableEnvVars(path.join(dir, 'root.js')),
+      ['DEEP_ONLY', 'ROOT_ONLY'],
+      'the scan must cross a require edge, not stop at the entry file',
+    );
+    assert.deepEqual(
+      reachableEnvVars(path.join(dir, 'leaf.js')),
+      ['DEEP_ONLY'],
+      'and must not reach a file that only requires IT',
+    );
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
 });
 test('the registry is checked against the dispatch, not against itself (#4278)', () => {
   // DISCLOSURE: every test above builds its expectation FROM `VALIDATORS`, so deleting a row


### PR DESCRIPTION
`--help` enumerated the tool's invocation modes and its validators. It read two environment
variables and advertised one.

| variable | site | advertised before |
| --- | --- | --- |
| `STRICT` | `check-ai-manifest.js:11` | yes |
| `GITHUB_STEP_SUMMARY` | `check-ai-manifest.js:1731` | **no** |

`GITHUB_STEP_SUMMARY` decides whether a run publishes a job summary at all.

## Why it survived three guards

`HELP_TEXT` is not unguarded. It carries three named, rigorous checks: the `23-agent` /
`81-entry` claims are derived rather than transcribed; `deepEqual(advertised, wired)` pins every
dispatched validator to a `--help` row **and back**; and the printed output is asserted equal to
the constant.

All three cover the *Validates* list. None covered the *Usage* block three lines above it **in
the same template literal**.

The comment above `VALIDATORS` already said, of the previous iteration of this same defect:
*"That reasoning covered the NUMBERS inside the sentence and not the sentence."* It then failed to
generalise to the neighbouring enumeration. Third iteration of one shape in one string.

Reachability was never the protective property — `--help` is executed by a test, exits 0, and is
read daily. **Exhaustiveness over the whole claim is the protective property**, and each guard was
exhaustive over a proper part of the text. A neighbouring rigorous check is the strongest
available disguise for an unchecked claim: the diligence is visible, its scope is not.

Reported as the inverse instance of `jrmoulckers/.github#936`; the framing is theirs.

## Population — derived, and deliberately not widened

Measured import closure of the entry point: **2 files, 2 variables**.

Widening to "every env var under `tools/`" would be a second defect wearing the fix's clothes.
20 sibling tools read 30+ variables this entry point cannot reach — including
`SUPABASE_DB_PASSWORD`, `GITHUB_TOKEN` and `GH_TOKEN` — and the wider rule would demand this help
text advertise credential names. The negative control pins the **derivation**, not the list, so it
fails if the closure ever grows to reach one of those entry points.

Known limitation, stated rather than papered over: a dynamic `process.env[name]` read is out of
reach of the scan and therefore out of reach of the rule.

## Verification

Firing control first. Anchors asserted unique. Sources restored and compared against the
in-memory original.

| mutant | result |
| --- | --- |
| A `ENV_INPUTS` drops `GITHUB_STEP_SUMMARY` | KILLED x2 by name |
| B `ENV_INPUTS` advertises an unread variable | KILLED by name |
| C forward predicate no-op'd | KILLED by name |
| D reverse predicate no-op'd | KILLED by name |
| E closure narrowed to the entry file | KILLED by name |
| F validator unwired from the dispatch | KILLED x2 by name |
| G `Environment:` section dropped from help | KILLED by name |

Both controls construct the violating state and read the **production** finding; neither
re-implements the comparison it controls. The reverse direction needs that more: a healthy tree
contains no advertised-but-unread variable, so that half has nothing keeping it honest and can be
weakened to a no-op with nothing changing colour — B and D prove it only because the control
constructs the state.

## Harness upgrade, and a control on the control

Adopted from `.github#941`: a file changing is **not** evidence that the surface under test
changed. Each mutant now declares an **observable** (`--help` output plus the production
validator's findings), captured before and after; a run whose observable did not move is scored
`NOT-REACHED` and **not scored as a survivor**.

That instrument fired zero times in the sweep above, which by the standard applied throughout this
program makes it indistinguishable from a stalled one. So it was validated directly against a
mutation that provably changes the file and provably cannot change the observable:

```
anchor occurrences: 1
file changed: true (byte delta 0)   observable moved: false   suite fail=0
old rule ("assert it applied")          -> SURVIVED     <-- false survivor
new rule ("assert the observable moved") -> NOT-REACHED  <-- refused
```

Note the byte delta: **0**. A character-count "did it apply" check reports this mutation as
*unapplied* and scores it as nothing, in the opposite direction from the false survivor. Comparing
content rather than length is load-bearing.

## Validation

- suite **96 passing, 0 failing** (93 before, measured on this base after rebase)
- `node tools/check-ai-manifest.js` exit 0; report states `Validators: 8 advertised, 8 run`
- `--help` now prints both variables under an `Environment:` heading
- `npx eslint` on both files, `--max-warnings 0`, exit 0; `npx prettier --write` applied
- `.studio-sync.lock.json` untouched; `packages/design-tokens` untouched; no workflow modified

Closes #4306