### PR TITLE
fix(tools): pin that every wired validator still delegates to a validator (#4314)

### DIFF
--- a/tools/check-ai-manifest.test.mjs
+++ b/tools/check-ai-manifest.test.mjs
@@ -1327,6 +1327,116 @@ test('the scanned population is derived from the surface, not narrowed to a samp
   );
 });
 
+/**
+ * Parse the single-line runner bodies out of `activationRunners`' production source.
+ *
+ * Fails closed: a body this cannot parse is reported rather than skipped, so reformatting the
+ * registry cannot silently empty the population.
+ */
+function runnerBodies(source) {
+  const start = source.indexOf('function activationRunners(');
+  assert.notEqual(start, -1, 'PREMISE: activationRunners must be locatable in production source');
+  const region = source.slice(start, source.indexOf('\n}', start));
+  const bodies = new Map();
+  for (const line of region.split('\n')) {
+    const parsed = /^ {4}(\w+): \(\) => (.+),$/.exec(line);
+    if (parsed) bodies.set(parsed[1], parsed[2]);
+  }
+  return bodies;
+}
+
+/**
+ * Report every wired runner that does not delegate to the validator its id names.
+ *
+ * Shared by the assertion and its control, so weakening it reddens the control too (.github#953).
+ */
+function delegationFindings(source, ids) {
+  const bodies = runnerBodies(source);
+  const findings = [];
+  const precomputedBy = new Map();
+  for (const id of ids) {
+    const body = bodies.get(id);
+    if (body === undefined) {
+      findings.push(`runner ${id} has no parsable body`);
+      continue;
+    }
+    if (body.includes(`validate${id[0].toUpperCase()}${id.slice(1)}(`)) continue;
+    const precomputed = /context\.(\w+)\.findings/.exec(body);
+    if (precomputed) {
+      const prior = precomputedBy.get(precomputed[1]);
+      if (prior !== undefined)
+        findings.push(`runners ${prior} and ${id} both read context.${precomputed[1]}.findings`);
+      precomputedBy.set(precomputed[1], id);
+      continue;
+    }
+    findings.push(`runner ${id} delegates to nothing: ${body}`);
+  }
+  return findings;
+}
+
+test('every wired runner delegates to the validator its id names (#4314)', () => {
+  // #4278 made the advertised set and the wired set one object, so a validator cannot be dropped
+  // or added silently. That proves WIRING. Measured against behaviour: replacing each runner body
+  // with `() => []` one at a time left 6 of 8 unnoticed by the whole suite -- every survivor has
+  // thorough DIRECT-CALL unit tests that never execute the path production reaches it by, and the
+  // only two kills are the two validators with a test that spawns the tool (.github#970).
+  //
+  // `syncLock` is the sharp one: gutting it MOVED the production output and still survived. And
+  // `envInputs` shipped one PR earlier with three new tests, so the newest guard in the file was
+  // unreached-tested. On a healthy tree every validator finds nothing, so a gutted runner and a
+  // working one usually print byte-identical reports -- output comparison cannot separate them.
+  //
+  // The population is the PRODUCTION object's own keys, not VALIDATORS and not a table written
+  // here; a hand-written probe list would be this same defect one level up (#4287, .github#977).
+  const ids = Object.keys(activationRunners({}));
+  assert.ok(ids.length > 5, 'PREMISE: the runner registry must be non-degenerate');
+  const source = fs.readFileSync(TOOL, 'utf8');
+  assert.deepEqual(delegationFindings(source, ids), [], 'every wired runner must delegate');
+
+  const gutted = source.replace(
+    '    envInputs: () => validateEnvInputs(),',
+    '    envInputs: () => [],',
+  );
+  assert.notEqual(gutted, source, 'PREMISE: the control must construct a different source');
+  assert.deepEqual(
+    delegationFindings(gutted, ids),
+    ['runner envInputs delegates to nothing: []'],
+    'a gutted runner must be reported',
+  );
+
+  // The fail-closed branch was LATENT: every body in this tree parses, so "no parsable body" could
+  // never fire and dropping it survived the sweep. Pinning "all bodies parse" would freeze an
+  // accident of the current formatting, so the state is CONSTRUCTED instead (#4300, .github#880).
+  const wrapped = source.replace(
+    '    envInputs: () => validateEnvInputs(),',
+    '    envInputs: () =>\n      validateEnvInputs(),',
+  );
+  assert.notEqual(wrapped, source, 'PREMISE: the control must construct a different source');
+  assert.deepEqual(
+    delegationFindings(wrapped, ids),
+    ['runner envInputs has no parsable body'],
+    'a body this cannot read must be reported, never skipped',
+  );
+
+  // Lower bound, stated rather than left to be inferred: this pins that each runner delegates to
+  // the validator its id names. It does not pin that the validator is correct -- the behavioural
+  // anchor stays the tests that spawn the tool and read its report.
+});
+
+test("every wired runner's findings reach the report (#4314)", () => {
+  const ids = Object.keys(activationRunners({}));
+  for (const id of ids) {
+    const runners = Object.fromEntries(ids.map((key) => [key, () => []]));
+    runners[id] = () => [`SENTINEL-${id}`];
+    const dispatched = dispatchValidators(runners);
+    assert.equal(dispatched.ran, ids.length, `${id}: every wired runner must be counted as run`);
+    assert.ok(
+      dispatched.findings.includes(`SENTINEL-${id}`),
+      `${id}: a wired runner's findings must arrive in the report`,
+    );
+  }
+});
+
 test('every route into the corpus is exercised by a claimant that uses only that route (#4309)', () => {
   // The #4270 cross-check filters git's index through BACKBONE_CLAIM -- the walk's own pattern --
   // so narrowing the pattern shrinks both enumerations identically and they go on agreeing. It

--- a/tools/check-ai-manifest.test.mjs
+++ b/tools/check-ai-manifest.test.mjs
@@ -1389,7 +1389,11 @@ test('every wired runner delegates to the validator its id names (#4314)', () =>
   // The population is the PRODUCTION object's own keys, not VALIDATORS and not a table written
   // here; a hand-written probe list would be this same defect one level up (#4287, .github#977).
   const ids = Object.keys(activationRunners({}));
-  assert.ok(ids.length > 5, 'PREMISE: the runner registry must be non-degenerate');
+  assert.equal(
+    ids.length,
+    VALIDATORS.length,
+    'PREMISE: the runner registry must cover every advertised validator',
+  );
   const source = fs.readFileSync(TOOL, 'utf8');
   assert.deepEqual(delegationFindings(source, ids), [], 'every wired runner must delegate');
 


### PR DESCRIPTION
## The defect

`#4278` made the advertised set and the wired set one object: a validator with no `--help` row is
reported, a row with no validator is reported, and `dispatchValidators` emits
`Validators: 8 advertised, 8 run`. That proves **wiring**. It says nothing about whether a wired
runner still does anything.

Reported by `jrmoulckers/.github#977`, where deleting the dispatch call site left 7 of 8
validators unnoticed. finance's wiring guard makes that deletion form visible, so the transferable
shape here is the one it cannot see: gut the body, leave the id, the advertisement and the count
intact.

## Measured — 6 of 8 survived

| runner | production output moved | before | after |
| --- | --- | --- | --- |
| `docCounts` | no | **SURVIVED** | KILLED |
| `agentRoster` | no | **SURVIVED** | KILLED |
| `activationDoc` | no | **SURVIVED** | KILLED |
| `syncLock` | **yes** | **SURVIVED** | KILLED |
| `enforcementDoc` | no | **SURVIVED** | KILLED |
| `triggerCoverage` | yes | KILLED | KILLED |
| `citations` | no | KILLED | KILLED |
| `envInputs` | no | **SURVIVED** | KILLED |

Every survivor has thorough direct-call unit tests. They pin the logic precisely — they never
execute the path production reaches it by. The two kills are exactly the two validators with a
test that spawns the tool and asserts on its stdout, and I did not choose those deliberately:
one came from `#4287`/`#4292`, the other from `#4270`/`#4300`/`#4309`. The only contracts wired
end-to-end are the ones an earlier defect forced me to wire.

Two details sharpen it:

- **`syncLock` moved the production output and still survived.** Not a silent corruption — the
  report visibly differed and 97 tests said nothing.
- **`envInputs` shipped one PR ago (#4306) with three new tests, and survived.** The newest guard
  in the file was unreached-tested on the day it landed.

On a healthy tree every validator finds nothing, so `prod moved false` is the normal case: a
gutted runner and a working one print byte-identical reports. Output comparison cannot separate
them, in the suite or in CI.

## Fix

No hand-written probe table — that is this same defect one level up. Two derived checks:

1. **Delegation.** Population from `Object.keys(activationRunners({}))`, the production object.
   Each runner's source must call `validate<Pascal(id)>(` or read a **distinct** precomputed
   `context.*.findings`; a gutted body matches neither. Assertion and control share one predicate,
   so weakening it reddens the control too.
2. **Relay.** For each wired id a sentinel finding must arrive in `dispatchValidators`' output, so
   no id can be dropped between the runner and the report.

## Sweep — 12 mutants, 0 survivors

8 gutted runners, all KILLED by `every wired runner delegates to the validator its id names
(#4314)`, plus three on the new guard: predicate always-empty, population narrowed to one runner
(caught by its premise), and unparsable bodies skipped rather than reported.

**One survivor, then repaired.** The fail-closed "no parsable body" branch was **latent** — every
body in this tree parses on one line, so it could never fire and deleting it survived. Pinning
"all bodies parse" would freeze an accident of the current formatting, so the control now
*constructs* a wrapped multi-line body. Re-run: KILLED.

## Stated as a lower bound

This pins that each runner delegates to the validator its id names. It does **not** pin that the
validator is correct — the behavioural anchor stays the tests that spawn the tool and read its
report. That sentence is in the test beside the assertion, not left for a reader to infer.

## Scope

Test file only; no production change. `packages/design-tokens`, `vendor/@jrm/tokens` and every
workflow file are untouched.

## Validation

- `node --test tools/check-ai-manifest.test.mjs` — **99 passing, 0 failing** (97 before)
- `node tools/check-ai-manifest.js` — exit 0
- `npx prettier --check` / `npx eslint` — exit 0

Closes #4314