### PR TITLE
chore(tools): harden the enumeration-fixture marker as a class (#4320)

### DIFF
--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -7118,7 +7118,7 @@ the first time this turn:
 
 Every ID resolves, every title matches, every anchor lands. And one of the 171 is wrong.
 
-`AGENTS.md` said: "`ENG-TEST-004` (distinct static signals) requires lint, format, type-check, and <!-- enumeration-fixture -->
+`AGENTS.md` said: "`ENG-TEST-004` (distinct static signals) requires lint, format, type-check, and <!-- enumeration-fixture: the defective quotation this section is about -->
 tests to report independently." The principle's statement names **five** — type, lint, **build**,
 format, and **security**. The restatement dropped two.
 
@@ -9421,6 +9421,63 @@ Notably, the first line the new array shape matched was the comment _documenting
 warning has sat inside the visual field of the defect it describes.
 
 Cites `ENG-TEST-002`, `ENG-TEST-004`, `ENG-OBS-002`.
+
+## A fix documented in a comment describes the instance, and reads as the class
+
+One change ago the `unsourced-bound:` marker in `tools/check-assertion-bounds.mjs` was hardened
+against three ways a marker can excuse a line it should not: written bare with no reason, appearing
+inside a string literal, appearing in an assertion message. The fix was recorded in a comment on
+that marker, and the comment is completely accurate.
+
+It is also the reason the sibling marker went untreated. `enumeration-fixture`, in a **required
+gate** in the same `tools/` directory, had all three defects. Each reproduced on the first probe: a
+bare marker excused, a marker as string data excused, a marker in prose _about_ the marker excused.
+
+A true sentence about a narrow fix is indistinguishable, at a glance, from a sentence about a
+general one. The prose is not wrong and cannot be made right by editing it — what is missing is a
+second application. The only evidence that a fix generalised is the fix appearing twice.
+
+## The count was 55% not-an-exemption
+
+`countExemptions()` claimed in its docstring that "an exemption cannot grow unseen." It counted
+occurrences of the marker string:
+
+|                       | count |
+| --------------------- | ----- |
+| marker occurrences    | 22    |
+| suppressed a real hit | 10    |
+| decorative            | 12    |
+
+The twelve are prose about the marker, comments explaining the marker, and reflexive markers on
+lines that were never violations. A total that is more than half noise cannot detect composition
+change: a real exemption can be added while a decorative one is deleted, and the number does not
+move.
+
+The remedy already existed **a hundred lines above, in the same file**. `fencedSuppressions()`
+counts hits the exclusion removed, not the excluded population, and this guide carries a section
+arguing for exactly that. It was written one change earlier and was not applied to the adjacent
+function. Proximity is not transfer. The distance at which a lesson fails to travel is smaller than
+a file.
+
+## Print an inventory, not a verdict
+
+A false excuse is invisible because the passing case emits no output. A gate that excuses the wrong
+line reports a number one larger and stays green, and no reader can act on a number.
+
+The counter is to make the yes-branch emit an **inventory**: name every excused line by `file:line`.
+The sibling repository's citation checker does this for its skips, and that disclosure is the only
+reason a defect in its ignore-pragma could be characterised rather than guessed at — its blast
+radius was readable off the output.
+
+This gate now prints its exemptions by name, and the inventory paid for itself on its first run. It
+named `docs/guides/engineering-practice-adoption.md:7121`, a line whose reason was `-->`. The
+hardened check requires a separator and then a reason; `<!-- marker -->` supplies `-` and then `->`,
+so the closing punctuation of the comment carrying the marker satisfied the demand that the marker
+be justified. The line had been silently exempt, and the count that covered it had been correct
+every time it was printed.
+
+Reported exemptions fell from 22 to **10** — not because anything was removed, but because the
+number finally means what its name says.
 
 ## Worth hoisting up
 

--- a/tools/check-citation-enumerations.mjs
+++ b/tools/check-citation-enumerations.mjs
@@ -161,6 +161,36 @@ export function fencedSuppressions(text) {
 }
 
 /**
+ * Decide whether a line carries a usable exemption marker.
+ *
+ * Generalised from `check-assertion-bounds.mjs` (#4313), where the same three defects were found
+ * and fixed for the `unsourced-bound:` marker -- and not carried across to this one. All three
+ * reproduced here unchanged: a bare marker with no reason excused a line, a marker appearing
+ * inside a string literal excused the line containing it, and a passing mention of the marker in
+ * prose excused whatever else was on that line. **A fix documented in a comment describes the
+ * instance that was fixed and reads as describing the class**, which is how one hardened marker
+ * and one unhardened marker sat in the same tree for two PRs.
+ *
+ * A reason is required for the same reason it is required there: an exemption is a claim that
+ * this line is a fixture, and a claim with no argument cannot be reviewed.
+ *
+ * @param {string} line The line.
+ * @returns {boolean} True when the marker is present, outside a string literal, and carries a reason.
+ */
+export function hasExemption(line) {
+  // Strip string literals first: the marker as *data* is a mention, not a claim.
+  const outsideLiterals = line.replace(/'[^']*'|"[^"]*"|`[^`]*`/g, '');
+  const at = outsideLiterals.indexOf(EXEMPTION);
+  if (at === -1) return false;
+  // Drop a trailing comment terminator before looking for a reason. `<!-- enumeration-fixture -->`
+  // otherwise reads as marker + separator + `->`, so the closing punctuation of the comment that
+  // carries the marker satisfies the requirement that the marker be justified. Found by the
+  // inventory added in the same change, on its first run.
+  const rest = outsideLiterals.slice(at + EXEMPTION.length).replace(/(?:-->|\*\/)\s*$/, '');
+  return /^\s*[:-]+\s*[A-Za-z]/.test(rest);
+}
+
+/**
  * Test one line, independent of any fence or file-type decision.
  *
  * Extracted so the included and excluded populations are decided by the *same* predicate. Two
@@ -172,7 +202,7 @@ export function fencedSuppressions(text) {
  * @returns {{line: number, id: string, enumeration: string, text: string}|null} A hit, or null.
  */
 export function enumerationOnLine(line, index) {
-  if (line.includes(EXEMPTION)) return null;
+  if (hasExemption(line)) return null;
   const id = CITATION.exec(line);
   if (!id) return null;
   if (!OBLIGATION.test(line)) return null;
@@ -186,9 +216,36 @@ export function isFenceAware(filePath) {
   return path.extname(filePath).toLowerCase() === '.md';
 }
 
-/** How many lines opted out via the marker. Reported so an exemption cannot grow unseen. */
+/**
+ * List the lines whose exemption marker actually suppressed a violation.
+ *
+ * Counts what the exclusion *removed*, not how often the marker appears -- the rule this file
+ * already applies to `fencedSuppressions` a hundred lines above, and did not apply here. Measured
+ * before the change: 22 marker occurrences, of which **10** suppressed a real hit. The other 12
+ * were prose describing the marker, comments describing the marker, and markers on lines that
+ * were never violations. A count that is 55% not-an-exemption cannot serve its stated purpose of
+ * letting an exemption grow unseen, because one real exemption can be added while one decorative
+ * one is deleted and the total does not move.
+ *
+ * Returned as an inventory rather than a number so composition is visible, not just magnitude.
+ *
+ * @param {string} text File contents.
+ * @returns {number[]} One-based line numbers where the marker suppressed a hit.
+ */
+export function exemptedSuppressions(text) {
+  const lines = text.split(/\r?\n/);
+  const suppressed = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (!hasExemption(lines[i])) continue;
+    const withoutMarker = lines[i].split(EXEMPTION).join('');
+    if (enumerationOnLine(withoutMarker, i)) suppressed.push(i + 1);
+  }
+  return suppressed;
+}
+
+/** How many lines opted out via the marker, counting only those that suppressed a hit. */
 export function countExemptions(text) {
-  return text.split(/\r?\n/).filter((line) => line.includes(EXEMPTION)).length;
+  return exemptedSuppressions(text).length;
 }
 
 async function* walk(directory) {
@@ -270,15 +327,39 @@ export function cleanLine(scanned, exempted, fenced) {
   );
 }
 
+/**
+ * Name every line the exemption marker excused.
+ *
+ * A count says an exemption did not grow; an inventory says which ones they are. The sibling
+ * repository's citation checker prints every skip by name, and that disclosure is the only reason
+ * the blast radius of a defect in its pragma could be characterised rather than guessed at. This
+ * checker printed a bare number, so a wrongly-placed exemption was invisible at any total.
+ *
+ * @param {{file: string, lines: number[]}[]} entries Per-file suppressed lines.
+ * @returns {string[]} Inventory lines, empty when nothing was excused.
+ */
+export function exemptionInventory(entries) {
+  const used = entries.filter((e) => e.lines.length > 0);
+  if (used.length === 0) return [];
+  return [
+    '',
+    `exempted via the "${EXEMPTION}" marker:`,
+    ...used.map((e) => `  ${e.file}:${e.lines.join(',')}`),
+  ];
+}
+
 export async function main(root) {
   const violations = [];
+  const exemptions = [];
   let scanned = 0;
   let exempted = 0;
   let fenced = 0;
   for await (const file of walk(root)) {
     scanned += 1;
     const text = await readFile(file, 'utf8');
-    exempted += countExemptions(text);
+    const lines = exemptedSuppressions(text);
+    exempted += lines.length;
+    if (lines.length > 0) exemptions.push({ file: path.relative(root, file), lines });
     const fenceAware = isFenceAware(file);
     if (fenceAware) fenced += fencedSuppressions(text).length;
     for (const hit of findRestatedEnumerations(text, { fenceAware })) {
@@ -286,13 +367,17 @@ export async function main(root) {
     }
   }
 
+  const inventory = exemptionInventory(exemptions);
+
   if (violations.length > 0) {
-    process.stdout.write(`\n${violationLines(violations, scanned, exempted, fenced).join('\n')}\n`);
+    process.stdout.write(
+      `\n${[...violationLines(violations, scanned, exempted, fenced), ...inventory].join('\n')}\n`,
+    );
     process.exitCode = 1;
     return;
   }
 
-  process.stdout.write(`${cleanLine(scanned, exempted, fenced)}\n`);
+  process.stdout.write(`${[cleanLine(scanned, exempted, fenced), ...inventory].join('\n')}\n`);
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/tools/check-citation-enumerations.test.mjs
+++ b/tools/check-citation-enumerations.test.mjs
@@ -19,6 +19,9 @@ import {
   isFenceAware,
   isScannedFile,
   violationLines,
+  exemptedSuppressions,
+  exemptionInventory,
+  hasExemption,
 } from './check-citation-enumerations.mjs';
 
 // Report-line tests (#4303).
@@ -90,7 +93,7 @@ test('a zero-exemption green result still names the exemption bucket', () => {
 
 test('the defect this was written for is caught', () => {
   const text =
-    'Notably, `ENG-TEST-004` (distinct static signals) requires lint, format, type-check, and tests'; // enumeration-fixture
+    'Notably, `ENG-TEST-004` (distinct static signals) requires lint, format, type-check, and tests'; // enumeration-fixture: input the detector must flag
   const found = findRestatedEnumerations(text);
   assert.equal(found.length, 1);
   assert.equal(found[0].id, 'ENG-TEST-004'); // enumeration-fixture
@@ -138,7 +141,7 @@ test('the closing conjunction is optional', () => {
   // Measured on the same 171 citations as the rejected widenings: allowing a
   // bare "a, b, c" adds reach at no false-positive cost. Pinned so that
   // narrowing it back to a required "and"/"or" fails here.
-  const found = findRestatedEnumerations('`ENG-SEC-001` requires alpha, beta, gamma'); // enumeration-fixture
+  const found = findRestatedEnumerations('`ENG-SEC-001` requires alpha, beta, gamma'); // enumeration-fixture: Oxford-comma-free list under test
   assert.equal(found.length, 1);
   assert.equal(found[0].id, 'ENG-SEC-001'); // enumeration-fixture
 });
@@ -154,19 +157,19 @@ test('a list without a serial comma is a known blind spot, not a pass', () => {
 });
 
 test('the line number is the line of the violation, not of the file', () => {
-  const text = ['first', 'second', '`ENG-SEC-001` requires a, b, and c'].join('\n'); // enumeration-fixture
+  const text = ['first', 'second', '`ENG-SEC-001` requires a, b, and c'].join('\n'); // enumeration-fixture: line number must be 3
   assert.equal(findRestatedEnumerations(text)[0].line, 3);
 });
 
 test('every violation on a line is reported once, not once per matching word', () => {
   const found = findRestatedEnumerations(
-    '`ENG-SEC-001` requires a, b, and c and mandates d, e, and f', // enumeration-fixture
+    '`ENG-SEC-001` requires a, b, and c and mandates d, e, and f', // enumeration-fixture: two enumerations on one line
   ); // enumeration-fixture
   assert.equal(found.length, 1);
 });
 
 test('CRLF input is split the same as LF', () => {
-  const text = 'x\r\n`ENG-SEC-001` requires a, b, and c\r\n'; // enumeration-fixture
+  const text = 'x\r\n`ENG-SEC-001` requires a, b, and c\r\n'; // enumeration-fixture: CRLF line numbering
   assert.equal(findRestatedEnumerations(text)[0].line, 2);
 });
 
@@ -187,7 +190,7 @@ test('only prose and source extensions are scanned', () => {
   assert.ok(SCANNED_EXTENSIONS.has('.md'));
 });
 test('a marked line is exempt and is counted', () => {
-  const text = '`ENG-SEC-001` requires a, b, and c // enumeration-fixture';
+  const text = '`ENG-SEC-001` requires a, b, and c // enumeration-fixture: fixture text'; // enumeration-fixture: marker inside the fixture string is data
   assert.deepEqual(findRestatedEnumerations(text), []);
   assert.equal(countExemptions(text), 1);
   assert.equal(EXEMPTION, 'enumeration-fixture');
@@ -197,8 +200,8 @@ test('exempting one line does not exempt its neighbours', () => {
   // The failure mode a path exclusion would have: one deliberate fixture
   // silently covering a real defect beside it.
   const text = [
-    '`ENG-SEC-001` requires a, b, and c // enumeration-fixture', // enumeration-fixture
-    '`ENG-SEC-002` requires d, e, and f', // enumeration-fixture
+    '`ENG-SEC-001` requires a, b, and c // enumeration-fixture: fixture text', // enumeration-fixture: exempt element beside a live one
+    '`ENG-SEC-002` requires d, e, and f', // enumeration-fixture: the live element of that pair
   ].join('\n');
   const found = findRestatedEnumerations(text);
   assert.equal(found.length, 1);
@@ -220,7 +223,7 @@ test('a failing run states both the scanned and the exempted bucket', () => {
   // enumeration-fixture -- this literal IS a violation, which is the point: a
   // test for an enumeration checker cannot avoid containing an enumeration as
   // data. The exclusion is structural, not a temporary narrowing.
-  const violatingLine = 'ENG-TEST-004 requires type, lint, build, format, and security checks.\n'; // enumeration-fixture
+  const violatingLine = 'ENG-TEST-004 requires type, lint, build, format, and security checks.\n'; // enumeration-fixture: the spawn test's input
   writeFileSync(probe, violatingLine, 'utf8');
   let result;
   try {
@@ -311,7 +314,7 @@ test('both populations are decided by the same predicate', () => {
 });
 
 test('the exemption marker still wins inside and outside a fence', () => {
-  const exempt = `${RESTATEMENT} <!-- ${EXEMPTION} -->`;
+  const exempt = `${RESTATEMENT} <!-- ${EXEMPTION}: illustration, not an obligation -->`;
   assert.equal(enumerationOnLine(exempt, 0), null);
   assert.deepEqual(fencedSuppressions(['```', exempt, '```'].join('\n')), []);
 });
@@ -337,4 +340,76 @@ test('the fenced count moves with its argument on both paths', () => {
   // A count that never varies in a test is indistinguishable from a constant in the template.
   assert.match(cleanLine(1, 0, 7), /7 markdown line/);
   assert.match(violationLines([VIOLATION], 1, 0, 7)[0], /7 markdown line/);
+});
+
+// --- the marker is hardened as a class, not as an instance (#4320) -----------------------------
+//
+// A sibling checker's marker was hardened against three acceptance defects one change earlier. The
+// fix was written as a comment on that marker, and the comment was completely accurate -- which is
+// exactly why it read as describing the class. All three defects survived untreated in this file.
+
+test('a bare marker does not excuse: an exemption must say why', () => {
+  assert.equal(hasExemption(`x // ${EXEMPTION}`), false);
+  assert.equal(hasExemption(`x // ${EXEMPTION}: fixture input`), true);
+  assert.equal(hasExemption(`x // ${EXEMPTION} - fixture input`), true);
+});
+
+test('the marker as string data does not excuse its own file', () => {
+  // The marker appearing as a value is a mention. Treating it as a claim lets any file excuse
+  // itself by quoting the pragma, which is how a checker comes to return green over real hits.
+  assert.equal(hasExemption(`const M = '${EXEMPTION}: not a real exemption';`), false);
+  assert.equal(
+    hasExemption(`const M = "${EXEMPTION}: x"; // ${EXEMPTION}: this one is real`),
+    true,
+  );
+});
+
+test('a comment terminator is not a reason', () => {
+  // `<!-- marker -->` parses as marker, separator `-`, then `->`. The closing punctuation of the
+  // comment carrying the marker satisfied the requirement that the marker be justified. Found by
+  // the inventory below on its first run, in a line that had been exempt for four changes.
+  assert.equal(hasExemption(`x <!-- ${EXEMPTION} -->`), false);
+  assert.equal(hasExemption(`x <!-- ${EXEMPTION}: the quotation under discussion -->`), true);
+  assert.equal(hasExemption(`x /* ${EXEMPTION} */`), false);
+});
+
+test('the marker in unrelated prose does not excuse a real hit', () => {
+  const prose = `${RESTATEMENT} and see the ${EXEMPTION} docs for how to exempt a line`;
+  assert.notEqual(enumerationOnLine(prose, 0), null, 'prose about the marker is not a marker');
+});
+
+test('exemptedSuppressions names what the marker removed, not where it appears', () => {
+  // countExemptions counted marker *occurrences*: 22 in this tree, of which 10 suppressed a real
+  // hit. A count that is 55% not-an-exemption cannot detect composition change, because one real
+  // exemption can be added while a decorative one is deleted. The rule -- count what the exclusion
+  // removed -- was written into fencedSuppressions a hundred lines above, in the same file, one
+  // change earlier, and was not applied here.
+  const text = [
+    `${RESTATEMENT} <!-- ${EXEMPTION}: real -->`,
+    `A sentence mentioning ${EXEMPTION} and nothing else.`,
+    `const M = '${EXEMPTION}';`,
+  ].join('\n');
+  assert.deepEqual(exemptedSuppressions(text), [1]);
+  assert.equal(countExemptions(text), 1, 'three occurrences, one suppression');
+});
+
+test('CONTROL: an exempted line is a line the detector would otherwise report', () => {
+  assert.equal(findRestatedEnumerations(RESTATEMENT).length, 1);
+  assert.deepEqual(exemptedSuppressions(RESTATEMENT), [], 'unmarked, so not an exemption');
+});
+
+test('the inventory names every exempted line by file and line', () => {
+  const lines = exemptionInventory([
+    { file: 'docs/a.md', lines: [7121] },
+    { file: 'tools/b.test.mjs', lines: [93, 141] },
+    { file: 'tools/c.mjs', lines: [] },
+  ]);
+  assert.match(lines.join('\n'), /docs\/a\.md:7121/);
+  assert.match(lines.join('\n'), /tools\/b\.test\.mjs:93,141/);
+  assert.doesNotMatch(lines.join('\n'), /c\.mjs/, 'a file with no exemptions is not listed');
+});
+
+test('the inventory is empty when nothing was excused', () => {
+  // A report that prints a heading over an empty list claims an exclusion happened.
+  assert.deepEqual(exemptionInventory([{ file: 'tools/c.mjs', lines: [] }]), []);
 });


### PR DESCRIPTION
## Summary

One change ago (#4313) the `unsourced-bound:` marker in `tools/check-assertion-bounds.mjs` was
hardened against three acceptance defects, and the fix was recorded in a comment on that marker.
The comment is completely accurate — which is precisely why it read as describing the **class**.

The sibling marker `enumeration-fixture` in `tools/check-citation-enumerations.mjs`, a **required
gate**, had all three untreated. Each reproduced on the first probe:

- a **bare** marker with no reason excused the line;
- the marker inside a **string literal** excused the line;
- the marker in **prose about the marker** excused the line.

## The count could not do its job

`countExemptions()` claimed "an exemption cannot grow unseen" while counting marker *occurrences*:

| | count |
| --- | --- |
| marker occurrences | 22 |
| suppressed a real hit | 10 |
| decorative | 12 |

A total that is **55% not-an-exemption** cannot detect composition change. The remedy —
`fencedSuppressions()`, which counts what the exclusion removed — sits **a hundred lines above in
the same file**, written one change earlier, with a guide section arguing for it. It was not
applied to the adjacent function.

## A count is not an inventory

The report printed a bare number. It now names every exempted line by `file:line` on both the clean
and violating paths. It paid for itself on its **first run**, naming
`docs/guides/engineering-practice-adoption.md:7121`, whose "reason" was `-->` — the closing
punctuation of the comment carrying the marker satisfied the demand that the marker be justified.

Reported exemptions fall 22 → **10**, which now equals the measured load-bearing figure.

## Changes

- `hasExemption()` — strips string literals, drops a trailing `-->` / `*/`, requires a reason.
- `exemptedSuppressions()` / `exemptionInventory()` — count and name suppressed hits.
- 10 load-bearing markers given reasons; 2 pre-existing tests updated to the new contract.
- 9 new tests, including two negative controls.

## Issues

Closes #4320

## Testing

- [x] `npm run format:check` — clean
- [x] `npx eslint . --max-warnings 0` — clean
- [x] `npm run type-check` — clean
- [x] `node tools/run-tool-tests.mjs` — **657/657**
- [x] All **15** gate scripts — pass