### PR TITLE
fix(tools): exercise every route into the citation corpus by name (#4309)

### DIFF
--- a/tools/check-ai-manifest.js
+++ b/tools/check-ai-manifest.js
@@ -784,6 +784,18 @@ function citationFindings(text, citations = CANON_CITATIONS, isLocallyOwned = ()
 // So the population is DERIVED from the same property that makes a file subject to the rule --
 // mentioning the backbone -- rather than written down beside it. A file that starts citing the
 // backbone tomorrow is scanned tomorrow, with nothing to update (#4270).
+//
+// The PATTERN, though, is still hand-written, and the #4270 cross-check filters git's index
+// through it. Both enumerations therefore share it: narrowing this regex shrinks both sides
+// identically and they go on agreeing. The cross-check pins how files were FOUND, not what counts
+// as a CLAIM. Measured: appending `\)` to the last alternative took the corpus from 73 to 8 while
+// staying above the floor, keeping the named .prettierignore control satisfied, and leaving the
+// enumeration test green (#4309, .github#953).
+//
+// The alternatives are not equally load-bearing, and the imbalance is the exposure: the repo
+// mention is the SOLE reason 70 of 73 claimants are scanned, while the five engine-file
+// alternatives are the sole reason for none of them. Each route is therefore exercised by a
+// constructed probe that uses only that route, because a shared enumeration cannot.
 const BACKBONE_CLAIM =
   /(sync\/lib\/|copier\.mjs|provenance\.mjs|basemerge\.mjs|lock\.mjs|jrmoulckers\/\.github)/;
 // The corpus gate is a PROPERTY OF THE FILE, not an extension allowlist. An allowlist is a

--- a/tools/check-ai-manifest.test.mjs
+++ b/tools/check-ai-manifest.test.mjs
@@ -1327,6 +1327,46 @@ test('the scanned population is derived from the surface, not narrowed to a samp
   );
 });
 
+test('every route into the corpus is exercised by a claimant that uses only that route (#4309)', () => {
+  // The #4270 cross-check filters git's index through BACKBONE_CLAIM -- the walk's own pattern --
+  // so narrowing the pattern shrinks both enumerations identically and they go on agreeing. It
+  // pins how files were FOUND and says nothing about what counts as a CLAIM (.github#953).
+  //
+  // Measured: `jrmoulckers\/\.github` -> `jrmoulckers\/\.github\)` took the corpus from 73 to 8,
+  // stayed above the floor, kept the named `.prettierignore` control satisfied, and left the
+  // enumeration test green; the suite only reddened via two #4281 bystanders pinning a printed
+  // number. A single named control pins one mention FORM, so a narrowing can be crafted around it.
+  //
+  // Constructed rather than named: a probe cannot freeze an accident of the current tree the way
+  // a live file can. This one's SOLE admission route is the bare repository mention -- its
+  // coordinate names an engine file that no other alternative matches -- so any narrowing of that
+  // alternative, which is the sole reason 70 of 73 claimants are scanned, fails here by name.
+  const probe = path.join(ROOT, 'PROBE-4309-prose.md');
+  const coordinate = at('sync/index.mjs', 42);
+  const body = `The engine in jrmoulckers/.github moved that logic; see ${coordinate}.\n`;
+  assert.doesNotMatch(
+    body,
+    /sync\/lib\/|copier\.mjs|provenance\.mjs|basemerge\.mjs|lock\.mjs/,
+    'PREMISE: the probe must be admitted by the repository mention alone',
+  );
+  fs.writeFileSync(probe, body, { flag: 'wx' });
+  try {
+    let out;
+    try {
+      out = execFileSync(process.execPath, [TOOL], { encoding: 'utf8' });
+    } catch (error) {
+      out = String(error.stdout || '');
+    }
+    assert.match(
+      out,
+      /PROBE-4309-prose\.md: cites a file this repository does not own/,
+      'a prose-only claimant must still be scanned',
+    );
+  } finally {
+    fs.unlinkSync(probe);
+  }
+});
+
 test('the gate excludes bytes it cannot read as prose, and only those (#4300)', () => {
   // Dropping the binary check changed no result: nothing binary in this tree happens to carry a
   // backbone claim, so that guard was LATENT -- dead by an impoverished corpus, not by an


### PR DESCRIPTION
## The defect

`#4300` derived the citation corpus from file content, replacing a hand-written extension
allowlist. It left the other hand-written half: `BACKBONE_CLAIM`, shared between the production
walk and the `#4270` cross-check that exists to prove the population is not a sample. Both sides
filter on the same regex, so narrowing it shrinks both enumerations identically and they go on
agreeing. The cross-check pins *how files were found*; it says nothing about *what counts as a
claim*. Reported as a general consequence of derive-the-population by `jrmoulckers/.github#953`.

## Measured, not inferred

The alternatives are not equally load-bearing:

| alternative | matches | sole reason for |
| --- | --- | --- |
| `sync/lib/`, `copier.mjs`, `provenance.mjs`, `basemerge.mjs`, `lock.mjs` | 10 | **0** |
| `jrmoulckers/.github` | 73 | **70** |

A narrowing crafted around the existing controls:

```
jrmoulckers\/\.github  ->  jrmoulckers\/\.github\)
corpus 73 -> 8    floor (> 5) satisfied    named .prettierignore control satisfied
#4270 enumeration test: GREEN
```

65 of 73 claimants dropped, and the guard whose whole purpose is to catch that stayed green. The
suite reddened only through two `#4281` bystanders that happen to pin a printed population number
— cover by accident, from tests that are not about this.

## Fix

A constructed probe per admission route, rather than more named live files: a probe cannot freeze
an accident of the current tree the way a named file can. The new claimant's sole route is the
bare repository mention — its coordinate names `sync/index.mjs`, which no other alternative
matches — and a **premise assertion** guards that isolation so it cannot be weakened silently.
The engine-file route was already isolated by the existing `.kt` probe.

Verified reachable before the test was written: the probe is reported as
`[DRIFT] PROBE-4309-prose.md: cites a file this repository does not own by line number`.

## Mutation sweep

| mutant | verdict | killed by |
| --- | --- | --- |
| A crafted partial narrowing (73 -> 8, both controls intact) | KILLED | `every route into the corpus… (#4309)` + 2 |
| B pattern collapsed to one engine alternative | KILLED | `#4270`, `#4309`, `#4281` x2, `#4287` |
| C engine alternatives dropped | KILLED | `#4300` x2, `#4270` |
| D isolation control: probe coordinate moved onto an engine file, then A applied | KILLED | the `#4309` premise guard |

A is the one that matters: it is the exact mutation that previously slipped past the enumeration
test, and it now dies by name. D is the control on the control — it models the silent weakening
that would make the new probe stop isolating anything, and it dies in **1.09 ms**, before the
~12 s tool spawn, which is how the premise guard is identified as the owner rather than the drift
assertion.

## Disclosed instrument error

C first scored **NOT-REACHED** under my observable-moved rule, because the rule captured only the
live tree's output and C's reachability is created by a *test-time* probe. The rule adopted last
PR is therefore incomplete as I stated it: the observable has to include the suite's constructed
states, not only the production run. C is genuinely KILLED; scored honestly it would have read as
an abstention. Re-scored against the suite here, and stating the correction rather than quietly
using the better number.

## Scope

Pattern and test only. `packages/design-tokens`, `vendor/@jrm/tokens` and every workflow file are
untouched.

## Validation

- `node --test tools/check-ai-manifest.test.mjs` — **97 passing, 0 failing** (96 before)
- `node tools/check-ai-manifest.js` — exit 0
- `npx prettier --check` / `npx eslint` on both touched files — exit 0

Closes #4309