### PR TITLE
refactor(tools): share the fence guard three scanners wrote separately

### DIFF
--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -9249,6 +9249,76 @@ notice on sight.
 
 Cites `ENG-TEST-002`, `ENG-TEST-004`.
 
+## Being importable is not being imported
+
+`markFences` -- the guard that stops a markdown scanner from reading a fenced code block as prose
+-- has lived in `tools/check-doc-links.mjs` for some time. It is exported. It is tested. Measured
+this turn, it had **zero external importers**.
+
+Two other scanners in the same tree did the job themselves:
+
+- `tools/check-upstream-refs.mjs` carried an independent inline reimplementation, with a comment
+  recording that it was written _after_ the check failed on the prose documenting the check.
+- `tools/check-citation-enumerations.mjs`, a **required gate**, had no guard at all and
+  false-accused a fenced illustration of the very violation it forbids. Demonstrated, not inferred.
+
+So the shared primitive already existed and the duplication happened anyway. That is a worse state
+than having no shared version, because the export makes the problem look solved to anyone
+grepping for one. **A shared primitive is the one that is used, not the one that could be** -- and
+the property to check is the importer count, which nothing was checking.
+
+The general remedy people reach for is "write a reusable extractor with the guard inside." Here the
+extractor existed and was reusable and was not reused, so writing one is not the remedy; being
+imported is. Extraction is a precondition for sharing, not sharing.
+
+## Count what the exclusion removed, not the excluded population
+
+Making the gate fence-aware adds an exclusion, and an exclusion that reports nothing is how a
+census silently changes its own denominator. The obvious number to print is _how many lines are
+fenced_. That number is nearly useless: it says how large the blind spot is, not whether the blind
+spot is hiding anything.
+
+What is printed instead is `fencedSuppressions()` -- the hits that **would have been reported but
+for the fence**. Measured today: **0**. A measured negative, recorded plainly: the guard removes
+nothing from the current verdict and exists to prevent a future false accusation. If it ever
+prints non-zero, the exclusion has started changing the answer and can be looked at.
+
+The two populations -- included and excluded -- are decided by the **same** predicate,
+`enumerationOnLine`. Two copies of a detector, one per branch, is exactly how a filter and its
+census come to disagree about what they were counting.
+
+Fence semantics are markdown's, so the guard is applied per-file and only to `.md`. A triple
+backtick in a `.mjs` file is inside a comment, not a delimiter; applying markdown fencing to source
+would blind the check to half a file at the first docstring that draws a box.
+
+## An unasserted report parameter, written minutes after measuring the same defect
+
+Adding a fourth `fenced` argument to `violationLines`/`cleanLine` left nine existing call sites
+passing the old arity. Both report paths then read `undefined markdown line(s) skipped inside
+fenced blocks`, and the full 66-test suite stayed green -- because no test asserted the count
+varied with its argument.
+
+This was written in the same session that had just cross-tabulated wiring against assertion across
+fifteen tools. Naming a defect class is not a control against it. The fix was to update the call
+sites _and_ assert that the printed count moves when the argument does.
+
+## A test in a subdirectory ran nowhere
+
+`run-tool-tests.mjs` discovered suites with a non-recursive `readdirSync`, so the new
+`tools/lib/markdown.test.mjs` would have been green, tracked, and reached by nothing -- the
+"reached" axis again, self-inflicted.
+
+Measured **before** changing discovery: **0** subdirectory test files existed. That makes recursion
+inert on today's tree, which is what makes it verifiable rather than merely plausible -- the
+discovered-file count had to be unchanged by the edit, and was (16 before, 16 after). It is now
+asserted twice: against a `withFileTypes` fake, and against the real tree, which must contain at
+least one nested suite or the recursion is untested against real files.
+
+Note the fake had to change too. It returned bare strings; discovery now reads `withFileTypes`, so
+a fake returning strings would have been testing a different function than the one that ships.
+
+Cites `ENG-TEST-002`, `ENG-TEST-004`, `ENG-ARCH-003`.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:

--- a/tools/check-citation-enumerations.mjs
+++ b/tools/check-citation-enumerations.mjs
@@ -38,6 +38,8 @@ import { readdir, readFile, stat } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 
+import { fencedLineNumbers } from './lib/markdown.mjs';
+
 /** Directories never scanned: build output, dependencies, and vendored upstream text. */
 export const SKIPPED_DIRECTORIES = new Set([
   'node_modules',
@@ -109,23 +111,79 @@ export function isScannedFile(filePath) {
 /**
  * Lines that attribute an enumerated obligation to a ratified principle.
  *
+ * Fenced blocks are skipped when `fenceAware` is set, which the walker does for markdown only: a
+ * triple backtick inside a `.mjs` file is a comment, not a delimiter, so applying markdown fence
+ * semantics to source would blind the check to half a file at the first docstring that draws a box.
+ *
+ * The guard is here because this gate false-accused a fenced *illustration* of the very violation
+ * it exists to describe. That is the over-report class, and it is the expensive one for a tool
+ * whose remedy is an opt-out marker: a check that flags correct prose teaches authors to reach for
+ * the exemption, and an exemption reached for by reflex stops being evidence of anything.
+ *
  * @param {string} text file contents
+ * @param {{fenceAware?: boolean}} [options] whether markdown fence semantics apply
  * @returns {{line: number, id: string, enumeration: string, text: string}[]}
  */
-export function findRestatedEnumerations(text) {
+export function findRestatedEnumerations(text, { fenceAware = false } = {}) {
   const found = [];
   const lines = text.split(/\r?\n/);
+  const fenced = fenceAware ? fencedLineNumbers(text) : null;
   for (let i = 0; i < lines.length; i += 1) {
-    const line = lines[i];
-    if (line.includes(EXEMPTION)) continue;
-    const id = CITATION.exec(line);
-    if (!id) continue;
-    if (!OBLIGATION.test(line)) continue;
-    const list = ENUMERATION.exec(line);
-    if (!list) continue;
-    found.push({ line: i + 1, id: id[0], enumeration: list[0], text: line.trim() });
+    if (fenced?.has(i + 1)) continue;
+    const hit = enumerationOnLine(lines[i], i);
+    if (hit) found.push(hit);
   }
   return found;
+}
+
+/**
+ * The hits the fence exclusion removed -- lines that would have been reported but for the fence.
+ *
+ * This is the number the scope line prints, and it is deliberately not "how many lines are fenced".
+ * A count of the excluded *population* says how big the blind spot is; a count of excluded *hits*
+ * says how much the exclusion changed the verdict, and only the second can be watched for growth.
+ * A pre-census filter reported by name rather than by effect is how an exclusion does unmeasured
+ * work for months.
+ *
+ * @param {string} text file contents
+ * @returns {{line: number, id: string, enumeration: string, text: string}[]} Suppressed hits.
+ */
+export function fencedSuppressions(text) {
+  const suppressed = [];
+  const lines = text.split(/\r?\n/);
+  const fenced = fencedLineNumbers(text);
+  for (let i = 0; i < lines.length; i += 1) {
+    if (!fenced.has(i + 1)) continue;
+    const hit = enumerationOnLine(lines[i], i);
+    if (hit) suppressed.push(hit);
+  }
+  return suppressed;
+}
+
+/**
+ * Test one line, independent of any fence or file-type decision.
+ *
+ * Extracted so the included and excluded populations are decided by the *same* predicate. Two
+ * copies of a detector, one per branch, is how a filter and its census come to disagree about what
+ * they were counting.
+ *
+ * @param {string} line The line.
+ * @param {number} index Zero-based line index.
+ * @returns {{line: number, id: string, enumeration: string, text: string}|null} A hit, or null.
+ */
+export function enumerationOnLine(line, index) {
+  if (line.includes(EXEMPTION)) return null;
+  const id = CITATION.exec(line);
+  if (!id) return null;
+  if (!OBLIGATION.test(line)) return null;
+  const list = ENUMERATION.exec(line);
+  if (!list) return null;
+  return { line: index + 1, id: id[0], enumeration: list[0], text: line.trim() };
+}
+
+/** True when markdown fence semantics apply to a path. */
+export function isFenceAware(filePath) {
+  return path.extname(filePath).toLowerCase() === '.md';
 }
 
 /** How many lines opted out via the marker. Reported so an exemption cannot grow unseen. */
@@ -167,12 +225,14 @@ async function* walk(directory) {
  * @param {{file: string, line: number, id: string, enumeration: string, text: string}[]} violations Findings.
  * @param {number} scanned Files read.
  * @param {number} exempted Lines skipped via the exemption marker.
+ * @param {number} fenced Markdown lines skipped for being inside a fenced block.
  * @returns {string[]} Report lines, newline-free.
  */
-export function violationLines(violations, scanned, exempted) {
+export function violationLines(violations, scanned, exempted, fenced) {
   const lines = [
     `Restated principle enumeration(s) — ${violations.length} across ${scanned} scanned ` +
-      `file(s), with ${exempted} line(s) exempted via the "${EXEMPTION}" marker:`,
+      `file(s), with ${exempted} line(s) exempted via the "${EXEMPTION}" marker and ` +
+      `${fenced} markdown line(s) skipped inside fenced blocks:`,
   ];
   for (const v of violations) {
     lines.push(
@@ -192,14 +252,20 @@ export function violationLines(violations, scanned, exempted) {
 /**
  * Build the passing report.
  *
+ * The fenced count is printed on both paths, and it is a *count of what was removed* rather than a
+ * name for the decision. A scope line reading "fenced blocks are out of scope" asserts only that
+ * somebody decided; a number asserts how much the decision moved, and can be seen to grow.
+ *
  * @param {number} scanned Files read.
  * @param {number} exempted Lines skipped via the exemption marker.
+ * @param {number} fenced Markdown lines skipped for being inside a fenced block.
  * @returns {string} The clean-result sentence.
  */
-export function cleanLine(scanned, exempted) {
+export function cleanLine(scanned, exempted, fenced) {
   return (
     `No principle enumeration is restated as an obligation. ${scanned} file(s) scanned, ` +
-    `${exempted} line(s) exempted via the "${EXEMPTION}" marker. Read one line at a ` +
+    `${exempted} line(s) exempted via the "${EXEMPTION}" marker, ${fenced} markdown line(s) ` +
+    'skipped inside fenced blocks. Read one line at a ' +
     'time, so a list wrapped across a line break is not seen.'
   );
 }
@@ -208,22 +274,25 @@ export async function main(root) {
   const violations = [];
   let scanned = 0;
   let exempted = 0;
+  let fenced = 0;
   for await (const file of walk(root)) {
     scanned += 1;
     const text = await readFile(file, 'utf8');
     exempted += countExemptions(text);
-    for (const hit of findRestatedEnumerations(text)) {
+    const fenceAware = isFenceAware(file);
+    if (fenceAware) fenced += fencedSuppressions(text).length;
+    for (const hit of findRestatedEnumerations(text, { fenceAware })) {
       violations.push({ ...hit, file: path.relative(root, file) });
     }
   }
 
   if (violations.length > 0) {
-    process.stdout.write(`\n${violationLines(violations, scanned, exempted).join('\n')}\n`);
+    process.stdout.write(`\n${violationLines(violations, scanned, exempted, fenced).join('\n')}\n`);
     process.exitCode = 1;
     return;
   }
 
-  process.stdout.write(`${cleanLine(scanned, exempted)}\n`);
+  process.stdout.write(`${cleanLine(scanned, exempted, fenced)}\n`);
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/tools/check-citation-enumerations.test.mjs
+++ b/tools/check-citation-enumerations.test.mjs
@@ -13,7 +13,10 @@ import {
   SCANNED_EXTENSIONS,
   cleanLine,
   countExemptions,
+  enumerationOnLine,
+  fencedSuppressions,
   findRestatedEnumerations,
+  isFenceAware,
   isScannedFile,
   violationLines,
 } from './check-citation-enumerations.mjs';
@@ -35,51 +38,54 @@ const VIOLATION = {
 };
 
 test('violationLines states all three buckets of the partition', () => {
-  const [header] = violationLines([VIOLATION], 3161, 4);
+  const [header] = violationLines([VIOLATION], 3161, 4, 0);
   assert.match(header, /— 1 across 3161 scanned file\(s\)/);
   assert.match(header, /with 4 line\(s\) exempted/);
   assert.ok(header.includes(`"${EXEMPTION}"`), 'the marker name must be named, not described');
 });
 
 test('violationLines counts violations, not scanned files, in the first bucket', () => {
-  const [header] = violationLines([VIOLATION, { ...VIOLATION, line: 43 }], 10, 0);
+  const [header] = violationLines([VIOLATION, { ...VIOLATION, line: 43 }], 10, 0, 0);
   assert.match(header, /— 2 across 10 scanned file\(s\)/);
 });
 
 test('violationLines emits file, line, id, enumeration and source text per finding', () => {
-  const lines = violationLines([VIOLATION], 1, 0);
+  const lines = violationLines([VIOLATION], 1, 0, 0);
   assert.ok(lines.includes('  docs/guides/x.md:42  ENG-SEC-008'), lines.join('\n'));
   assert.ok(lines.includes('    enumerates: accounts, balances, and transactions'));
   assert.ok(lines.some((l) => l.includes(VIOLATION.text)));
 });
 
 test('violationLines closes with the remedy and cites ADR-0003', () => {
-  const lines = violationLines([VIOLATION], 1, 0);
+  const lines = violationLines([VIOLATION], 1, 0, 0);
   assert.match(lines.at(-1), /ADR-0003 \(four-authority topology\)/);
   assert.ok(lines.some((l) => l.includes('drifts by losing an item')));
 });
 
 test('violationLines line count scales by three per finding', () => {
-  const one = violationLines([VIOLATION], 1, 0).length;
-  const two = violationLines([VIOLATION, VIOLATION], 1, 0).length;
+  const one = violationLines([VIOLATION], 1, 0, 0).length;
+  const two = violationLines([VIOLATION, VIOLATION], 1, 0, 0).length;
   assert.equal(two - one, 3);
 });
 
 test('cleanLine reports both the scanned and exempted counts', () => {
-  const line = cleanLine(3161, 4);
+  const line = cleanLine(3161, 4, 0);
   assert.match(line, /3161 file\(s\) scanned/);
   assert.match(line, /4 line\(s\) exempted/);
   assert.match(line, /No principle enumeration is restated as an obligation\./);
 });
 
 test('cleanLine discloses the line-at-a-time limitation that makes a wrapped list invisible', () => {
-  assert.match(cleanLine(1, 0), /Read one line at a time, so a list wrapped across a line break/);
+  assert.match(
+    cleanLine(1, 0, 0),
+    /Read one line at a time, so a list wrapped across a line break/,
+  );
 });
 
 test('a zero-exemption green result still names the exemption bucket', () => {
   // Omitting the bucket when it is empty would make "0 exempted" and "not measured"
   // render identically -- the failure mode this tool's own comment warns about.
-  assert.match(cleanLine(3161, 0), /0 line\(s\) exempted/);
+  assert.match(cleanLine(3161, 0, 0), /0 line\(s\) exempted/);
 });
 
 test('the defect this was written for is caught', () => {
@@ -231,4 +237,104 @@ test('a passing run states the same two buckets', () => {
   const result = spawnSync(process.execPath, [ENUM_TOOL], { encoding: 'utf8' });
   assert.equal(result.status, 0);
   assert.match(result.stdout, /\d+ file\(s\) scanned, \d+ line\(s\) exempted/);
+});
+
+// --- fence awareness (#4315) -------------------------------------------------------------------
+//
+// This gate false-accused a fenced *illustration* of the violation it exists to describe: prose
+// showing what a restated enumeration looks like was reported as a restated enumeration. Two other
+// scanners in this repository had already grown the same guard independently, and one of them
+// exported it -- with zero importers.
+
+// The fixture sentence is assembled rather than written out: this gate scans its own test file,
+// and a `.mjs` file has no fence semantics, so a literal restatement here is a real violation.
+// Assembling the ID keeps `CITATION` from matching the source line while the runtime value is
+// exactly what a document would contain. The alternative -- the `enumeration-fixture` marker --
+// cannot be used, because the marker also suppresses detection at runtime, so the fixture would
+// stop exercising the thing under test.
+const FIXTURE_ID = ['ENG', 'TEST', '004'].join('-');
+const RESTATEMENT = `\`${FIXTURE_ID}\` requires lint, format, and type-check.`;
+
+const FENCED_DOC = [
+  'Prose about the rule.',
+  '',
+  '```md',
+  RESTATEMENT,
+  '```',
+  '',
+  'That block illustrates the violation; it does not commit it.',
+].join('\n');
+
+test('a fenced illustration is not reported when fence semantics apply', () => {
+  assert.equal(findRestatedEnumerations(FENCED_DOC, { fenceAware: true }).length, 0);
+});
+
+test('CONTROL: the same line outside a fence is still reported', () => {
+  // Without this the test above would pass on a detector that finds nothing at all, which is the
+  // failure mode of every scope narrowing: the exclusion and a broken predicate look identical.
+  assert.equal(findRestatedEnumerations(RESTATEMENT, { fenceAware: true }).length, 1);
+});
+
+test('fence semantics are off by default, so source files are unaffected', () => {
+  assert.equal(
+    findRestatedEnumerations(FENCED_DOC).length,
+    1,
+    'a backtick run in .mjs is a comment',
+  );
+});
+
+test('isFenceAware selects markdown and nothing else', () => {
+  assert.equal(isFenceAware('docs/guides/x.md'), true);
+  assert.equal(isFenceAware('docs/guides/X.MD'), true);
+  assert.equal(isFenceAware('tools/x.mjs'), false);
+  assert.equal(isFenceAware('.github/workflows/ci.yml'), false);
+});
+
+test('the exclusion reports what it removed, not that it happened', () => {
+  const suppressed = fencedSuppressions(FENCED_DOC);
+  assert.equal(suppressed.length, 1);
+  assert.equal(suppressed[0].id, FIXTURE_ID);
+  assert.equal(suppressed[0].line, 4, 'the one-based line inside the fence');
+});
+
+test('fencedSuppressions counts nothing when nothing was excluded', () => {
+  assert.deepEqual(fencedSuppressions(RESTATEMENT), []);
+});
+
+test('both populations are decided by the same predicate', () => {
+  // Two copies of a detector, one per branch, is how a filter and its census come to disagree
+  // about what they were counting.
+  const direct = enumerationOnLine(RESTATEMENT, 0);
+  assert.equal(direct.id, FIXTURE_ID);
+  assert.deepEqual(findRestatedEnumerations(RESTATEMENT, { fenceAware: true }), [direct]);
+  assert.equal(fencedSuppressions(['```', RESTATEMENT, '```'].join('\n'))[0].id, direct.id);
+});
+
+test('the exemption marker still wins inside and outside a fence', () => {
+  const exempt = `${RESTATEMENT} <!-- ${EXEMPTION} -->`;
+  assert.equal(enumerationOnLine(exempt, 0), null);
+  assert.deepEqual(fencedSuppressions(['```', exempt, '```'].join('\n')), []);
+});
+
+// --- the fenced count is asserted, not merely printed -------------------------------------------
+
+test('the clean line states the fenced-skip count', () => {
+  // Added as a fourth argument, and every existing call site passed three. The reports read
+  // "undefined markdown line(s) skipped" and the whole suite stayed green -- an unasserted report
+  // parameter, reproduced in code written minutes earlier by someone who had just measured the
+  // same defect in fifteen other tools.
+  assert.match(cleanLine(3161, 4, 9), /9 markdown line\(s\) skipped inside fenced blocks/);
+  assert.doesNotMatch(cleanLine(3161, 4, 0), /undefined/);
+});
+
+test('the failing header states the fenced-skip count too', () => {
+  const [header] = violationLines([VIOLATION], 3161, 4, 9);
+  assert.match(header, /9 markdown line\(s\) skipped inside fenced blocks/);
+  assert.doesNotMatch(header, /undefined/);
+});
+
+test('the fenced count moves with its argument on both paths', () => {
+  // A count that never varies in a test is indistinguishable from a constant in the template.
+  assert.match(cleanLine(1, 0, 7), /7 markdown line/);
+  assert.match(violationLines([VIOLATION], 1, 0, 7)[0], /7 markdown line/);
 });

--- a/tools/check-doc-links.mjs
+++ b/tools/check-doc-links.mjs
@@ -22,8 +22,9 @@ import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 
+import { markFences } from './lib/markdown.mjs';
+
 const LINK = /\[[^\]]*\]\(([^)\s]+)\)/g;
-const FENCE = /^\s*(?:```|~~~)/;
 const INLINE_CODE = /`[^`]*`/g;
 
 /**
@@ -164,21 +165,11 @@ export function isRepoRelative(target) {
  * reported an elided example as a broken link, so this is measured rather than assumed:
  * the count of skipped links is printed.
  *
- * @param {string} text
- * @returns {{ line: string, fenced: boolean }[]}
+ * Re-exported from `lib/markdown.mjs`, where it now lives so other scanners can share it. It was
+ * exported from here for months with zero external importers while two other tools rediscovered
+ * the same guard; being importable is not the same as being imported.
  */
-export function markFences(text) {
-  let fenced = false;
-  return String(text)
-    .split('\n')
-    .map((line) => {
-      if (FENCE.test(line)) {
-        fenced = !fenced;
-        return { line, fenced: true };
-      }
-      return { line, fenced };
-    });
-}
+export { markFences };
 
 /**
  * Collect markdown links from one document: relative targets of any kind, and same-file

--- a/tools/check-upstream-refs.mjs
+++ b/tools/check-upstream-refs.mjs
@@ -43,6 +43,8 @@
 import { readFileSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 
+import { markFences } from './lib/markdown.mjs';
+
 // Recorded, not approved. Lower it whenever the real count drops; the tool
 // prints the new floor when it can. See docs/guides/engineering-practice-adoption.md.
 export const BASELINE = 23;
@@ -93,16 +95,16 @@ export function isFixtureFile(file) {
 /** Extract every jrmoulckers cross-repo link from one file's text. */
 export function collectRefs(text, file = '', { fenceAware = true } = {}) {
   const out = [];
-  let fenced = false;
+  // A link inside a fenced block is an illustration, not a reference this
+  // repository follows. Counting them made the check fail on the prose that
+  // documents the check -- the fix is scope, not a higher baseline.
+  //
+  // This used to be an inline fence walker. It is the shared one now: the same
+  // guard had been written independently here and in `check-doc-links.mjs`,
+  // and a third scanner that lacked it was false-accusing its own examples.
+  const marked = fenceAware ? markFences(text) : null;
   text.split(/\r?\n/).forEach((line, i) => {
-    // A link inside a fenced block is an illustration, not a reference this
-    // repository follows. Counting them made the check fail on the prose that
-    // documents the check -- the fix is scope, not a higher baseline.
-    if (fenceAware && /^\s*(```|~~~)/.test(line)) {
-      fenced = !fenced;
-      return;
-    }
-    if (fenced) return;
+    if (marked && marked[i]?.fenced) return;
     for (const pattern of [BLOB, RAW]) {
       pattern.lastIndex = 0;
       for (const [, repo, ref, path] of line.matchAll(pattern)) {

--- a/tools/lib/markdown.mjs
+++ b/tools/lib/markdown.mjs
@@ -1,0 +1,69 @@
+/**
+ * Shared markdown scanning primitives (#4315).
+ *
+ * Every tool in this repository that reads markdown for a pattern eventually discovers that a
+ * fenced code block is an *illustration*, not an assertion, and that counting it makes the tool
+ * fail on the prose documenting the tool. That discovery has happened three separate times here:
+ *
+ * - `check-doc-links.mjs` grew {@link markFences}, exported and tested, after a fence-blind census
+ *   reported an elided example as a broken link.
+ * - `check-upstream-refs.mjs` grew its own inline copy, with a comment recording that "counting
+ *   them made the check fail on the prose that documents the check."
+ * - `check-citation-enumerations.mjs`, a required gate, never grew one, and false-accuses a fenced
+ *   illustration of the very violation it exists to describe.
+ *
+ * The guard was exported and had **zero external importers**, so being reusable did no work. A
+ * shared primitive is not the one that could be imported; it is the one that is. This module makes
+ * the guard the path of least resistance rather than a thing each tool rediscovers after being
+ * bitten by it.
+ *
+ * Fence semantics are markdown's, so callers scanning other extensions must opt out: a triple
+ * backtick in a `.mjs` file is inside a comment, not a delimiter.
+ */
+
+/** Opening or closing delimiter of a fenced code block. */
+export const FENCE = /^\s*(?:```|~~~)/;
+
+/**
+ * Split a document into lines, marking which are inside a fenced code block.
+ *
+ * The delimiter lines themselves are marked fenced, so a caller can skip on the flag alone without
+ * separately recognising the fence. An unterminated fence leaves the remainder of the document
+ * fenced, which is what a markdown renderer does and therefore what a reader sees.
+ *
+ * Splits on `/\r?\n/` so a CRLF document does not leave a stray carriage return on every line;
+ * indices are unaffected either way.
+ *
+ * @param {string} text Document contents.
+ * @returns {{line: string, fenced: boolean}[]} One entry per line, in order.
+ */
+export function markFences(text) {
+  let fenced = false;
+  return String(text)
+    .split(/\r?\n/)
+    .map((line) => {
+      if (FENCE.test(line)) {
+        fenced = !fenced;
+        return { line, fenced: true };
+      }
+      return { line, fenced };
+    });
+}
+
+/**
+ * The one-based line numbers that sit inside a fenced block.
+ *
+ * Returned as a `Set` of line numbers rather than a filtered list of lines, because a caller that
+ * has already found a hit needs to ask "was line N fenced?" without re-deriving the numbering. A
+ * filtered list silently renumbers, which is how an exclusion turns into a wrong citation.
+ *
+ * @param {string} text Document contents.
+ * @returns {Set<number>} One-based line numbers inside fences, including delimiters.
+ */
+export function fencedLineNumbers(text) {
+  const fenced = new Set();
+  markFences(text).forEach((entry, index) => {
+    if (entry.fenced) fenced.add(index + 1);
+  });
+  return fenced;
+}

--- a/tools/lib/markdown.test.mjs
+++ b/tools/lib/markdown.test.mjs
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { FENCE, markFences, fencedLineNumbers } from './markdown.mjs';
+
+// The guard these tests cover had been written three times in this repository before it was
+// written once in a shared place. This file is also the first test under a `tools/` subdirectory,
+// and it is reached only because `run-tool-tests.mjs` discovery was made recursive in the same
+// change -- before that, a test here would have run nowhere while looking like a test that runs.
+
+test('FENCE matches both delimiters and tolerates indentation', () => {
+  assert.equal(FENCE.test('```'), true);
+  assert.equal(FENCE.test('~~~'), true);
+  assert.equal(FENCE.test('   ```js'), true);
+  assert.equal(FENCE.test('not a fence'), false);
+  assert.equal(FENCE.test('a ``` mid-line'), false, 'a delimiter starts its line');
+});
+
+test('markFences marks the delimiter lines themselves', () => {
+  // So a caller can skip on the flag alone. A caller that had to recognise the fence separately
+  // would be reimplementing the thing it imported.
+  const marked = markFences('a\n```\nb\n```\nc');
+  assert.deepEqual(
+    marked.map((entry) => entry.fenced),
+    [false, true, true, true, false],
+  );
+});
+
+test('markFences leaves an unterminated fence open to the end', () => {
+  const marked = markFences('a\n```\nb\nc');
+  assert.deepEqual(
+    marked.map((entry) => entry.fenced),
+    [false, true, true, true],
+    'which is what a renderer does, and therefore what a reader sees',
+  );
+});
+
+test('markFences handles CRLF without leaving a carriage return on every line', () => {
+  const marked = markFences('a\r\n```\r\nb\r\n```\r\nc');
+  assert.deepEqual(
+    marked.map((entry) => entry.line),
+    ['a', '```', 'b', '```', 'c'],
+  );
+  assert.deepEqual(
+    marked.map((entry) => entry.fenced),
+    [false, true, true, true, false],
+  );
+});
+
+test('markFences returns one entry per line, including a trailing blank', () => {
+  assert.equal(markFences('a\nb\n').length, 3);
+  assert.equal(markFences('').length, 1, 'an empty document is one empty line, not zero');
+});
+
+test('markFences coerces rather than throwing on a non-string', () => {
+  assert.deepEqual(markFences(undefined), [{ line: 'undefined', fenced: false }]);
+});
+
+test('a tilde fence closes a tilde fence', () => {
+  const marked = markFences('a\n~~~\nb\n~~~\nc');
+  assert.equal(marked[2].fenced, true);
+  assert.equal(marked[4].fenced, false);
+});
+
+test('fencedLineNumbers is one-based and includes the delimiters', () => {
+  assert.deepEqual([...fencedLineNumbers('a\n```\nb\n```\nc')], [2, 3, 4]);
+});
+
+test('fencedLineNumbers is empty when the document has no fence', () => {
+  assert.equal(fencedLineNumbers('a\nb\nc').size, 0);
+});
+
+test('fencedLineNumbers agrees with markFences rather than re-deriving', () => {
+  // Two implementations of one rule is how a filter and its census come to disagree.
+  const text = 'a\n```\nb\n```\nc\n~~~\nd';
+  const fromMarks = new Set(
+    markFences(text)
+      .map((entry, index) => (entry.fenced ? index + 1 : null))
+      .filter((n) => n !== null),
+  );
+  assert.deepEqual([...fencedLineNumbers(text)], [...fromMarks]);
+});

--- a/tools/run-tool-tests.mjs
+++ b/tools/run-tool-tests.mjs
@@ -78,18 +78,35 @@ export function leakLines(files, phase) {
 }
 
 /**
- * List every tool test file.
+ * List every tool test file, at any depth.
+ *
+ * Discovery was `readdirSync` on the top level only, so a test placed in a `tools/` subdirectory
+ * would run nowhere while looking exactly like a test that runs. Measured before changing it:
+ * **0** subdirectory test files existed, so recursion is inert on today's tree and the suite count
+ * must be unchanged by this edit -- which is what makes the change verifiable rather than merely
+ * plausible. The hazard it removes is prospective: the first shared module under `tools/lib/`
+ * arrives with this PR.
+ *
+ * `withFileTypes` rather than a stat per entry, and directories are walked in sorted order so the
+ * whole listing stays deterministic and therefore diffable.
  *
  * @param {string} [dir] Directory to scan.
  * @param {{readdirSync: Function}} [fsImpl] Injectable fs for tests.
- * @returns {string[]} Paths, sorted.
+ * @returns {string[]} Paths, sorted, depth-first.
  */
 export function testFiles(dir = TOOLS_DIR, fsImpl = fs) {
-  return fsImpl
-    .readdirSync(dir)
-    .filter((f) => f.endsWith('.test.mjs'))
-    .sort()
-    .map((f) => path.join(dir, f));
+  const entries = fsImpl.readdirSync(dir, { withFileTypes: true });
+  const found = [];
+  for (const entry of [...entries].sort((a, b) => (a.name < b.name ? -1 : 1))) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules' || entry.name.startsWith('.')) continue;
+      found.push(...testFiles(full, fsImpl));
+    } else if (entry.name.endsWith('.test.mjs')) {
+      found.push(full);
+    }
+  }
+  return found;
 }
 
 /**

--- a/tools/run-tool-tests.test.mjs
+++ b/tools/run-tool-tests.test.mjs
@@ -75,23 +75,59 @@ test('leakLines distinguishes an inherited leak from one this run created', () =
   assert.match(after, /The run that leaks is the run that must fail/);
 });
 
+// Dirent-like entries: discovery reads `withFileTypes`, so a fake that returns bare strings would
+// be testing a different function than the one that ships.
+const file = (name) => ({ name, isDirectory: () => false });
+const dir = (name) => ({ name, isDirectory: () => true });
+
 test('testFiles selects only test files', () => {
-  const fake = { readdirSync: () => ['a.mjs', 'a.test.mjs', 'b.test.mjs'] };
+  const fake = { readdirSync: () => [file('a.mjs'), file('a.test.mjs'), file('b.test.mjs')] };
   const files = testFiles('tools', fake);
   assert.equal(files.length, 2);
   assert.ok(files.every((f) => f.endsWith('.test.mjs')));
 });
 
 test('testFiles returns a sorted list', () => {
-  const fake = { readdirSync: () => ['z.test.mjs', 'a.test.mjs'] };
+  const fake = { readdirSync: () => [file('z.test.mjs'), file('a.test.mjs')] };
   const files = testFiles('tools', fake);
   assert.ok(files[0].endsWith('a.test.mjs'));
+});
+
+test('testFiles descends into subdirectories', () => {
+  // Discovery was top-level only, so a test in `tools/lib/` would have run nowhere while looking
+  // exactly like a test that runs -- green, and reached by nothing.
+  const fake = {
+    readdirSync: (target) =>
+      target === 'tools'
+        ? [dir('lib'), file('top.test.mjs')]
+        : [file('markdown.test.mjs'), file('markdown.mjs')],
+  };
+  const files = testFiles('tools', fake);
+  assert.equal(files.length, 2);
+  assert.ok(files.some((f) => f.endsWith(path.join('lib', 'markdown.test.mjs'))));
+});
+
+test('testFiles does not descend into node_modules or dot directories', () => {
+  const fake = {
+    readdirSync: (target) =>
+      target === 'tools'
+        ? [dir('node_modules'), dir('.cache'), file('top.test.mjs')]
+        : [file('vendored.test.mjs')],
+  };
+  assert.deepEqual(testFiles('tools', fake), [path.join('tools', 'top.test.mjs')]);
 });
 
 test('testFiles finds this repository real suites', () => {
   // unsourced-bound: no artifact commits to how many tool test files exist -- that is the
   // point of enumerating from disk. A floor only excludes a silently emptied glob (#4296).
   assert.ok(testFiles().length >= 10);
+});
+
+test('the real tree contains a subdirectory suite, so recursion is exercised', () => {
+  // Without this the recursion is asserted only against a fake. Measured before the change: zero
+  // subdirectory test files existed, so recursion was inert and unfalsifiable on the real tree.
+  const nested = testFiles().filter((f) => path.dirname(f) !== path.resolve('tools'));
+  assert.ok(nested.length > 0, 'no nested suite; recursion is untested against real files');
 });
 
 test('testFiles includes this very file, so the population contains its own checker', () => {


### PR DESCRIPTION
## Summary

`markFences` -- the guard that stops a markdown scanner reading a fenced code block as prose --
was already exported from `tools/check-doc-links.mjs`, already tested, and imported by **nothing**.
Two other scanners did the job themselves anyway:

- `tools/check-upstream-refs.mjs` had an independent inline reimplementation, whose own comment
  records it was written *after* the check failed on the prose documenting the check.
- `tools/check-citation-enumerations.mjs` -- a **required gate** -- had no guard at all and
  false-accuses a fenced illustration of the very violation it forbids. Demonstrated, not inferred.

Being importable is not being imported. The usual remedy -- "write a reusable extractor with the
guard inside" -- does not apply, because the extractor existed and was reusable and was not reused.

## Changes

- **`tools/lib/markdown.mjs`** (new): `FENCE`, `markFences`, `fencedLineNumbers`, with its own
  suite at `tools/lib/markdown.test.mjs`.
- **`check-doc-links.mjs`** imports and re-exports it; behaviour verified identical (7260 links,
  593 files, 6 fenced skipped, exit 0).
- **`check-upstream-refs.mjs`** drops its inline fence walker.
- **`check-citation-enumerations.mjs`** becomes fence-aware for `.md` **only** -- a triple backtick
  in a `.mjs` file is inside a comment, not a delimiter, and applying markdown fencing to source
  would blind the check at the first docstring that draws a box. Included and excluded populations
  share **one** predicate (`enumerationOnLine`), because two copies of a detector is how a filter
  and its census come to disagree about what they counted.
- The report prints **suppressed hits**, not fenced lines: how much the exclusion changed the
  verdict, not how big the blind spot is. Measured today: **0**. A measured negative -- the guard
  prevents a future false accusation rather than fixing a present one.
- **`run-tool-tests.mjs`** discovery is now recursive. Measured **before** the edit: 0 subdirectory
  test files, so recursion is inert on today's tree -- which is what makes it verifiable: the
  discovered count had to be unchanged, and was (16 -> 16). Asserted against a `withFileTypes` fake
  *and* against the real tree.

Two defects found in this change's own code, both fixed:

1. A fourth `fenced` report argument left nine call sites at the old arity, printing `undefined
   markdown line(s) skipped` while the suite stayed green -- an unasserted report parameter,
   written minutes after measuring that same defect across fifteen tools.
2. The new test fixture contained a literal restatement, which the gate correctly flagged; the ID
   is now assembled so the source line does not match while the runtime value is exactly what a
   document would contain. The `enumeration-fixture` marker could not be used -- it suppresses the
   predicate, so the fixture would stop exercising the thing under test.

## Issues

Closes #4315

## Testing

- [x] `npm run format:check`, `npx eslint . --max-warnings 0`, `npm run type-check` -- clean
- [x] `node tools/run-tool-tests.mjs` -- **636/636** (was 611)
- [x] All 15 gate scripts pass, including `tool:imports:check` (new relative import) and
      `test:independence:check`