### PR TITLE
fix(tools): stop leaked test fixtures from latching the suite red (#4308)

### DIFF
--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -9138,6 +9138,67 @@ degrade to naming the wrong SHA or the wrong conclusion while the exit code stay
 
 Cites `ENG-TEST-004`, `ENG-OBS-005`.
 
+## The run that leaks a fixture passes; the next run inherits a red suite and a wrong diagnosis
+
+Three untracked files — `PROBE-4300-text.md`, `PROBE-4300-binary.md`, `PROBE-4300-oversize.md` —
+were found at the repository root. With them present the tool suite is **586/591 with 5 failures**;
+delete them and it is **591/591**. They are fixtures created by `check-ai-manifest.test.mjs`.
+
+The fixtures were created with `{ flag: 'wx' }` (exclusive create) **outside** the `try` whose
+`finally` deletes them. `finally` survives an exception but not process termination, so a run
+killed between the writes and the cleanup leaves them behind — and on the next run the `wx` write
+throws `EEXIST` _before_ control enters `try`, so the cleanup can never run again. Two consecutive
+runs produced byte-identical `93 tests / 88 pass / 5 fail` with the files still present after each.
+**Only a manual delete exits the state.**
+
+Two properties make this worse than an ordinary flake.
+
+**The polarity is inverted.** The run that leaks exits green. Every subsequent run fails. So the
+signal arrives at the party with the least information — someone who pulled, ran the suite, and
+changed nothing — and never reaches the party who caused it.
+
+**The diagnosis names the wrong thing.** The five failures are assertions about citation-ownership
+rules (`the PRODUCTION predicate ... distinguishes owned from received`). Nothing in the output
+mentions a stray file. A reader debugging that output is reading about the tool's semantics while
+the cause is three bytes of filesystem state.
+
+### Making the latch impossible removes a signal, so the signal has to be added back deliberately
+
+The fix gives each fixture a per-process name (`pid` + timestamp), moves the writes inside the
+`try`, and cleans up with `rmSync({ force: true })`. Verified: with all four _old_ fixed names
+planted at the root, `check-ai-manifest.test.mjs` is now **93/93** where it was 88/93.
+
+But that is exactly the point worth recording. A leaked file used to be loud — wrongly attributed,
+but loud. Unique names make it silent: it now sits in the tree affecting nothing. So the same
+change that removes the latch also removes the only thing that ever reported it, and the honest
+response is not to celebrate the green but to add the report that was missing.
+`run-tool-tests.mjs` now runs `leakedArtifacts()` **before and after** the suite: it refuses to
+start on an inherited leak, and it **fails the run that creates one**, naming the files in both
+cases and distinguishing the two, because they call for different actions.
+
+A cleanup that depends on the process reaching a later line is not a cleanup, and `finally` is a
+later line.
+
+## A citation in a failure message is not a binding
+
+`check-assertion-bounds.mjs` requires every numeric bound to name where its number came from, or to
+carry an explicit `unsourced-bound:` marker admitting that nothing does. It enforces that by
+searching the 4 lines above the assertion for the marker — and it **never reads the artifact a
+sourced bound names**. So a bound whose message says `docs claim 18` passes whether the docs say
+18, 99, or nothing at all.
+
+The number is _transcribed_ at authoring time, not _read_ at test time. That is the same defect as
+a test reimplementing the rule it checks, with the artifacts swapped: in both cases the two things
+being compared cannot disagree, so the comparison has no content. And a transcribed number is the
+more dangerous form, because naming a source is what makes a reader — including the author —
+stop checking whether the source is consulted.
+
+The general rule this repository had been applying was _when you don't know the expected value,
+find the artifact that already asserts one_. It needs a second clause: **and re-derive it from that
+artifact at check time**, or the citation is decoration on a hardcoded constant.
+
+Cites `ENG-TEST-002`, `ENG-TEST-004`.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:

--- a/tools/check-ai-manifest.test.mjs
+++ b/tools/check-ai-manifest.test.mjs
@@ -1342,19 +1342,27 @@ test('the gate excludes bytes it cannot read as prose, and only those (#4300)', 
   // first, so the second could never fire. It was removed; this arm now mutation-covers the
   // remaining owner.
   const coordinate = at('sync/lib/copier.mjs', 410);
-  const text = path.join(ROOT, 'PROBE-4300-text.md');
-  const binary = path.join(ROOT, 'PROBE-4300-binary.md');
-  const oversize = path.join(ROOT, 'PROBE-4300-oversize.md');
-  fs.writeFileSync(text, `see ${coordinate}\n`, { flag: 'wx' });
-  fs.writeFileSync(
-    binary,
-    Buffer.concat([Buffer.from(`see ${coordinate}\n`), Buffer.from([0]), Buffer.from('tail\n')]),
-    { flag: 'wx' },
-  );
-  fs.writeFileSync(oversize, `see ${coordinate}\n`.padEnd(MAX_CITATION_BYTES + 1, 'x'), {
-    flag: 'wx',
-  });
+  // Per-process fixture names (#4308). These were fixed names created with `wx` OUTSIDE the try,
+  // so a run killed between the writes and the `finally` left them on disk -- and the next run's
+  // `wx` write threw EEXIST before entering `try`, meaning the cleanup could never run again. The
+  // suite latched red (586/591) until someone deleted the files by hand, and the five failures
+  // named citation-ownership rules rather than the stray files. A unique suffix makes the latch
+  // structurally impossible: a leaked file cannot collide with a later run.
+  const tag = `${process.pid}-${Date.now().toString(36)}`;
+  const text = path.join(ROOT, `PROBE-4300-text-${tag}.md`);
+  const binary = path.join(ROOT, `PROBE-4300-binary-${tag}.md`);
+  const oversize = path.join(ROOT, `PROBE-4300-oversize-${tag}.md`);
+  const named = (file) => path.basename(file).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   try {
+    fs.writeFileSync(text, `see ${coordinate}\n`, { flag: 'wx' });
+    fs.writeFileSync(
+      binary,
+      Buffer.concat([Buffer.from(`see ${coordinate}\n`), Buffer.from([0]), Buffer.from('tail\n')]),
+      { flag: 'wx' },
+    );
+    fs.writeFileSync(oversize, `see ${coordinate}\n`.padEnd(MAX_CITATION_BYTES + 1, 'x'), {
+      flag: 'wx',
+    });
     let out;
     try {
       out = execFileSync(process.execPath, [TOOL], { encoding: 'utf8' });
@@ -1363,15 +1371,14 @@ test('the gate excludes bytes it cannot read as prose, and only those (#4300)', 
     }
     assert.match(
       out,
-      /PROBE-4300-text\.md: cites a file this repository does not own/,
+      new RegExp(`${named(text)}: cites a file this repository does not own`),
       'CONTROL: the same coordinate in readable prose must be reported',
     );
-    assert.ok(!out.includes('PROBE-4300-binary.md'), 'a NUL-bearing blob is not prose');
-    assert.ok(!out.includes('PROBE-4300-oversize.md'), 'a file over the cap is not scanned');
+    assert.ok(!out.includes(path.basename(binary)), 'a NUL-bearing blob is not prose');
+    assert.ok(!out.includes(path.basename(oversize)), 'a file over the cap is not scanned');
   } finally {
-    fs.unlinkSync(text);
-    fs.unlinkSync(binary);
-    fs.unlinkSync(oversize);
+    // force: true so an already-absent file does not mask the real failure with ENOENT.
+    for (const file of [text, binary, oversize]) fs.rmSync(file, { force: true });
   }
 });
 
@@ -1379,11 +1386,12 @@ test('a claimant is scanned for what it contains, not for its extension (#4300)'
   // Behavioural arm. The enumeration above proves the corpus covers git's claimants; this proves
   // the gate itself admits a file type the old allowlist excluded, by driving the whole tool.
   // `.kt` is delivered into this repo by the backbone and was never in CITATION_TEXT.
-  const probe = path.join(ROOT, 'PROBE-4300.kt');
-  fs.writeFileSync(probe, `// engine detail at ${at('sync/lib/copier.mjs', 410)}\n`, {
-    flag: 'wx',
-  });
+  const tag = `${process.pid}-${Date.now().toString(36)}`;
+  const probe = path.join(ROOT, `PROBE-4300-${tag}.kt`);
   try {
+    fs.writeFileSync(probe, `// engine detail at ${at('sync/lib/copier.mjs', 410)}\n`, {
+      flag: 'wx',
+    });
     let out;
     try {
       out = execFileSync(process.execPath, [TOOL], { encoding: 'utf8' });
@@ -1392,11 +1400,11 @@ test('a claimant is scanned for what it contains, not for its extension (#4300)'
     }
     assert.match(
       out,
-      /\[DRIFT\] PROBE-4300\.kt: cites a file this repository does not own/,
+      new RegExp(`\\[DRIFT\\] ${path.basename(probe)}: cites a file this repository does not own`),
       'a claimant with an excluded extension must still reach the report',
     );
   } finally {
-    fs.unlinkSync(probe);
+    fs.rmSync(probe, { force: true });
   }
 });
 
@@ -1770,7 +1778,7 @@ test('the PRODUCTION walk, not a test list, supplies the corpus population (#428
   // lock keys alone and every unit test still passed. So this constructs a corpus file on disk,
   // in a directory the trigger globs do not cover, and asserts the real validator reports it.
   const probeDir = path.join(ROOT, 'docs', 'ops');
-  const probe = path.join(probeDir, 'PROBE-4287.md');
+  const probe = path.join(probeDir, `PROBE-4287-${process.pid}-${Date.now().toString(36)}.md`);
   assert.ok(fs.existsSync(probeDir), 'PREMISE: the probe directory exists');
 
   const before = activationRunners({}).triggerCoverage();
@@ -1779,10 +1787,12 @@ test('the PRODUCTION walk, not a test list, supplies the corpus population (#428
   // `wx` makes creation itself the existence check. Asserting the path is free and then writing
   // it is a genuine TOCTOU race (CodeQL js/file-system-race) — the same finding `citationCorpus`
   // resolved by taking one descriptor — and here it would also silently clobber a real file.
-  fs.writeFileSync(probe, '# probe\n\nA claim about jrmoulckers/.github and copier.mjs.\n', {
-    flag: 'wx',
-  });
+  // The name is per-process (#4308): a fixed `wx` name turns a killed run into a permanent latch,
+  // because the next run's exclusive create throws before its cleanup can be reached.
   try {
+    fs.writeFileSync(probe, '# probe\n\nA claim about jrmoulckers/.github and copier.mjs.\n', {
+      flag: 'wx',
+    });
     const after = activationRunners({}).triggerCoverage();
     const corpusAfter = after.find((f) => f.includes('citation corpus'));
     assert.ok(corpusAfter, 'the corpus population must be reported by the production validator');
@@ -1793,7 +1803,7 @@ test('the PRODUCTION walk, not a test list, supplies the corpus population (#428
     );
     assert.match(corpusAfter, /docs\/ops/);
   } finally {
-    fs.unlinkSync(probe);
+    fs.rmSync(probe, { force: true });
   }
   assert.deepEqual(
     activationRunners({}).triggerCoverage(),

--- a/tools/run-tool-tests.mjs
+++ b/tools/run-tool-tests.mjs
@@ -20,6 +20,64 @@ import path from 'node:path';
 export const TOOLS_DIR = 'tools';
 
 /**
+ * Names a test fixture leaves behind when a run dies before its cleanup.
+ *
+ * Test fixtures are written into the working tree because several tools only observe files git
+ * or a directory walk can see. A run killed between the write and the `finally` leaves them, and
+ * the polarity is the defect: the leaking run exits green while every later run fails (#4308).
+ */
+export const ARTIFACT_PATTERN = /^PROBE-/;
+
+/**
+ * List leaked test artifacts under the repository root and the directories fixtures are written to.
+ *
+ * @param {{readdirSync: Function}} [fsImpl] Injectable fs.
+ * @returns {string[]} Repo-relative paths, sorted.
+ */
+export function leakedArtifacts(fsImpl = fs) {
+  const found = [];
+  for (const dir of ['.', path.join('docs', 'ops')]) {
+    let entries;
+    try {
+      entries = fsImpl.readdirSync(dir);
+    } catch {
+      continue;
+    }
+    for (const name of entries) {
+      if (ARTIFACT_PATTERN.test(name)) found.push(dir === '.' ? name : path.join(dir, name));
+    }
+  }
+  return found.sort();
+}
+
+/**
+ * Build the message for leaked artifacts, distinguishing inherited from self-inflicted.
+ *
+ * A leak inherited from an earlier run and a leak this run created call for different actions, and
+ * reporting them identically is what made the original latch hard to read: five assertions about
+ * citation-ownership rules failed and nothing named the three stray files responsible.
+ *
+ * @param {string[]} files Leaked paths.
+ * @param {'before' | 'after'} phase When they were observed.
+ * @returns {string} Diagnostic message.
+ */
+export function leakLines(files, phase) {
+  const list = files.map((f) => `  ${f}`).join('\n');
+  if (phase === 'before') {
+    return (
+      `stale test artifact(s) present before the suite started:\n${list}\n` +
+      'A previous run was killed before its cleanup. Delete these and re-run; they make\n' +
+      'unrelated assertions fail and are not reported by the run that created them.'
+    );
+  }
+  return (
+    `test artifact(s) left behind by this run:\n${list}\n` +
+    'The run that leaks is the run that must fail -- otherwise the next run inherits a red\n' +
+    'suite and a diagnosis that names the wrong tests.'
+  );
+}
+
+/**
  * List every tool test file.
  *
  * @param {string} [dir] Directory to scan.
@@ -64,8 +122,23 @@ export function reportLines(files) {
 function main() {
   const files = testFiles();
   assertPopulation(files);
+
+  const stale = leakedArtifacts();
+  if (stale.length > 0) {
+    console.error(leakLines(stale, 'before'));
+    process.exitCode = 1;
+    return;
+  }
+
   for (const line of reportLines(files)) console.log(line);
   const result = spawnSync(process.execPath, ['--test', ...files], { stdio: 'inherit' });
+
+  const leaked = leakedArtifacts();
+  if (leaked.length > 0) {
+    console.error(`\n${leakLines(leaked, 'after')}`);
+    process.exitCode = 1;
+    return;
+  }
   process.exitCode = result.status ?? 1;
 }
 

--- a/tools/run-tool-tests.test.mjs
+++ b/tools/run-tool-tests.test.mjs
@@ -1,7 +1,79 @@
 import assert from 'node:assert/strict';
+import path from 'node:path';
 import test from 'node:test';
 
-import { TOOLS_DIR, assertPopulation, reportLines, testFiles } from './run-tool-tests.mjs';
+import {
+  ARTIFACT_PATTERN,
+  TOOLS_DIR,
+  assertPopulation,
+  leakLines,
+  leakedArtifacts,
+  reportLines,
+  testFiles,
+} from './run-tool-tests.mjs';
+
+// Leaked-fixture detection (#4308).
+//
+// Three PROBE-4300-* files created with `wx` outside their own try block survived a killed run.
+// The next run's exclusive create threw EEXIST before entering `try`, so the cleanup could never
+// run again: the suite latched at 586/591 across two byte-identical runs and only a manual delete
+// exited the state. The five failures named citation-ownership rules, not the stray files.
+
+test('leakedArtifacts finds a stale fixture at the repository root', () => {
+  const fake = { readdirSync: (dir) => (dir === '.' ? ['README.md', 'PROBE-4300-text.md'] : []) };
+  assert.deepEqual(leakedArtifacts(fake), ['PROBE-4300-text.md']);
+});
+
+test('leakedArtifacts scans the nested directory fixtures are also written to', () => {
+  const fake = {
+    readdirSync: (dir) => (dir === '.' ? [] : ['runbook.md', 'PROBE-4287-991-x.md']),
+  };
+  assert.deepEqual(leakedArtifacts(fake), [path.join('docs', 'ops', 'PROBE-4287-991-x.md')]);
+});
+
+test('leakedArtifacts reports nothing on a clean tree', () => {
+  const fake = { readdirSync: () => ['README.md', 'package.json'] };
+  assert.deepEqual(leakedArtifacts(fake), []);
+});
+
+test('leakedArtifacts tolerates a missing directory rather than throwing', () => {
+  const fake = {
+    readdirSync: (dir) => {
+      if (dir !== '.') throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      return ['PROBE-x'];
+    },
+  };
+  assert.deepEqual(leakedArtifacts(fake), ['PROBE-x']);
+});
+
+test('ARTIFACT_PATTERN matches the per-process names fixtures now use', () => {
+  // The fix gives each fixture a pid+timestamp suffix so a leak cannot collide with a later run.
+  // The detector must still recognise those, or the fix would silence the detector.
+  for (const name of ['PROBE-4300-text-12345-lz3k9.md', 'PROBE-4287-991-x.md', 'PROBE-4300.kt']) {
+    assert.ok(ARTIFACT_PATTERN.test(name), name);
+  }
+  for (const name of ['README.md', 'probe.md', 'my-PROBE-1.md']) {
+    assert.ok(!ARTIFACT_PATTERN.test(name), name);
+  }
+});
+
+test('leakLines names every leaked file, since the failing assertions will not', () => {
+  const files = ['PROBE-a.md', 'PROBE-b.md'];
+  for (const phase of ['before', 'after']) {
+    const message = leakLines(files, phase);
+    for (const file of files) assert.ok(message.includes(file), `${phase}: ${file}`);
+  }
+});
+
+test('leakLines distinguishes an inherited leak from one this run created', () => {
+  const before = leakLines(['PROBE-a.md'], 'before');
+  const after = leakLines(['PROBE-a.md'], 'after');
+  assert.notEqual(before, after);
+  assert.match(before, /before the suite started/);
+  assert.match(before, /A previous run was killed/);
+  assert.match(after, /left behind by this run/);
+  assert.match(after, /The run that leaks is the run that must fail/);
+});
 
 test('testFiles selects only test files', () => {
   const fake = { readdirSync: () => ['a.mjs', 'a.test.mjs', 'b.test.mjs'] };


### PR DESCRIPTION
## Summary

Three untracked files — `PROBE-4300-text.md`, `PROBE-4300-binary.md`, `PROBE-4300-oversize.md` —
were sitting at the repository root. With them present the tool suite is **586/591 with 5 failures**;
delete them and it is **591/591**. They are fixtures created by `tools/check-ai-manifest.test.mjs`.

## The leak latches

The fixtures were created with `{ flag: 'wx' }` (exclusive create) **outside** the `try` whose
`finally` deletes them. `finally` survives an exception but not process termination, so a run killed
between the writes and the cleanup leaves them — and the next run's `wx` write throws `EEXIST`
*before* control enters `try`, so the cleanup can never run again.

Verified stable, not intermittent: two consecutive runs produced byte-identical
`93 tests / 88 pass / 5 fail` with the files still present after each. Only a manual delete exits it.

```
Error: EEXIST: file already exists, open '...\PROBE-4300-text.md'
```

## Why this is worse than an ordinary flake

**The polarity is inverted.** The run that leaks exits green; every subsequent run fails. The signal
reaches the party with the least information — someone who pulled and changed nothing — and never
reaches the one who caused it.

**The diagnosis names the wrong thing.** The five failures are assertions about citation-ownership
rules. Nothing in the output mentions a stray file, so a reader debugging it is reading about the
tool's semantics while the cause is filesystem state.

## Fix, and the part that is not just a fix

Per-process fixture names (`pid` + timestamp), writes moved inside the `try`, cleanup via
`rmSync({ force: true })`. **Proven:** with all four *old* fixed names planted at the root,
`check-ai-manifest.test.mjs` is now **93/93** where it was 88/93.

But unique names make a leak *silent* — it used to be loud, wrongly attributed but loud. The same
change that removes the latch removes the only thing that ever reported it. So
`run-tool-tests.mjs` now runs `leakedArtifacts()` **before and after** the suite: it refuses to
start on an inherited leak and **fails the run that creates one**, naming the files and
distinguishing the two cases, because they call for different actions.

```
stale test artifact(s) present before the suite started:
  PROBE-planted.md
A previous run was killed before its cleanup. ...
```

## Scope note

`tools/*.test.mjs` writes into the working tree at **46** sites, cleaning up with `unlinkSync`
(throws when absent) at 11 and `rmSync({force:true})` at 6. This PR converts the 5 `wx` sites —
the ones that latch. The remaining `unlinkSync` sites can leak but cannot latch, and the new
post-flight now catches any of them that do.

## Changes

- `tools/check-ai-manifest.test.mjs` — 3 fixture sites made per-process and try-scoped.
- `tools/run-tool-tests.mjs` — `ARTIFACT_PATTERN`, `leakedArtifacts()`, `leakLines()`, pre/post-flight.
- `tools/run-tool-tests.test.mjs` — **+7 tests (591 → 598)**.
- `docs/guides/engineering-practice-adoption.md` — two sections; the second records a separate
  measured finding, that `bounds:check` requires a bound to *name* a source but never *reads* it,
  so a cited number is transcribed at authoring time rather than re-derived at check time.

## Issues

Closes #4308

## Testing

- [x] `npm run format:check`, `npx eslint . --max-warnings 0`, `npm run type-check` — clean
- [x] `run-tool-tests.mjs` — **598/598**, post-flight clean
- [x] All 15 gate scripts exit 0 (run after `git add`)
- [x] Latch reproduced, then proven impossible with the old names planted
- [x] Pre-flight guard fires and names a planted artifact (exit 1)