### PR TITLE
chore(tools): census independent fence predicates (#4322)

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -161,6 +161,13 @@ jobs:
       # from the artifact that already commits to the number, or annotated with why none does.
       - name: Every numeric bound names its source
         run: npm run bounds:check
+
+      # A shared primitive is the one that is imported, and importer count cannot detect a fourth
+      # authoring: it reads green on a tree with nothing to import, and it reads a forced hand
+      # (CommonJS cannot load the ESM owner) as a decision not to reuse. This censuses independent
+      # implementations instead, which needs no extraction to have happened first.
+      - name: One definition of a markdown fence
+        run: npm run markdown:primitives:check
   pr-title:
     name: Semantic PR Title
     needs: changes

--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -9479,6 +9479,69 @@ every time it was printed.
 Reported exemptions fell from 22 to **10** — not because anything was removed, but because the
 number finally means what its name says.
 
+## Importer count reads green on a tree with nothing to import
+
+Consolidating the fence guard into `tools/lib/markdown.mjs` fixed the three independent authorings
+that existed, and the metric that justified it was importer count: a shared primitive is not the
+one that _could_ be imported, it is the one that is. That metric cannot prevent a fourth authoring,
+for two reasons that only became visible when a sibling repository ran the same check.
+
+**It is a ratio whose denominator is "modules someone extracted."** A tree that never extracted
+anything scores perfectly while being maximally duplicated. The sibling measured 18 exporting
+modules, 10 exported to their own test and nothing else, and no shared directory at all — so the
+state "exported, tested, imported by nobody" could not arise there, because there was nothing
+anyone could have imported. The metric is only meaningful where extraction has already been
+attempted, and it reads as green where it has not.
+
+**It reads a forced hand as a free choice.** Measured here: 36 of the scripts under `tools/` and
+`scripts/` are CommonJS, and the shared primitive is ESM. `require()` cannot load it. Those files
+do not import the guard because they _cannot_, and an importer census records that as a decision
+not to reuse.
+
+The check that catches a fourth authoring is not "who imports the shared module" but **how many
+independent implementations of this predicate exist** — a duplication census, which needs no prior
+extraction and does not care why a file failed to import.
+
+## The census found one immediately, and my first census missed it
+
+Running it by hand found `tools/check-ai-manifest.js` — a **required gate** — carrying its own
+fence toggle at two sites, recognising ``` and not `~~~` where the shared definition recognises
+both. Tilde fences in the tree today: **0**. So the divergence is latent, and it is exactly the
+shape a second definition always has: correct until a document uses the delimiter the copy does not
+recognise, with no test failing in between.
+
+The first census I ran reported **zero**. It globbed `tools\*.mjs` and `tools\lib\*.mjs`, which
+silently excluded every `.js` file — the one extension the finding was in. That is the fourth
+consecutive round in which a pre-census filter went unstated, and this time it was in a number I
+had already reported as a clean result in the same message. The filter is never the interesting
+part, which is precisely why it is never disclosed.
+
+## A guard propagates along the corpus, not along the rule
+
+The causal account, which the sibling established and which holds here: each author of a fence
+guard either was corrected by their own fixture or was not. The tool scanning documents that
+contain fenced examples grows the guard; the tool scanning documents that happen not to, never
+learns it needs one. Nobody decides the rule is narrow — the rule is simply never observed to fail.
+
+So the guard's presence tracks the corpus, and the corpus is a fixture nobody chose. This also
+applies to _scope_, not just presence. Fence-awareness here is scoped by path — `.md` only, because
+a triple backtick in `.mjs` is a comment rather than a delimiter. Measured: non-`.md` scanned files
+containing a fence-opening line, **0**; markdown-variant extensions in the tree (`.mdx`,
+`.markdown`), **0**. The path scoping is exact — today, and because the corpus complies, not
+because anyone verified that it must. The rule's real applicability is "markdown that quotes
+markdown," which is a property of content that no file extension carries.
+
+## The second application is the evidence
+
+One change earlier the `enumeration-fixture` marker was hardened to require a reason, and the
+lesson recorded was that a fix documented in a comment describes the instance and reads as
+describing the class. The new census has an allowlist — `check-ai-manifest.js` cannot import the
+owner — and every allowlist entry is required to carry the reason it cannot, asserted by a test,
+written at authoring time rather than a round later.
+
+That is not a stronger statement of the lesson. It is the only kind of evidence the lesson admits:
+a fix appearing twice.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "tools:test": "node tools/run-tool-tests.mjs",
     "gate:enforcement": "node tools/check-gate-enforcement.mjs",
     "bounds:check": "node tools/check-assertion-bounds.mjs",
+    "markdown:primitives:check": "node tools/check-markdown-primitives.mjs",
     "docs:links:check": "node tools/check-doc-links.mjs",
     "docs:links:test": "node --test tools/check-doc-links.test.mjs"
   },

--- a/tools/check-markdown-primitives.mjs
+++ b/tools/check-markdown-primitives.mjs
@@ -1,0 +1,202 @@
+#!/usr/bin/env node
+/**
+ * Fails when a tool detects markdown fence delimiters without using the shared primitive (#4322).
+ *
+ * `tools/lib/markdown.mjs` exists because the same fence guard was written three separate times in
+ * this repository, each time after the author's own corpus bit them. Consolidating it fixed the
+ * three that existed. Nothing prevented a fourth.
+ *
+ * The metric that was supposed to prevent it -- how many importers the shared module has -- cannot,
+ * for two reasons that only became visible when a sibling repository ran the same check and scored
+ * perfectly while being maximally duplicated:
+ *
+ * 1. **Importer count reads green on a tree with nothing to import.** It is a ratio whose
+ *    denominator is "modules someone extracted", so a tree that never extracted anything scores
+ *    100%. The metric is only meaningful where extraction has already been attempted.
+ * 2. **It reads a forced hand as a free choice.** 36 files under `tools/` and `scripts/` are
+ *    CommonJS, and the shared primitive is ESM. They do not import it because they *cannot*. A
+ *    census of importers records that as a decision not to reuse.
+ *
+ * The check that catches a fourth authoring is not "who imports the shared module" but "how many
+ * independent implementations of this predicate exist" -- a duplication census, which needs no
+ * extraction to have happened first and does not care why a file failed to import.
+ *
+ * It found one immediately: `tools/check-ai-manifest.js`, a required gate, carries its own fence
+ * toggle that recognises ``` and not ~~~, where the shared definition recognises both.
+ *
+ * Why a fourth authoring was inevitable rather than careless: a guard propagates along the
+ * *corpus*, not along the rule. Each author either was corrected by their own fixture or was not,
+ * so a tool scanning documents that happen to contain no fenced example never learns it needs the
+ * guard. Nobody decides the rule is narrow; the rule is simply never observed to fail.
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/** Directories whose scripts are scanned. */
+export const SCANNED_DIRECTORIES = ['tools', 'scripts'];
+
+/** The module that is allowed to define the fence predicate. */
+export const OWNER = path.join('tools', 'lib', 'markdown.mjs');
+
+/**
+ * Files permitted to carry their own fence predicate, each with the reason it cannot use the owner.
+ *
+ * A bare allowlist is an exemption with no reason, which is the defect this repository hardened the
+ * `enumeration-fixture` marker against one change earlier. That fix was written as a comment on
+ * that marker and read as describing the class; it did not travel one file over. Applying it here,
+ * at authoring time rather than a round later, is the only evidence that the lesson generalised --
+ * a fix appearing twice is the whole of the evidence that it was ever about the class.
+ *
+ * @type {Record<string, string>}
+ */
+export const ALLOWED = {
+  [path.join('tools', 'check-ai-manifest.js')]:
+    'CommonJS: require() cannot load the ESM owner, and the fence toggle is embedded in a ' +
+    'line-reflow algorithm rather than used as a standalone predicate',
+};
+
+// Assembled rather than written out: this file is scanned by itself, and a literal fence delimiter
+// in the source would make the census report its own patterns. The same reason the enumeration
+// gate's fixture ID is built from parts.
+const TICK = String.fromCharCode(96).repeat(3);
+const TILDE = '~'.repeat(3);
+const RUN = `(?:${TICK}|${TILDE})`;
+
+/** Constructs that mean "this line opens or closes a fenced block". */
+const SIGNATURES = [
+  // An anchored regex literal that tests for a fence run.
+  new RegExp(`/\\^[^/\\n]*${RUN}`),
+  // A string test against a fence run.
+  new RegExp(`\\.startsWith\\(\\s*['"\`]\\s*${RUN}`),
+];
+
+/** True when the path is a script this census reads. */
+export function isScannedFile(name) {
+  const text = String(name ?? '');
+  return /\.(mjs|cjs|js)$/.test(text) && !/\.test\.(mjs|cjs|js)$/.test(text);
+}
+
+/**
+ * The one-based line numbers on which a file defines a fence predicate.
+ *
+ * Reported as line numbers rather than a count, because a count cannot be acted on: a reader
+ * shown "3 implementations" cannot go and look at them, and a number is never wrong in a way that
+ * is visible. Every exclusion and every finding in this tool is named.
+ *
+ * @param {string} text File contents.
+ * @returns {number[]} One-based line numbers, ascending.
+ */
+export function fencePredicateLines(text) {
+  const found = [];
+  String(text)
+    .split(/\r?\n/)
+    .forEach((line, index) => {
+      if (SIGNATURES.some((signature) => signature.test(line))) found.push(index + 1);
+    });
+  return found;
+}
+
+/** Recursively enumerate scanned scripts from disk, never from a shell glob. */
+export function collectScripts(root) {
+  const out = [];
+  const skippedTests = [];
+  const walk = (dir) => {
+    let entries;
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      return;
+    }
+    for (const entry of entries.sort()) {
+      if (entry === 'node_modules' || entry.startsWith('.')) continue;
+      const full = path.join(dir, entry);
+      if (statSync(full).isDirectory()) walk(full);
+      else if (isScannedFile(entry)) out.push(full);
+      else if (/\.test\.(mjs|cjs|js)$/.test(entry)) skippedTests.push(full);
+    }
+  };
+  for (const dir of SCANNED_DIRECTORIES) walk(path.join(root, dir));
+  out.skippedTests = skippedTests;
+  return out;
+}
+
+/**
+ * Partition every fence predicate in the tree into owner, allowed, and unowned.
+ *
+ * @param {{file: string, lines: number[]}[]} sites Per-file predicate locations.
+ * @returns {{owner: object[], allowed: object[], unowned: object[]}} The three populations.
+ */
+export function classify(sites) {
+  const owner = [];
+  const allowed = [];
+  const unowned = [];
+  for (const site of sites) {
+    if (site.file === OWNER) owner.push(site);
+    else if (Object.hasOwn(ALLOWED, site.file)) allowed.push(site);
+    else unowned.push(site);
+  }
+  return { owner, allowed, unowned };
+}
+
+/**
+ * The full census, named rather than counted, on both the passing and failing path.
+ *
+ * A gate that prints only on failure cannot be audited when it passes, and a wrongly-allowed
+ * implementation is exactly the case that passes. The allowed population is printed with its
+ * stated reason so a reader can judge the reason rather than trust that one exists.
+ *
+ * @param {{owner: object[], allowed: object[], unowned: object[]}} groups Partitioned sites.
+ * @param {number} scanned How many scripts were read.
+ * @returns {string[]} Report lines.
+ */
+export function censusLines(groups, scanned, skippedTests = 0) {
+  const total = groups.owner.length + groups.allowed.length + groups.unowned.length;
+  const lines = [
+    `Fence-predicate census: ${total} implementation(s) across ${scanned} script(s) scanned, ` +
+      `${skippedTests} test file(s) not scanned. A test for a fence checker contains fence ` +
+      'delimiters as data, so scanning tests would report the fixtures; the number is stated ' +
+      'rather than left implied, because a denominator a reader cannot see is one they cannot ' +
+      'judge.',
+  ];
+  const name = (site) => `  ${site.file}:${site.lines.join(',')}`;
+  if (groups.owner.length > 0) lines.push('owner:', ...groups.owner.map(name));
+  if (groups.allowed.length > 0) {
+    lines.push('allowed, with the reason it cannot use the owner:');
+    for (const site of groups.allowed) {
+      lines.push(name(site), `    ${ALLOWED[site.file]}`);
+    }
+  }
+  if (groups.unowned.length > 0) {
+    lines.push(
+      '',
+      `Independent fence predicate(s) outside ${OWNER}:`,
+      ...groups.unowned.map(name),
+      '',
+      `Import { FENCE, markFences } from ${OWNER} instead. A second definition of "what is a`,
+      'fenced block" diverges silently: it is correct until a document uses the delimiter the',
+      'copy does not recognise, and no test fails in between. If the file cannot import the',
+      `owner -- CommonJS cannot load ESM -- add it to ALLOWED with the reason, so the constraint`,
+      'is recorded where the next reader will look rather than rediscovered.',
+    );
+  }
+  return lines;
+}
+
+export function main(root) {
+  const scripts = collectScripts(root);
+  const sites = [];
+  for (const file of scripts) {
+    const lines = fencePredicateLines(readFileSync(file, 'utf8'));
+    if (lines.length > 0) sites.push({ file: path.relative(root, file), lines });
+  }
+  const groups = classify(sites);
+  process.stdout.write(
+    `${censusLines(groups, scripts.length, scripts.skippedTests.length).join('\n')}\n`,
+  );
+  if (groups.unowned.length > 0) process.exitCode = 1;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main(process.argv[2] ? path.resolve(process.argv[2]) : process.cwd());
+}

--- a/tools/check-markdown-primitives.test.mjs
+++ b/tools/check-markdown-primitives.test.mjs
@@ -1,0 +1,182 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, rmdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import {
+  ALLOWED,
+  OWNER,
+  SCANNED_DIRECTORIES,
+  censusLines,
+  classify,
+  collectScripts,
+  fencePredicateLines,
+  isScannedFile,
+} from './check-markdown-primitives.mjs';
+
+// The fence delimiters below are assembled, for the same reason the tool assembles its own: a
+// literal run in this file would be scanned as a predicate by the tool it tests.
+const TICK = String.fromCharCode(96).repeat(3);
+const TILDE = '~'.repeat(3);
+
+test('an anchored regex testing for a fence run is a predicate', () => {
+  assert.deepEqual(fencePredicateLines(`const F = /^\\s*${TICK}/;`), [1]);
+  assert.deepEqual(fencePredicateLines(`const F = /^\\s*(?:${TICK}|${TILDE})/;`), [1]);
+});
+
+test('a startsWith test against a fence run is a predicate', () => {
+  assert.deepEqual(fencePredicateLines(`if (line.startsWith('${TICK}')) toggle();`), [1]);
+});
+
+test('CONTROL: a fence delimiter that is not used as a predicate is not reported', () => {
+  // Without this the detector could be matching the delimiter alone, which appears in every
+  // fixture and most prose, and the census would be a count of documents rather than of code.
+  assert.deepEqual(fencePredicateLines(`const doc = ['${TICK}md', 'x', '${TICK}'].join('n');`), []);
+  assert.deepEqual(fencePredicateLines(`// a ${TICK} block is an illustration`), []);
+});
+
+test('line numbers are one-based and every occurrence is named', () => {
+  const text = ['const a = 1;', `const F = /^${TICK}/;`, 'const b = 2;', `x.startsWith('${TILDE}')`]
+    .join('\n')
+    .replace('x.startsWith', 'line.startsWith');
+  assert.deepEqual(fencePredicateLines(text), [2, 4]);
+});
+
+test('the owner is not reported as a duplicate', () => {
+  const { owner, unowned } = classify([{ file: OWNER, lines: [25] }]);
+  assert.equal(owner.length, 1);
+  assert.equal(unowned.length, 0);
+});
+
+test('an allowlisted file is separated from an unowned one', () => {
+  const allowedFile = Object.keys(ALLOWED)[0];
+  const groups = classify([
+    { file: allowedFile, lines: [337] },
+    { file: path.join('tools', 'invented.mjs'), lines: [9] },
+  ]);
+  assert.equal(groups.allowed.length, 1);
+  assert.equal(groups.unowned.length, 1);
+});
+
+test('every allowlist entry states why it cannot use the owner', () => {
+  // A bare allowlist is an exemption with no reason -- the defect hardened out of the
+  // enumeration-fixture marker one change earlier. That fix was recorded in a comment which read
+  // as describing the class and did not travel one file over. This assertion is the second
+  // application, which is the only evidence the lesson was ever about the class.
+  const entries = Object.entries(ALLOWED);
+  assert.ok(entries.length > 0, 'the allowlist is non-empty, so the rule is exercised');
+  for (const [file, reason] of entries) {
+    assert.match(reason, /[A-Za-z]{4,}/, `${file} has a reason`);
+    // unsourced-bound: nothing in the tree commits to a minimum reason length, and inventing a
+    // threshold here would be the defect this repository's bounds gate exists to catch. The bound
+    // is a floor against an empty or one-word placeholder, not a measure of quality; the reason is
+    // judged by a reader, which is why the census prints it rather than only asserting it exists.
+    assert.ok(reason.length > 20, `${file}'s reason says something specific`);
+  }
+});
+
+test('the census names every implementation, on the passing path too', () => {
+  // A gate that prints only on failure cannot be audited when it passes, and a wrongly-allowed
+  // implementation is exactly the case that passes.
+  const allowedFile = Object.keys(ALLOWED)[0];
+  const out = censusLines(
+    classify([
+      { file: OWNER, lines: [25] },
+      { file: allowedFile, lines: [337, 370] },
+    ]),
+    68,
+    17,
+  ).join('\n');
+  assert.match(out, /2 implementation\(s\) across 68 script\(s\)/);
+  assert.match(out, /17 test file\(s\) not scanned/);
+  assert.match(out, /337,370/, 'the allowed lines are named, not counted');
+  assert.match(
+    out,
+    new RegExp(ALLOWED[allowedFile].slice(0, 20).replace(/[(){}[\]*+?.\\^$|]/g, '\\$&')),
+  );
+});
+
+test('the report counts move with their arguments', () => {
+  // A number that never varies in a test is indistinguishable from a constant in the template --
+  // reproduced twice in this repository, both times in a report parameter nothing asserted.
+  const groups = classify([{ file: OWNER, lines: [25] }]);
+  assert.match(censusLines(groups, 5, 1)[0], /across 5 script\(s\) scanned, 1 test file/);
+  assert.match(censusLines(groups, 9, 4)[0], /across 9 script\(s\) scanned, 4 test file/);
+});
+
+test('an unowned implementation produces the remedy, naming the owner', () => {
+  const out = censusLines(classify([{ file: path.join('tools', 'x.mjs'), lines: [9] }]), 1, 0).join(
+    '\n',
+  );
+  assert.match(out, /Independent fence predicate\(s\)/);
+  assert.match(out, /tools[\\/]x\.mjs:9/);
+  assert.match(out, /CommonJS cannot load ESM/, 'the forced case is offered, not just the fix');
+});
+
+test('tests are excluded from the population and counted', () => {
+  assert.equal(isScannedFile('check-x.mjs'), true);
+  assert.equal(
+    isScannedFile('check-x.js'),
+    true,
+    'CommonJS is scanned: it is the forced-copy case',
+  );
+  assert.equal(isScannedFile('check-x.test.mjs'), false, 'a fence test contains fences as data');
+  assert.equal(isScannedFile('notes.md'), false);
+});
+
+test('both script directories are censused', () => {
+  // scripts/ is where the CommonJS tools live, which is the population that structurally cannot
+  // import the ESM owner. Censusing only tools/ would exclude the reason the allowlist exists.
+  assert.deepEqual([...SCANNED_DIRECTORIES].sort(), ['scripts', 'tools']);
+});
+
+test('scripts are enumerated from disk, recursively, and the gate fires on a real tree', () => {
+  // The end-to-end negative control: the census is only worth having if an added reimplementation
+  // is actually caught. Asserting the classifier alone would pass on a walker that finds nothing.
+  const root = mkdtempSync(path.join(tmpdir(), 'mdprim-'));
+  const made = [];
+  const write = (rel, body) => {
+    const full = path.join(root, rel);
+    mkdirSync(path.dirname(full), { recursive: true });
+    writeFileSync(full, body);
+    made.push(full);
+    return full;
+  };
+  try {
+    write(path.join('tools', 'clean.mjs'), 'export const x = 1;\n');
+    write(path.join('tools', 'nested', 'dup.mjs'), `const F = /^\\s*${TICK}/;\n`);
+    write(path.join('tools', 'dup.test.mjs'), `const F = /^\\s*${TICK}/;\n`);
+    write(path.join('scripts', 'clean.js'), 'module.exports = {};\n');
+
+    const scripts = collectScripts(root);
+    const names = scripts.map((f) => path.relative(root, f));
+    assert.ok(names.includes(path.join('tools', 'nested', 'dup.mjs')), 'walks subdirectories');
+    assert.ok(names.includes(path.join('scripts', 'clean.js')), 'walks every scanned directory');
+    assert.equal(scripts.skippedTests.length, 1, 'the excluded test is counted, not discarded');
+    assert.ok(!names.some((n) => n.endsWith('.test.mjs')));
+
+    const sites = scripts
+      .map((f) => ({
+        file: path.relative(root, f),
+        lines: fencePredicateLines(readFileSync(f, 'utf8')),
+      }))
+      .filter((s) => s.lines.length > 0);
+    const groups = classify(sites);
+    assert.equal(groups.unowned.length, 1, 'the added reimplementation is caught');
+    assert.equal(groups.unowned[0].file, path.join('tools', 'nested', 'dup.mjs'));
+    assert.match(censusLines(groups, scripts.length, 1).join('\n'), /Independent fence predicate/);
+  } finally {
+    // Removed by name, innermost first: an empty directory is removed with rmdir, never with a
+    // recursive delete. A cleanup that reaches for -rf is one typo from the wrong subtree.
+    for (const full of made) rmSync(full, { force: true });
+    for (const dir of [
+      path.join(root, 'tools', 'nested'),
+      path.join(root, 'tools'),
+      path.join(root, 'scripts'),
+      root,
+    ]) {
+      rmdirSync(dir);
+    }
+  }
+});


### PR DESCRIPTION
## Summary

`tools/lib/markdown.mjs` was extracted (#4315) because the fence guard had been written **three**
times independently. The metric that justified it — **importer count** — cannot prevent a fourth,
and a census found one already present.

## Why importer count cannot catch this

1. **Its denominator is "modules someone extracted."** A tree that never extracted anything scores
   perfectly while being maximally duplicated.
2. **It reads a forced hand as a free choice.** Measured: **36** of the scripts under `tools/` and
   `scripts/` are CommonJS; the owner is ESM. `require()` cannot load it. They do not import the
   guard because they **cannot**.

A **duplication census** needs no prior extraction and does not care why a file failed to import.

## What it found

`tools/check-ai-manifest.js` — a **required gate** — carries its own fence toggle at two sites,
recognising backtick fences and not tilde fences, where the shared definition recognises both.

- Tilde-fence lines in the tree: **0**, so the divergence is **latent**.
- It is CommonJS, so the duplication is enforced by the module system, not chosen. It is
  allowlisted **with that reason recorded**, not silently.

## My first census was wrong

It reported **zero**. It globbed `tools\*.mjs` and silently excluded every `.js` file — the one
extension the finding was in. Fourth consecutive round with an unstated pre-census filter.

## Why a fourth authoring was inevitable

A guard propagates along the **corpus**, not the rule: each author was either corrected by their
own fixture or was not. The same applies to *scope* — fence-awareness is scoped by path (`.md`
only). Measured: non-`.md` scanned files with a fence-opening line **0**; `.mdx`/`.markdown` files
**0**. Exact today because the corpus complies, not because anyone verified it must.

## Changes

- New gate `tools/check-markdown-primitives.mjs`, **wired** as `markdown:primitives:check` in
  `ci-lint.yml` — a script is not a gate.
- Prints a **named census on the passing path too**, with the skipped-test denominator disclosed.
- Allowlist entries must state why they cannot use the owner, asserted by a test — the second
  application of #4320's lesson, which is the only evidence it was about the class.
- 12 tests including an end-to-end negative control that an added reimplementation is caught.
- The repo's own `bounds:check` caught an invented `> 20` in my new test; annotated honestly.

## Issues

Closes #4322

## Testing

- [x] `npm run format:check` — clean
- [x] `npx eslint . --max-warnings 0` — clean
- [x] `npm run type-check` — clean
- [x] `node tools/run-tool-tests.mjs` — **672/672**
- [x] All **16** gate scripts — pass (new gate reached by `gate:enforcement`)