### PR TITLE
fix(tools): close three escape hatches on the bounds checker acceptance path (#4312)

### DIFF
--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -9179,23 +9179,73 @@ cases and distinguishing the two, because they call for different actions.
 A cleanup that depends on the process reaching a later line is not a cleanup, and `finally` is a
 later line.
 
-## A citation in a failure message is not a binding
+## A citation in a failure message is not a binding — and the retraction that followed
 
-`check-assertion-bounds.mjs` requires every numeric bound to name where its number came from, or to
-carry an explicit `unsourced-bound:` marker admitting that nothing does. It enforces that by
-searching the 4 lines above the assertion for the marker — and it **never reads the artifact a
-sourced bound names**. So a bound whose message says `docs claim 18` passes whether the docs say
-18, 99, or nothing at all.
+A sibling session retracted a claim that `jrmoulckers/engineering`'s bounded assertions "source
+their expected value from an artifact that already committed to one." They _transcribe_ it:
+mutating the cited doc to claim 99 left the suite at 402/402, exit 0. The general rule stated here
+— _when you don't know the expected value, find the artifact that already asserts one_ — needs a
+second clause: **and re-derive it from that artifact at check time**, or the citation is decoration
+on a hardcoded constant.
 
-The number is _transcribed_ at authoring time, not _read_ at test time. That is the same defect as
-a test reimplementing the rule it checks, with the artifacts swapped: in both cases the two things
-being compared cannot disagree, so the comparison has no content. And a transcribed number is the
-more dangerous form, because naming a source is what makes a reader — including the author —
-stop checking whether the source is consulted.
+**This section previously recorded that the same defect reproduced in
+`tools/check-assertion-bounds.mjs`. That claim was wrong and is withdrawn.** Probed directly rather
+than reasoned about:
 
-The general rule this repository had been applying was _when you don't know the expected value,
-find the artifact that already asserts one_. It needs a second clause: **and re-derive it from that
-artifact at check time**, or the citation is decoration on a hardcoded constant.
+```
+citation-in-message, no marker         bounds=1 flagged=1
+citation in comment above, no marker   bounds=1 flagged=1
+```
+
+Both are flagged. The checker has no "sourced literal" acceptance path at all. Its only non-marker
+acceptance is comparing against an _expression_, which removes the literal and therefore genuinely
+binds. I had read the report's advice — "compare against the artifact that already commits to the
+number" — as describing a category the tool recognises, when it describes the shape that leaves the
+population entirely. The failure was assuming a defect reproduced because the two tools share a
+subject, which is the same mistake as assuming two instruments agree because they share a method.
+
+## A checker's escape hatches are the part nobody tests
+
+Probing the **acceptance** path instead found three real defects, all of which had passed since the
+tool was written:
+
+```
+marker only inside a string literal    annotated=1   <-- data excused a real bound
+marker in the assert message itself    annotated=1
+bare marker, nothing after it          annotated=1   <-- recorded nothing, discharged the duty
+```
+
+1. A bare `unsourced-bound:` was accepted. The file's own docstring says the annotation "forces the
+   author to record which artifact they looked for and failed to find"; an empty one satisfies the
+   grep and records nothing — the rubber stamp the same file warns an over-reporting checker
+   produces.
+2. `comparisons()` strips literals because "a syntactic pattern is not a semantic class."
+   `hasMarker()` did not. So the marker appearing as _fixture data_ annotated any bound within four
+   lines. The tool applied its own stated principle in one direction only.
+3. The recommended fix was never counted. The green line read _"Every bound is annotated or
+   derived"_ and then printed only the annotated count. Derived bounds were asserted to exist and
+   never measured, so the sentence read identically whether every bound derived its constant or
+   none did. Measured: **6 derived against 10 marker-annotated** — the escape hatch is used more
+   often than the fix, and no output said so.
+
+The unifying property is that all three are on the path where the tool says yes. Considerable care
+had gone into who it accuses — stripping literals, exempting existence and sign checks, surfacing
+unparsed forms rather than skipping them, all to avoid a false accusation that would turn the
+annotations into rubber stamps. None of that care was applied to who it excuses, because **a
+passing case emits no output, so nothing about the tree ever looks wrong.** A false accusation is
+visible to the person accused; a false excuse is visible to nobody.
+
+The fix requires the marker to carry a non-empty reason and to survive literal-stripping — both
+existence checks, so it invents no threshold and cannot trip this checker's own rule — and prints
+the derived/annotated/neither split on both the passing and failing paths.
+
+One detail worth keeping. The first measurement of the derived population reported **45**; the real
+count is **6**. The detector's `>` matched the `>` in `=>`, so every `(f) => f.x` read as a
+comparison against an identifier. It was caught by a control asserting the detector must _not_ fire
+on an arrow function, which is the cheapest possible check and was written only because a previous
+instrument in this session had already reported `0 of 24` and `tests=0`. A 7.5x inflated population
+would have been published as a finding otherwise, and unlike those two it was not absurd enough to
+notice on sight.
 
 Cites `ENG-TEST-002`, `ENG-TEST-004`.
 

--- a/tools/check-assertion-bounds.mjs
+++ b/tools/check-assertion-bounds.mjs
@@ -129,15 +129,85 @@ export function isExistence(comparison) {
 }
 
 /**
- * True when the marker appears on the line or close enough above it to be about this bound.
+ * The reason recorded after the marker on one line, or `null` when the line carries no marker.
+ *
+ * Literals are stripped first, for the same reason {@link comparisons} strips them: the marker
+ * inside a string is *data*, not an annotation. Test fixtures in this repository contain the
+ * marker text as sample input, and without this the fixture would silently annotate any real
+ * bound within the lookbehind. The checker stated that principle in one direction -- who it
+ * accuses -- and did not apply it to the other -- who it lets through.
+ *
+ * Lengths are preserved by {@link stripLiterals}, so the index found in the stripped line is the
+ * index in the original, and the reason is read from the original to keep its text intact.
+ *
+ * @param {string} line Source line.
+ * @returns {string|null} The trimmed reason, `''` when the marker is bare, `null` when absent.
+ */
+export function markerReason(line) {
+  const at = stripLiterals(line).indexOf(UNSOURCED_MARKER);
+  if (at === -1) return null;
+  return line.slice(at + UNSOURCED_MARKER.length).trim();
+}
+
+/**
+ * True when a marker *with a reason* covers this bound.
+ *
+ * A bare `unsourced-bound:` is not an annotation. The whole purpose of the marker is to make the
+ * author record which artifact they looked for and failed to find; an empty one discharges the
+ * obligation while recording nothing, which is exactly the rubber stamp this file argues an
+ * over-reporting checker produces. Emptiness is an existence check, so requiring a reason invents
+ * no threshold and cannot trip this checker's own rule.
  *
  * @param {string[]} lines All lines of the file.
  * @param {number} index Zero-based index of the line carrying the bound.
- * @returns {boolean} Whether an `unsourced-bound:` note covers it.
+ * @returns {boolean} Whether a reasoned `unsourced-bound:` note covers it.
  */
 export function hasMarker(lines, index) {
   const start = Math.max(0, index - MARKER_LOOKBEHIND);
-  return lines.slice(start, index + 1).some((line) => line.includes(UNSOURCED_MARKER));
+  return lines.slice(start, index + 1).some((line) => {
+    const reason = markerReason(line);
+    return reason !== null && reason.length > 0;
+  });
+}
+
+/**
+ * True when a bare marker -- present but with no reason -- covers this bound.
+ *
+ * Reported as its own class rather than folded into the unsourced count, because the two call for
+ * different actions: an unsourced bound needs its source found, a bare marker needs its sentence
+ * finished.
+ *
+ * @param {string[]} lines All lines of the file.
+ * @param {number} index Zero-based index of the line carrying the bound.
+ * @returns {boolean} Whether a reasonless marker covers it.
+ */
+export function hasBareMarker(lines, index) {
+  const start = Math.max(0, index - MARKER_LOOKBEHIND);
+  return lines.slice(start, index + 1).some((line) => markerReason(line) === '');
+}
+
+/**
+ * Comparisons whose right operand is an expression rather than a literal.
+ *
+ * This is the *recommended fix* -- the constant moves with its source, so the two artifacts can
+ * disagree. It was previously invisible: the report asserted that such bounds "never enter this
+ * population" and never counted them, so a green run was equally consistent with every bound being
+ * derived and with none of them being. A checker that measures only the population it rejects
+ * cannot say whether its own advice is ever taken.
+ *
+ * The lookarounds exclude `=>`, `>=`/`<=` already captured by the operator alternation, and the
+ * `!==`/`===` families. Without the `=` lookbehind an arrow function reads as a comparison, which
+ * inflated the first measurement of this population from 6 to 45.
+ *
+ * @param {string} line Source line.
+ * @returns {string[]} The derived comparison tokens found.
+ */
+export function derivedComparisons(line) {
+  const found = [];
+  const pattern = /(?<![=!<>])(>=|<=|>|<)(?![=>])\s*([A-Za-z_$][\w.$]*)/g;
+  let match;
+  while ((match = pattern.exec(stripLiterals(line))) !== null) found.push(`${match[1]}${match[2]}`);
+  return found;
 }
 
 /**
@@ -159,19 +229,22 @@ export function isJudged(line) {
  *
  * @param {string} file Path to the file.
  * @param {string} source Its contents.
- * @returns {{bounds: object[], existence: number, reversed: object[]}} What the file contains.
+ * @returns {{bounds: object[], existence: number, derived: number, reversed: object[]}} What the
+ *   file contains.
  */
 export function censusFile(file, source) {
   const lines = source.split('\n');
   const bounds = [];
   const reversed = [];
   let existence = 0;
+  let derived = 0;
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
     if (line.trimStart().startsWith('*') || line.trimStart().startsWith('//')) continue;
     if (!isJudged(line)) continue;
 
+    derived += derivedComparisons(line).length;
     for (const token of reversedComparisons(line)) {
       reversed.push({ file, line: i + 1, token, text: lines[i].trim() });
     }
@@ -185,11 +258,12 @@ export function censusFile(file, source) {
         line: i + 1,
         token: comparison.token,
         annotated: hasMarker(lines, i),
+        bare: hasBareMarker(lines, i),
         text: lines[i].trim(),
       });
     }
   }
-  return { bounds, existence, reversed };
+  return { bounds, existence, derived, reversed };
 }
 
 /**
@@ -225,20 +299,23 @@ export function assertPopulation(population, what) {
  * Run the census across every source file.
  *
  * @param {string[]} [files] Override for tests.
- * @returns {{bounds: object[], existence: number, reversed: object[], files: number}} The census.
+ * @returns {{bounds: object[], existence: number, derived: number, reversed: object[],
+ *   files: number}} The census.
  */
 export function census(files = sourceFiles()) {
   assertPopulation(files, 'no tool sources found to scan for bounds');
   const bounds = [];
   const reversed = [];
   let existence = 0;
+  let derived = 0;
   for (const file of files) {
     const result = censusFile(path.basename(file), readFileSync(file, 'utf8'));
     bounds.push(...result.bounds);
     reversed.push(...result.reversed);
     existence += result.existence;
+    derived += result.derived;
   }
-  return { bounds, existence, reversed, files: files.length };
+  return { bounds, existence, derived, reversed, files: files.length };
 }
 
 /**
@@ -248,15 +325,26 @@ export function census(files = sourceFiles()) {
  * line is emitted on both the passing and failing paths -- a scope line only on the green path
  * describes the run nobody needs described.
  *
+ * The annotated/derived split is printed on both paths too, and for the same reason one step
+ * further in: the derived count is the one that says whether the *recommended fix* is used. Only
+ * ever reporting the rejected population lets a checker be green whether its advice is followed or
+ * ignored, and the green sentence still claims both categories exist.
+ *
  * @param {ReturnType<typeof census>} result The census.
  * @returns {{lines: string[], ok: boolean}} Report lines and the verdict.
  */
 export function report(result) {
+  const { derived } = result;
   const unannotated = result.bounds.filter((bound) => !bound.annotated);
+  const bare = unannotated.filter((bound) => bound.bare);
+  const invented = unannotated.filter((bound) => !bound.bare);
+  const annotated = result.bounds.length - unannotated.length;
   const lines = [
     `Scanned ${result.files} tool source file(s): ` +
       `${result.bounds.length} numeric bound(s), ${result.existence} existence check(s), ` +
       `${result.reversed.length} reversed comparison(s).`,
+    `Bounds by form: ${derived} derived from an expression, ${annotated} annotated ` +
+      `\`${UNSOURCED_MARKER}\`, ${unannotated.length} neither.`,
   ];
 
   for (const item of result.reversed) {
@@ -264,23 +352,33 @@ export function report(result) {
   }
 
   if (unannotated.length === 0) {
-    lines.push(
-      `Every bound is annotated or derived. ${result.bounds.length} annotated invented ` +
-        `constant(s); a bound compared against an expression never enters this population.`,
-    );
+    lines.push(`Every bound is annotated or derived.`);
     return { lines, ok: true };
   }
 
-  lines.push(
-    `${unannotated.length} of ${result.bounds.length} bound(s) invent a number with no source:`,
-  );
-  for (const bound of unannotated) {
-    lines.push(`  ${bound.file}:${bound.line}  ${bound.token}  ${bound.text.slice(0, 100)}`);
+  if (bare.length > 0) {
+    lines.push(`${bare.length} bound(s) carry a marker with no reason after it:`);
+    for (const bound of bare) {
+      lines.push(`  ${bound.file}:${bound.line}  ${bound.token}  ${bound.text.slice(0, 100)}`);
+    }
+    lines.push(
+      `A bare \`${UNSOURCED_MARKER}\` records nothing. Finish the sentence: which artifact did ` +
+        `you look for, and why does none commit to this number?`,
+    );
   }
-  lines.push(
-    `Fix by comparing against the artifact that already commits to the number, or record ` +
-      `\`${UNSOURCED_MARKER} <why nothing commits to one>\` within ${MARKER_LOOKBEHIND} lines above.`,
-  );
+
+  if (invented.length > 0) {
+    lines.push(
+      `${invented.length} of ${result.bounds.length} bound(s) invent a number with no source:`,
+    );
+    for (const bound of invented) {
+      lines.push(`  ${bound.file}:${bound.line}  ${bound.token}  ${bound.text.slice(0, 100)}`);
+    }
+    lines.push(
+      `Fix by comparing against the artifact that already commits to the number, or record ` +
+        `\`${UNSOURCED_MARKER} <why nothing commits to one>\` within ${MARKER_LOOKBEHIND} lines above.`,
+    );
+  }
   return { lines, ok: false };
 }
 

--- a/tools/check-assertion-bounds.test.mjs
+++ b/tools/check-assertion-bounds.test.mjs
@@ -20,6 +20,9 @@ import {
   stripLiterals,
   isExistence,
   hasMarker,
+  hasBareMarker,
+  markerReason,
+  derivedComparisons,
   isJudged,
   censusFile,
   census,
@@ -153,6 +156,109 @@ test('a marker below the bound does not cover it', () => {
   assert.equal(hasMarker(lines, 0), false);
 });
 
+// --- the acceptance path, which was the untested half ------------------------------------------
+//
+// Every case below passed before #4312. They are all on the path where the checker lets a bound
+// through, and a passing case produces no output, so nothing about the tree ever looked wrong.
+// The checker was careful about who it accused -- stripping literals, exempting existence and sign
+// checks, surfacing unparsed forms -- and applied none of that care to who it excused.
+
+test('a bare marker with no reason is not an annotation', () => {
+  const lines = [`// ${UNSOURCED_MARKER}`, 'assert.ok(x >= 5);'];
+  assert.equal(hasMarker(lines, 1), false, 'an empty note records nothing');
+  assert.equal(hasBareMarker(lines, 1), true, 'but it is reported as its own class');
+});
+
+test('a marker inside a string literal does not annotate a nearby bound', () => {
+  // Real shape: this very file contains the marker as fixture data. Without stripping, that data
+  // would excuse any bound written within the lookbehind of it.
+  const lines = [`const FIXTURE = '${UNSOURCED_MARKER} sample';`, 'assert.ok(x >= 5);'];
+  assert.equal(hasMarker(lines, 1), false);
+  assert.equal(hasBareMarker(lines, 1), false, 'data is neither a reason nor a bare marker');
+});
+
+test('markerReason distinguishes absent, bare, and reasoned', () => {
+  assert.equal(markerReason('assert.ok(x >= 5);'), null);
+  assert.equal(markerReason(`// ${UNSOURCED_MARKER}`), '');
+  assert.equal(
+    markerReason(`// ${UNSOURCED_MARKER}  nothing declares it  `),
+    'nothing declares it',
+  );
+});
+
+test('a trailing comment marker still annotates, so the fix did not narrow the rule', () => {
+  const lines = [`assert.ok(x >= 5); // ${UNSOURCED_MARKER} nothing declares it`];
+  assert.equal(hasMarker(lines, 0), true);
+});
+
+// --- derived bounds are counted, not merely asserted to exist ----------------------------------
+
+test('derivedComparisons finds an expression operand and ignores a literal one', () => {
+  assert.deepEqual(derivedComparisons('assert.ok(n >= want);'), ['>=want']);
+  assert.deepEqual(derivedComparisons('assert.ok(n >= 18);'), []);
+});
+
+test('derivedComparisons does not read an arrow function as a comparison', () => {
+  // The first measurement of this population reported 45 because `) => f` matched `>` followed by
+  // an identifier. The real count was 6. A detector that inflates its population 7.5x would have
+  // been published as a finding had the number not been checked against a control.
+  assert.deepEqual(derivedComparisons('assert.ok(a.some((f) => f.x));'), []);
+  assert.deepEqual(derivedComparisons('assert.ok(a !== b);'), []);
+});
+
+test('censusFile counts derived bounds alongside invented ones', () => {
+  const source = 'assert.ok(a >= b);\nassert.ok(c >= 18);\n';
+  const result = censusFile('x.mjs', source);
+  assert.equal(result.derived, 1, 'the expression-compared bound');
+  assert.equal(result.bounds.length, 1, 'only the literal one is a candidate for annotation');
+});
+
+test('the report states the derived count on both paths', () => {
+  // The old green sentence claimed "annotated or derived" and printed only the annotated count, so
+  // it read identically whether the recommended fix was used everywhere or nowhere.
+  const shape = { files: 1, existence: 0, reversed: [] };
+  const pass = report({ ...shape, derived: 4, bounds: [] });
+  const fail = report({
+    ...shape,
+    derived: 4,
+    bounds: [{ file: 'a', line: 1, token: '>=7', annotated: false, bare: false, text: 't' }],
+  });
+  assert.ok(
+    pass.lines.some((line) => line.includes('4 derived from an expression')),
+    pass.lines.join('\n'),
+  );
+  assert.ok(
+    fail.lines.some((line) => line.includes('4 derived from an expression')),
+    fail.lines.join('\n'),
+  );
+});
+
+test('a bare marker fails with different advice than an invented number', () => {
+  const shape = { files: 1, existence: 0, derived: 0, reversed: [] };
+  const bareRun = report({
+    ...shape,
+    bounds: [{ file: 'a', line: 1, token: '>=7', annotated: false, bare: true, text: 't' }],
+  });
+  const inventedRun = report({
+    ...shape,
+    bounds: [{ file: 'a', line: 1, token: '>=7', annotated: false, bare: false, text: 't' }],
+  });
+  assert.equal(bareRun.ok, false);
+  assert.equal(inventedRun.ok, false);
+  assert.ok(bareRun.lines.some((line) => line.includes('Finish the sentence')));
+  assert.ok(
+    !inventedRun.lines.some((line) => line.includes('Finish the sentence')),
+    'an invented number needs its source found, not its sentence finished',
+  );
+  assert.ok(inventedRun.lines.some((line) => line.includes('invent a number with no source')));
+});
+
+test('PREMISE: the derived population in this repository is not empty', () => {
+  // Without this the two counts could both be reported and both be zero, and the split would be a
+  // sentence about nothing. This is an existence check, so it commits to no particular number.
+  assert.ok(census().derived > 0, 'no bound in this tree derives its constant from an expression');
+});
+
 // --- reversed comparisons are reported, not skipped ------------------------------------------
 
 test('a literal on the left is surfaced rather than silently unparsed', () => {
@@ -212,6 +318,7 @@ test('an unannotated bound fails the run, and the report names it', () => {
     files: 1,
     existence: 0,
     reversed: [],
+    derived: 0,
     bounds: [{ file: 'x.test.mjs', line: 9, token: '>=7', annotated: false, text: 'assert' }],
   });
   assert.equal(result.ok, false);
@@ -221,10 +328,11 @@ test('an unannotated bound fails the run, and the report names it', () => {
 
 test('the scope line is printed on both the passing and the failing path', () => {
   const bound = { file: 'a', line: 1, token: '>=7', text: 't' };
-  const pass = report({ files: 2, existence: 3, reversed: [], bounds: [] });
+  const pass = report({ files: 2, existence: 3, derived: 0, reversed: [], bounds: [] });
   const fail = report({
     files: 2,
     existence: 3,
+    derived: 0,
     reversed: [],
     bounds: [{ ...bound, annotated: false }],
   });
@@ -233,7 +341,7 @@ test('the scope line is printed on both the passing and the failing path', () =>
 });
 
 test('the report interpolates its counts rather than restating them', () => {
-  const result = report({ files: 7, existence: 4, reversed: [], bounds: [] });
+  const result = report({ files: 7, existence: 4, derived: 0, reversed: [], bounds: [] });
   assert.match(result.lines[0], /Scanned 7 .*: 0 numeric bound\(s\), 4 existence check\(s\)/);
 });
 
@@ -241,6 +349,7 @@ test('a reversed comparison is listed on the passing path too', () => {
   const result = report({
     files: 1,
     existence: 0,
+    derived: 0,
     bounds: [],
     reversed: [{ file: 'a.mjs', line: 3, token: '5<=' }],
   });


### PR DESCRIPTION
## Summary

Three ways to satisfy the `unsourced-bound:` annotation without annotating anything. All three
passed before this PR; all three are on the path where the checker says **yes**.

```
marker only inside a string literal    annotated=1   <-- fixture data excused a real bound
marker in the assert message itself    annotated=1
bare marker, nothing after it          annotated=1   <-- recorded nothing, discharged the duty
```

## Why they survived

Considerable care had gone into who the checker **accuses**: `stripLiterals()` exists because "a
syntactic pattern is not a semantic class", existence and sign checks are exempt because neither
involves a chosen number, and unparsed `literal OP expr` forms are surfaced rather than skipped —
all so the tool never makes a false accusation, since the stated cost of over-reporting is that the
annotations it forces become rubber stamps.

None of that care was applied to who it **excuses**. `comparisons()` strips literals; `hasMarker()`
did not, so the marker appearing as fixture data annotated any bound within four lines.
`hasMarker()` also accepted a bare `unsourced-bound:` with nothing after it — which satisfies the
grep and records nothing, producing exactly the rubber stamp the file's own comment warns about.

**A false accusation is visible to the person accused. A false excuse is visible to nobody**,
because a passing case emits no output.

## The recommended fix was never counted

The green line read *"Every bound is annotated or derived"* and then printed only the annotated
count. Derived bounds — the recommended fix, where the constant moves with its source — were
asserted to exist and never measured, so the sentence read identically whether every bound derived
its constant or none did.

Measured: **6 derived against 10 marker-annotated**. The escape hatch is used more often than the
fix, and no output said so. The split is now printed on both the passing and failing paths.

## Retraction

`docs/guides/engineering-practice-adoption.md` recorded that a sibling session's
citation-is-not-a-binding defect reproduced here. **It does not, and the claim is withdrawn.**

```
citation-in-message, no marker         bounds=1 flagged=1
citation in comment above, no marker   bounds=1 flagged=1
```

The checker has no "sourced literal" acceptance path at all; its only non-marker acceptance is
comparing against an expression, which removes the literal and therefore genuinely binds. I had
read the report's advice as describing a category the tool recognises when it describes the shape
that leaves the population entirely.

## A detector defect caught by a control, not by absurdity

The first measurement of the derived population reported **45**. The real count is **6** — the
detector's `>` matched the `>` in `=>`, so every `(f) => f.x` read as a comparison against an
identifier. A 7.5x inflated population, and unlike the two instrument failures earlier in this
session it was not absurd enough to notice on sight. It was caught by a control asserting the
detector must *not* fire on an arrow function, which is now a test.

## Changes

- `tools/check-assertion-bounds.mjs` — `markerReason()`, `hasBareMarker()`, `derivedComparisons()`;
  `hasMarker()` now strips literals and requires a non-empty reason. Both new requirements are
  existence checks, so the fix invents no threshold and cannot trip this checker's own rule. Bare
  markers report as a distinct class: "finish the sentence" is different advice from "find the
  source".
- `tools/check-assertion-bounds.test.mjs` — **+13 tests (598 → 611)**, including a `PREMISE` test
  that the derived population is non-empty, so the new split cannot become a sentence about nothing.
- `docs/guides/engineering-practice-adoption.md` — retraction and the acceptance-path finding.

## Issues

Closes #4312

## Testing

- [x] `npm run format:check`, `npx eslint . --max-warnings 0`, `npm run type-check` — clean
- [x] `run-tool-tests.mjs` — **611/611**, exit 0
- [x] All 15 gate scripts exit 0 (run after `git add`)
- [x] Each of the three probes flips to rejected; a genuine annotation and a trailing-comment
      marker still pass, so the fix did not narrow the rule