### PR TITLE
fix(tools): validate the report-site definition against the tree it measures

### DIFF
--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -9319,6 +9319,109 @@ a fake returning strings would have been testing a different function than the o
 
 Cites `ENG-TEST-002`, `ENG-TEST-004`, `ENG-ARCH-003`.
 
+## A shared definition manufactures agreement
+
+Two sessions ran the same sweep over different trees and got 33% and 34%. The sibling flagged the
+agreement as suspicious rather than corroborating, which is the correct instinct, and named the
+reason precisely: **a shared numerator definition plus a shared denominator definition produces
+agreement whether or not the underlying trees agree.** Both sweeps inherited the same idea of what
+a "report site" is, and neither had validated it against any ground truth.
+
+So I validated it here, and it is wrong.
+
+```
+missed: process.stdout.write / stderr.write   2 sites
+missed: array-literal report builders         4 sites
+                       330 sites -> 337
+false positives among the original 4 shapes   0 of 330   (measured negative)
+residue never disclosed                      69 sites
+```
+
+Both missed `stdout.write` sites are in `check-citation-enumerations.mjs`, **written in the session
+that published the ratio**. The denominator omitted report lines the same author had added days
+earlier, and nothing about adding them suggested the instrument would not see them.
+
+## I claimed a direction, measured it, and it was backwards
+
+Writing the fix up, I reasoned: a site the regexes miss cannot be counted as unasserted, unasserted
+sites are the majority, therefore **every omission raises the published percentage** -- error biased
+toward the flattering answer. It went into the commit message, the issue, the tool's own scope
+line, and a test that asserted the phrase.
+
+It is wrong. A missed site cannot be counted as _asserted_ either. It is absent from numerator and
+denominator both, so the ratio simply describes a subset, and the direction of the error depends
+entirely on whether that subset's assertion rate differs from the whole -- which is not knowable
+without measuring.
+
+Measured, by isolating the definition change from the tree's own movement:
+
+```
+old definition, today's tree   144/331  43.5%
+new definition, today's tree   150/337  44.5%
+all 6 newly included sites      asserted
+```
+
+Every one of the six was asserted, so the old boundary had been **understating** the ratio by
+1.0pp. The opposite of what I claimed, in the one direction I had argued was structurally
+impossible.
+
+The error is exactly the one this tool exists to catch: **a sign asserted from a plausible argument
+instead of a measurement.** It survived because the argument was good -- it has a real premise, one
+valid inference, and a conclusion that feels forced -- and because it flattered nobody, which made
+it read as the rigorous, self-critical option. A claim that costs you something is not thereby true.
+
+The residual lesson stands in weaker form: an instrument's error usually does have a sign, and
+asking which way it pushes is the right question. What I got wrong was answering it from an
+armchair when a 310-second sweep could answer it from the tree.
+
+## Do not compare a ratio across a moving tree
+
+The sweep returned 44.5% where I had previously published 34%. The tempting sentence -- "validating
+the definition raised the measured ratio by ten points" -- is false. Four PRs landed between the
+two runs, adding tests that assert report lines. **Both the definition and the tree moved**, and a
+delta across two moving things is attributable to neither.
+
+The isolation above is the only honest comparison available: re-derive the _old_ definition's
+number on _today's_ tree, so exactly one thing differs. That turned a headline ten-point delta into
+a real one-point delta, and reversed its sign.
+
+Cites `ENG-TEST-002`, `ENG-OBS-002`.
+
+## Disclose the boundary, do not defend it
+
+Most of the 69 residual sites are legitimately not report output: regex construction, cache keys,
+error messages. The fix is therefore not to widen the definition until it is right -- it never will
+be -- but to **publish the size of what was declined**. The scope block now prints the residue and
+names the direction of the bias, so a reader can see how much of the file the ratio never looked at
+rather than inferring that the ratio looked at everything.
+
+The same rule as the fenced-hit count one section up, arriving from the other side: there, the
+exclusion's _effect_ was the number worth printing; here, the declined _population_ is, because the
+declined sites were never evaluated at all and so have no effect to measure. **Print the effect
+when the exclusion removed decided cases; print the population when it removed uninspected ones.**
+
+And print it without a claimed direction. The next section is what happened when I attached one.
+
+`buildsReport()` is the single predicate for both the counted and the declined set. Two copies --
+one per branch -- is how a filter and its census come to disagree about where the line was.
+
+## A detector I could not validate, not shipped
+
+I also tried to catch continuation lines of multi-line template literals, using backtick parity to
+track whether a line sits inside an open template. Backticks inside comments and regexes toggle the
+parity, so the classifier's output was mostly wrong -- it labelled ordinary lines as continuations,
+including three in the file implementing the parity check.
+
+It is not shipped. **A boundary I can disclose beats a detector I cannot validate**, and shipping
+the second while claiming the first is how a denominator acquires a defect that looks like rigour.
+The continuations stay in the residue, counted and visible, as a named limitation.
+
+Notably, the first line the new array shape matched was the comment _documenting_ the array shape
+-- the detector counting its own explanation. That is the fifth time in this session a written
+warning has sat inside the visual field of the defect it describes.
+
+Cites `ENG-TEST-002`, `ENG-TEST-004`, `ENG-OBS-002`.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:

--- a/tools/check-report-assertions.mjs
+++ b/tools/check-report-assertions.mjs
@@ -32,6 +32,40 @@ const RETURN_TEMPLATE = /return\s+`/;
 // extracting a printer into a returning function removed its sites from the population instead of
 // making them asserted, improving the ratio for the wrong reason.
 const BARE_TEMPLATE = /^`/;
+// `process.stdout.write` is report output that `console.*` does not cover. Two such sites existed
+// in this tree, both written in the same session that published a coverage ratio computed without
+// them, so the ratio's denominator omitted report lines the same author had just added (#4317).
+const STREAM_WRITE = /process\.(?:stdout|stderr)\.write\(/;
+// An array of report lines built in one expression -- `return ['', 'header:', ...xs.map(...)]`.
+// The elements are report output; only those beginning a line were caught by BARE_TEMPLATE.
+const ARRAY_BUILDER = /(?:return|=)\s*\[/;
+// Prose is not output. This guard is required only by ARRAY_BUILDER, which is loose enough to
+// match a comment illustrating the shape -- measured: the four original shapes matched zero
+// comment lines across 330 sites, and the first line ARRAY_BUILDER newly matched was the comment
+// above documenting BARE_TEMPLATE. A detector that counts its own explanation is measuring prose.
+const COMMENT = /^(?:\/\/|\*|\/\*)/;
+
+/**
+ * Decide whether a line builds report output.
+ *
+ * One predicate, used by both `reportSites` and `unclassifiedSites`, so the counted and the
+ * declined populations cannot disagree about where the boundary is.
+ *
+ * @param {string} text Raw source line.
+ * @returns {boolean} True when the line builds report output.
+ */
+export function buildsReport(text) {
+  const trimmed = text.trim();
+  if (COMMENT.test(trimmed)) return false;
+  return (
+    PRINT_CALL.test(text) ||
+    PUSH_CALL.test(text) ||
+    RETURN_TEMPLATE.test(text) ||
+    STREAM_WRITE.test(text) ||
+    (ARRAY_BUILDER.test(text) && text.includes('`')) ||
+    BARE_TEMPLATE.test(trimmed)
+  );
+}
 
 /**
  * Find interpolation sites on lines that build report output.
@@ -45,20 +79,36 @@ export function reportSites(source) {
   for (let i = 0; i < lines.length; i++) {
     const text = lines[i];
     if (!text.includes('${')) continue;
-    const trimmed = text.trim();
-    if (
-      !PRINT_CALL.test(text) &&
-      !PUSH_CALL.test(text) &&
-      !RETURN_TEMPLATE.test(text) &&
-      !BARE_TEMPLATE.test(trimmed)
-    ) {
-      continue;
-    }
+    if (!buildsReport(text)) continue;
     for (const m of text.matchAll(/\$\{([^{}]+)\}/g)) {
       out.push({ line: i + 1, expr: m[1] });
     }
   }
   return out;
+}
+
+/**
+ * Count interpolation sites this detector declined to treat as report output.
+ *
+ * The ratio this tool publishes has a denominator drawn by six regexes, and a site those regexes
+ * miss is not counted as unasserted -- it disappears. Since unasserted sites are the majority,
+ * every omission biases the published percentage *upward*, which is the flattering direction and
+ * therefore the one nobody checks. Disclosing the residue does not make the boundary correct; it
+ * makes the boundary visible, so a reader can see how much of the file the ratio never saw.
+ *
+ * Most of this residue is legitimately not report output -- regex construction, key building,
+ * error messages. The number is published as a magnitude to watch, not as a defect count.
+ *
+ * @param {string} source Full source text of a tool.
+ * @returns {number} Interpolation sites on non-report lines.
+ */
+export function unclassifiedSites(source) {
+  let count = 0;
+  for (const text of source.split('\n')) {
+    if (!text.includes('${') || buildsReport(text)) continue;
+    count += [...text.matchAll(/\$\{([^{}]+)\}/g)].length;
+  }
+  return count;
 }
 
 /**
@@ -130,7 +180,8 @@ export function reportLines(result) {
  * without tests contribute no sites and are therefore invisible in the ratio rather than counted
  * as unasserted -- the omission that would otherwise make the number look better than the tree.
  *
- * @param {{tools: number, allTools: number, skippedRed: string[], sentinel: string}} result Counts.
+ * @param {{tools: number, allTools: number, skippedRed: string[], sentinel: string,
+ *   unclassified?: number}} result Counts.
  * @returns {string[]} Scope lines.
  */
 export function scopeLines(result) {
@@ -147,6 +198,15 @@ export function scopeLines(result) {
     lines.push(
       `  ${result.skippedRed.length} tool(s) had a red baseline and were skipped; a red baseline makes every mutant look caught.`,
     );
+  }
+  if (result.unclassified > 0) {
+    lines.push(
+      `  ${result.unclassified} interpolation site(s) were not classified as report output and are outside`,
+    );
+    lines.push(
+      `  the ratio entirely. Omitting a site cannot count it as unasserted, so the boundary drawn here`,
+    );
+    lines.push(`  biases the percentage upward; this figure is how much of the file it never saw.`);
   }
   lines.push(`  Sentinel: ${result.sentinel}. Counts are stable across sentinel choice;`);
   lines.push(`  a site whose true value equals the sentinel is reported as unmeasurable.`);
@@ -187,6 +247,7 @@ export function measure(options = {}) {
   const survivors = [];
   const skippedRed = [];
   let unmeasurable = 0;
+  let unclassified = 0;
 
   for (const tool of tools) {
     const file = path.join(dir, tool);
@@ -195,6 +256,7 @@ export function measure(options = {}) {
       skippedRed.push(tool);
       continue;
     }
+    unclassified += unclassifiedSites(original);
     const lines = original.split('\n');
     try {
       for (const site of reportSites(original)) {
@@ -222,6 +284,7 @@ export function measure(options = {}) {
     caught,
     survivors,
     unmeasurable,
+    unclassified,
     skippedRed,
     sentinel,
   };

--- a/tools/check-report-assertions.mjs
+++ b/tools/check-report-assertions.mjs
@@ -91,10 +91,15 @@ export function reportSites(source) {
  * Count interpolation sites this detector declined to treat as report output.
  *
  * The ratio this tool publishes has a denominator drawn by six regexes, and a site those regexes
- * miss is not counted as unasserted -- it disappears. Since unasserted sites are the majority,
- * every omission biases the published percentage *upward*, which is the flattering direction and
- * therefore the one nobody checks. Disclosing the residue does not make the boundary correct; it
- * makes the boundary visible, so a reader can see how much of the file the ratio never saw.
+ * miss is absent from *both* the numerator and the denominator -- so the percentage describes a
+ * subset, and is only trustworthy if that subset's assertion rate matches the whole. It need not.
+ *
+ * An earlier version of this comment claimed the omission "biases the percentage upward," on the
+ * reasoning that a missed site cannot be counted as unasserted. That reasoning is wrong: a missed
+ * site cannot be counted as *asserted* either. Measured when the boundary was widened, all six
+ * newly included sites turned out to be asserted, so the old boundary had been understating the
+ * ratio by 1.0pp -- the opposite of the claimed direction. Asserting a sign without measuring it
+ * is the same error this tool exists to find.
  *
  * Most of this residue is legitimately not report output -- regex construction, key building,
  * error messages. The number is published as a magnitude to watch, not as a defect count.
@@ -204,9 +209,12 @@ export function scopeLines(result) {
       `  ${result.unclassified} interpolation site(s) were not classified as report output and are outside`,
     );
     lines.push(
-      `  the ratio entirely. Omitting a site cannot count it as unasserted, so the boundary drawn here`,
+      `  the ratio entirely -- absent from both numerator and denominator, so the percentage`,
     );
-    lines.push(`  biases the percentage upward; this figure is how much of the file it never saw.`);
+    lines.push(
+      `  describes a subset whose assertion rate need not match the whole. The direction of that`,
+    );
+    lines.push(`  error is not knowable a priori; this figure is how much the ratio never saw.`);
   }
   lines.push(`  Sentinel: ${result.sentinel}. Counts are stable across sentinel choice;`);
   lines.push(`  a site whose true value equals the sentinel is reported as unmeasurable.`);

--- a/tools/check-report-assertions.test.mjs
+++ b/tools/check-report-assertions.test.mjs
@@ -399,7 +399,11 @@ test('unclassifiedSites counts every site on a declined line, not the line', () 
 test('scopeLines discloses the residue rather than assuming it away', () => {
   const line = scopeLines({ ...baseResult, unclassified: 57 }).join('\n');
   assert.match(line, /57 interpolation site\(s\) were not classified/);
-  assert.match(line, /biases the percentage upward/, 'the direction of the bias is the point');
+  assert.match(
+    line,
+    /not knowable a priori/,
+    'the disclosure must not claim a direction; measurement showed the guessed one was backwards',
+  );
 });
 
 test('the disclosed residue moves with its input', () => {

--- a/tools/check-report-assertions.test.mjs
+++ b/tools/check-report-assertions.test.mjs
@@ -3,6 +3,7 @@ import test from 'node:test';
 
 import {
   DEFAULT_SENTINEL,
+  buildsReport,
   measure,
   mutateSite,
   perToolLines,
@@ -13,6 +14,7 @@ import {
   scopeLines,
   survivorLines,
   toolsWithTests,
+  unclassifiedSites,
   wiredTools,
 } from './check-report-assertions.mjs';
 
@@ -333,4 +335,82 @@ test('reportSites counts a returned template and a logged one alike', () => {
   const logged = reportSites('console.log(`${v}`);');
   const returned = reportSites('  return `${v}`;');
   assert.equal(logged.length, returned.length);
+});
+
+// --- site-definition validation (#4317) ---------------------------------------------------------
+// The published ratio's denominator is drawn by regexes that had never been checked against the
+// tree they measure. These cover both directions: shapes that are report output and were missed,
+// and prose that is not report output and would newly be counted.
+
+test('process.stdout.write is report output', () => {
+  const src = 'process.stdout.write(`${count} files\\n`);';
+  assert.equal(reportSites(src).length, 1, 'console.* is not the only way a tool prints');
+});
+
+test('process.stderr.write is report output', () => {
+  assert.equal(reportSites('process.stderr.write(`${n} failed`);').length, 1);
+});
+
+test('an array of report lines counts every element, not just the one starting the line', () => {
+  const src = "return ['', 'header:', ...xs.map((x) => `  ${x}`)];";
+  assert.equal(reportSites(src).length, 1);
+});
+
+test('an assigned array of report lines is counted', () => {
+  const src = "const lines = ['', 'per tool:', `  ${name}${rate}`];";
+  assert.equal(reportSites(src).length, 2);
+});
+
+test('a comment illustrating a report line is not a report line', () => {
+  // The first line the array shape newly matched was the comment documenting the array shape.
+  // A detector that counts its own explanation is measuring prose.
+  const src = '// e.g. `const lines = [`a ${x}`, `b ${y}`];` carries the same values';
+  assert.deepEqual(reportSites(src), []);
+});
+
+test('a jsdoc line mentioning an interpolation is not a report line', () => {
+  assert.deepEqual(reportSites(' * @returns {string} One entry per `${...}` on a line.'), []);
+});
+
+test('the comment guard does not suppress a real report line', () => {
+  // Negative control: the guard keys on the line's own start, so a trailing comment is harmless.
+  assert.equal(reportSites('console.log(`${n} done`); // tally').length, 1);
+});
+
+test('buildsReport is the single boundary both populations use', () => {
+  // Two copies of a detector -- one for what is counted, one for what is declined -- is how a
+  // filter and its census come to disagree about where the line was.
+  assert.equal(buildsReport('console.log(`${a}`);'), true);
+  assert.equal(buildsReport('const key = `${b}:${c}`;'), false);
+  assert.equal(buildsReport('// `${d}`'), false);
+  const src = ['console.log(`${a}`);', 'const key = `${b}:${c}`;', '// `${d}`'].join('\n');
+  assert.equal(reportSites(src).length, 1);
+  assert.equal(unclassifiedSites(src), 3, 'two key sites plus the commented one');
+});
+
+test('unclassifiedSites ignores lines with no interpolation', () => {
+  assert.equal(unclassifiedSites('const a = 1;\nconst b = `plain`;'), 0);
+});
+
+test('unclassifiedSites counts every site on a declined line, not the line', () => {
+  assert.equal(unclassifiedSites('const key = `${a}-${b}-${c}`;'), 3);
+});
+
+test('scopeLines discloses the residue rather than assuming it away', () => {
+  const line = scopeLines({ ...baseResult, unclassified: 57 }).join('\n');
+  assert.match(line, /57 interpolation site\(s\) were not classified/);
+  assert.match(line, /biases the percentage upward/, 'the direction of the bias is the point');
+});
+
+test('the disclosed residue moves with its input', () => {
+  // An unasserted report parameter prints a constant, or `undefined`, and stays green.
+  const a = scopeLines({ ...baseResult, unclassified: 1 }).join('\n');
+  const b = scopeLines({ ...baseResult, unclassified: 2 }).join('\n');
+  assert.notEqual(a, b);
+  assert.match(a, /\b1 interpolation site/);
+});
+
+test('scopeLines says nothing about residue when there is none', () => {
+  const lines = scopeLines({ ...baseResult, unclassified: 0 }).join('\n');
+  assert.doesNotMatch(lines, /not classified/, 'a zero exclusion is not a caveat');
 });


### PR DESCRIPTION
## Summary

A sibling session ran an equivalent asserted-ratio sweep on `jrmoulckers/engineering` and got 33%
against finance's 34%, then flagged the agreement as **suspicious rather than corroborating**:
a shared numerator definition plus a shared denominator definition produces agreement whether or
not the underlying trees agree. Neither of us had validated the site definition against ground
truth.

Validated it here. It was wrong.

## What the definition missed

- **`process.stdout.write` / `process.stderr.write`** — 2 sites. `PRINT_CALL` covered only
  `console.log|error|warn`. Both missed sites were written in the same session that published the
  ratio, so the denominator omitted report lines the same author had just added.
- **Array-literal report builders** — 4 sites, e.g. `return ['', 'header:', ...xs.map(x => \`  ${x}\`)]`.
  Only elements that *began* a line were caught.

330 → **337** sites. False positives among the original four shapes: **0 of 330** — a measured
negative. The comment guard added here is needed only by the new array shape, whose first new match
was the comment documenting the shape it generalises: the detector counting its own explanation.

## The part I got wrong, and then measured

I shipped "omitting a site biases the percentage upward" — in the scope line, in a test asserting
that phrase, in the issue, and in the guide. **It is false.** A missed site is absent from
numerator *and* denominator, so the direction depends on whether the omitted subset's assertion
rate differs from the whole, which is not knowable without measuring.

Measured, isolating the definition change from the tree's own movement:

```
old definition, today's tree   144/331  43.5%
new definition, today's tree   150/337  44.5%
all 6 newly included sites      asserted
```

The old boundary was **understating** the ratio by 1.0pp — the direction I had argued was
structurally impossible. Retracted in the second commit; the disclosure now reports the residue
**without** claiming a direction.

Related: the raw sweep returned 44.5% against a previously published 34%, but four PRs landed
between the runs. Both the definition and the tree moved, so that ten-point delta is attributable
to neither. The isolation above is the only honest comparison available.

## Also not shipped

A multi-line-template continuation detector, using backtick parity. Backticks inside comments and
regexes toggle the parity, so its output was mostly wrong — including on the file implementing it.
A boundary I can disclose beats a detector I cannot validate; those continuations stay in the
69-site residue as a named limitation.

## Changes

- `buildsReport()` — the single predicate deciding both the counted and the declined population.
- `unclassifiedSites()` + residue disclosure in `scopeLines()`.
- 14 tests, including a negative control (the comment guard must not suppress a real report line)
  and an assertion that the disclosed figure moves with its input.

## Issues

Closes #4317

## Testing

- [x] `npm run format:check`, `npx eslint . --max-warnings 0`, `npm run type-check` — clean
- [x] `node tools/run-tool-tests.mjs` — **649/649** (was 636)
- [x] Full mutation sweep, 310s, exit 0
- [x] All 15 gate scripts pass