### PR TITLE
fix(tools): disclose wired tools absent from the assertion cross-tabulation

### DIFF
--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -9542,6 +9542,60 @@ written at authoring time rather than a round later.
 That is not a stronger statement of the lesson. It is the only kind of evidence the lesson admits:
 a fix appearing twice.
 
+### Absence is not a score (#4324)
+
+`tools/check-report-assertions.mjs` publishes a wiring x assertion cross-tabulation. Its per-tool
+table is keyed by mutated site, so a wired tool that produced no site never enters the map and
+appears in **no row and no quadrant** — rendered identically to a tool that was measured and
+scored well. The sibling `jrmoulckers/engineering` session found the same class by a different
+route: their report-site boundary excluded whole files, so three tools entered a per-tool ratio as
+`0/0`, one of them the most unambiguously wired tool in their repo.
+
+**Their transferable test, run against finance.** Are the omissions per-site or per-file? Measured
+against finance's actual pre-#4319 boundary:
+
+```
+old 457  new 463  delta +6
+files with sites: old 25, new 25
+per-file omissions (tool invisible under old defn):  0
+per-site omissions (file counted, sites missed):     4
+```
+
+**Measured negative.** finance's #4319 widening was purely per-site; no tool was ever invisible
+because of the site definition. The hole here has a different cause, and finding it required
+abandoning their diagnosis rather than confirming it.
+
+**The actual cause: two populations, different boundaries, silently joined.** `wiredTools()` spans
+`.mjs` and `.js`; the sweep measures `.mjs` files _that have a colocated test_. Of 24 wired tools,
+**11 produce no row**:
+
+| reason                                     | count |
+| ------------------------------------------ | ----- |
+| CommonJS — outside the measured population | 7     |
+| no colocated test file — never mutated     | 4     |
+
+The published quadrants had a wired denominator of **13**, not 24, and nothing in the output said
+so.
+
+**Four of them are instrument-independent findings.** `check-text-encoding.mjs`,
+`check-web-performance-budget.mjs`, `run-citations-check.mjs` and `verify-build-env.mjs` are wired
+into CI and have **no test file anywhere in the tree**. `check-text-encoding.mjs` backs the
+`encoding:check` gate. That needs no ratio, no site definition, and no sweep to state — which is
+why it survives every instrument failure above. A result that uses no population cannot be
+invalidated by the population being wrong.
+
+**The fix is the inventory discipline from #4320**, applied to the yes-branch rather than the
+no-branch: print every absent wired tool **by name with its reason**, and state the denominator
+the quadrants used. A count cannot be wrong in a way a reader can see; a name can.
+
+**Self-correction.** The issue filed for this work classified `run-citations-check.mjs` as
+"zero report sites". It is not — it has no test file and was never in the measured population at
+all. The misclassification came from my probe using `.mjs` non-test as the population while the
+sweep uses `.mjs`-with-tests. **The disclosure block corrected its author's own filed diagnosis on
+its first render**, which is the second time an inventory has done that (the first was #4321,
+where the reason `-->` surfaced on run one). A verdict cannot do this. Only an itemisation can, and
+that is now twice observed rather than argued.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:

--- a/tools/check-report-assertions.mjs
+++ b/tools/check-report-assertions.mjs
@@ -289,6 +289,7 @@ export function measure(options = {}) {
   return {
     tools: tools.length - skippedRed.length,
     allTools,
+    measured: tools,
     caught,
     survivors,
     unmeasurable,
@@ -347,7 +348,42 @@ export function wiredTools(fsImpl = fs) {
     for (const match of body.matchAll(/tools\/([\w.-]+\.(?:mjs|js))/g)) wired.add(match[1]);
   }
   for (const match of workflows.matchAll(/tools\/([\w.-]+\.(?:mjs|js))/g)) wired.add(match[1]);
+  // `[\w.-]+` admits dots, so `node --test tools/x.test.mjs` registered the test file as a wired
+  // tool. A test file is not a tool; it inflated the wired set by 5 without adding a measurable.
+  for (const name of [...wired]) if (name.endsWith('.test.mjs')) wired.delete(name);
   return wired;
+}
+
+/**
+ * Classify wired tools that produced no row in the per-tool table.
+ *
+ * The table is keyed by mutated site, so a tool with no report sites never enters it. That is
+ * indistinguishable in the output from a tool that was measured and scored well -- three distinct
+ * situations rendered as one silence. Naming them is the only way a reader can tell which.
+ *
+ * @param {Set<string>} wired Tools invoked by a workflow.
+ * @param {Set<string>} scored Tool filenames that produced at least one measured site.
+ * @param {string[]} measured Tool filenames the sweep actually mutated (those with a test file).
+ * @param {string[]} [skippedRed] Tool filenames skipped for a red baseline.
+ * @returns {{tool: string, reason: string}[]} One entry per absent wired tool, sorted by name.
+ */
+export function absentWiredTools(wired, scored, measured, skippedRed = []) {
+  const inPopulation = new Set(measured);
+  const red = new Set(skippedRed);
+  const out = [];
+  for (const tool of wired) {
+    if (scored.has(tool)) continue;
+    if (!tool.endsWith('.mjs')) {
+      out.push({ tool, reason: 'CommonJS -- outside the measured population' });
+    } else if (red.has(tool)) {
+      out.push({ tool, reason: 'red baseline -- skipped, every mutant would look caught' });
+    } else if (inPopulation.has(tool)) {
+      out.push({ tool, reason: 'zero report sites -- nothing to mutate' });
+    } else {
+      out.push({ tool, reason: 'no colocated test file -- never mutated' });
+    }
+  }
+  return out.sort((a, b) => a.tool.localeCompare(b.tool));
 }
 
 /**
@@ -363,7 +399,7 @@ export function wiredTools(fsImpl = fs) {
  * @param {Set<string>} wired Tools invoked by a workflow.
  * @returns {string[]} Report lines.
  */
-export function perToolLines(result, wired) {
+export function perToolLines(result, wired, measured = []) {
   const per = new Map();
   const tally = (labels, key) => {
     for (const label of labels) {
@@ -396,9 +432,10 @@ export function perToolLines(result, wired) {
   }
   const quadrant = (isWired, isAsserted) =>
     rows.filter((r) => r.wired === isWired && r.pct >= 50 === isAsserted).length;
+  const wiredRows = rows.filter((r) => r.wired).length;
   lines.push(
     '',
-    'wiring x assertion (asserted = >=50% of sites):',
+    `wiring x assertion (asserted = >=50% of sites; wired denominator ${wiredRows}):`,
     `  gate,  asserted    ${quadrant(true, true)}`,
     `  gate,  unasserted  ${quadrant(true, false)}`,
     `  inert, asserted    ${quadrant(false, true)}`,
@@ -406,6 +443,17 @@ export function perToolLines(result, wired) {
     'A populated off-diagonal means these are independent properties, not one judgement:',
     'a tool can be well-tested and never run, or run on every push and assert nothing.',
   );
+  const absent = absentWiredTools(wired, new Set(per.keys()), measured, result.skippedRed ?? []);
+  if (absent.length > 0) {
+    lines.push(
+      '',
+      `${absent.length} wired tool(s) produced no row above and are in no quadrant.`,
+      'Absence here is not a score. Each is named with why it could not be measured:',
+      ...absent.map((a) => `  ${a.tool.padEnd(38)}${a.reason}`),
+      `The wired denominator ${wiredRows} therefore excludes these; a table that omitted them`,
+      'silently would report the same quadrants while describing a smaller population.',
+    );
+  }
   return lines;
 }
 
@@ -455,7 +503,7 @@ function main() {
   for (const line of scopeLines(result)) console.log(line);
   console.log('');
   console.log(elapsedLine(Date.now() - started));
-  for (const line of perToolLines(result, wiredTools())) console.log(line);
+  for (const line of perToolLines(result, wiredTools(), result.measured)) console.log(line);
   for (const line of survivorLines(result.survivors)) console.log(line);
 }
 

--- a/tools/check-report-assertions.test.mjs
+++ b/tools/check-report-assertions.test.mjs
@@ -3,6 +3,7 @@ import test from 'node:test';
 
 import {
   DEFAULT_SENTINEL,
+  absentWiredTools,
   buildsReport,
   measure,
   mutateSite,
@@ -417,4 +418,81 @@ test('the disclosed residue moves with its input', () => {
 test('scopeLines says nothing about residue when there is none', () => {
   const lines = scopeLines({ ...baseResult, unclassified: 0 }).join('\n');
   assert.doesNotMatch(lines, /not classified/, 'a zero exclusion is not a caveat');
+});
+
+// Absent-wired-tool disclosure (#4324).
+
+test('absentWiredTools names a wired tool that produced no measured site', () => {
+  const absent = absentWiredTools(new Set(['a.mjs', 'z.mjs']), new Set(['a.mjs']), [
+    'a.mjs',
+    'z.mjs',
+  ]);
+  assert.deepEqual(
+    absent.map((a) => a.tool),
+    ['z.mjs'],
+  );
+  assert.match(absent[0].reason, /zero report sites/);
+});
+
+test('absentWiredTools separates the four reasons a wired tool can be missing', () => {
+  const absent = absentWiredTools(
+    new Set(['scored.mjs', 'zero.mjs', 'untested.mjs', 'red.mjs', 'legacy.js']),
+    new Set(['scored.mjs']),
+    ['scored.mjs', 'zero.mjs', 'red.mjs'],
+    ['red.mjs'],
+  );
+  const byTool = Object.fromEntries(absent.map((a) => [a.tool, a.reason]));
+  assert.equal(Object.keys(byTool).length, 4);
+  assert.match(byTool['zero.mjs'], /zero report sites/);
+  assert.match(byTool['untested.mjs'], /no colocated test file/);
+  assert.match(byTool['red.mjs'], /red baseline/);
+  assert.match(byTool['legacy.js'], /CommonJS/);
+});
+
+test('a wired tool with zero sites is distinguishable from a fully-asserted one', () => {
+  // The negative control. Before #4324 both rendered as absence from the table, so this pair of
+  // renders had to differ for the disclosure to carry any information at all.
+  const wired = new Set(['a.mjs', 'zero.mjs']);
+  const withZero = perToolLines(CROSS, wired, ['a.mjs', 'b.mjs', 'c.mjs', 'zero.mjs']).join('\n');
+  const withoutZero = perToolLines(CROSS, new Set(['a.mjs']), ['a.mjs', 'b.mjs', 'c.mjs']).join(
+    '\n',
+  );
+  assert.match(withZero, /zero\.mjs/);
+  assert.doesNotMatch(withoutZero, /zero\.mjs/);
+  assert.notEqual(withZero, withoutZero);
+});
+
+test('perToolLines states the wired denominator its quadrants used', () => {
+  const lines = perToolLines(CROSS, new Set(['a.mjs', 'c.mjs']), []).join('\n');
+  assert.match(lines, /wired denominator 2/);
+});
+
+test('perToolLines emits no disclosure block when every wired tool has a row', () => {
+  const lines = perToolLines(CROSS, new Set(['a.mjs', 'b.mjs']), ['a.mjs', 'b.mjs']).join('\n');
+  assert.doesNotMatch(lines, /produced no row above/);
+});
+
+test('the disclosure counts what it lists, so the number cannot drift from the names', () => {
+  const wired = new Set(['a.mjs', 'zero.mjs', 'legacy.js']);
+  const lines = perToolLines(CROSS, wired, ['a.mjs', 'zero.mjs']);
+  const header = lines.find((l) => /produced no row above/.test(l));
+  const stated = Number(header.match(/^(\d+) wired/)[1]);
+  const named = absentWiredTools(wired, new Set(['a.mjs', 'b.mjs', 'c.mjs']), [
+    'a.mjs',
+    'zero.mjs',
+  ]).length;
+  assert.equal(stated, named);
+});
+
+test('wiredTools excludes test files, which are not tools', () => {
+  const fake = {
+    readFileSync: (file) =>
+      file === 'package.json'
+        ? '{"scripts":{}}'
+        : 'run: node --test tools/check-x.test.mjs tools/check-x.mjs',
+    readdirSync: () => ['ci.yml'],
+  };
+  const wired = wiredTools(fake);
+  assert.equal(wired.has('check-x.mjs'), true);
+  assert.equal(wired.has('check-x.test.mjs'), false);
 });


### PR DESCRIPTION
## Summary

The wiring x assertion cross-tabulation in `tools/check-report-assertions.mjs` joined two
populations with different boundaries and disclosed neither. Its per-tool table is keyed by
mutated site, so a wired tool that produced no site entered **no row and no quadrant** — rendered
identically to a tool that was measured and scored well.

Of **24** wired tools, **11** produce no row:

| reason | count |
| --- | --- |
| CommonJS — outside the measured population | 7 |
| no colocated test file — never mutated | 4 |

The published quadrants had a wired denominator of **13**, not 24, and nothing in the output said
so.

## Instrument-independent finding

`check-text-encoding.mjs`, `check-web-performance-budget.mjs`, `run-citations-check.mjs` and
`verify-build-env.mjs` are wired into CI and have **no test file anywhere in the tree**.
`check-text-encoding.mjs` backs the `encoding:check` gate. That claim needs no ratio, no site
definition and no sweep, so it survives every instrument failure above.

## Measured negative

The sibling `jrmoulckers/engineering` session found the same class via their report-site boundary
excluding whole files. Ran their test against finance's actual pre-#4319 boundary:

```
old 457  new 463  delta +6
files with sites: old 25, new 25
per-file omissions (tool invisible under old defn):  0
per-site omissions (file counted, sites missed):     4
```

finance's omissions were **purely per-site**. The hole here has a different cause — the extension
boundary of the measured set versus the wired set — which was only findable by abandoning their
diagnosis rather than confirming it.

## Changes

- `wiredTools()` excludes `.test.mjs`; the filename class admits dots, so
  `node --test tools/x.test.mjs` had registered the test file as a wired tool (5 such entries).
- New `absentWiredTools()` classifies each absent wired tool into one of four reasons: CommonJS,
  red baseline, zero report sites, no colocated test file.
- `perToolLines()` prints every absent wired tool **by name with its reason**, and states the
  wired denominator its quadrants used.
- `measure()` returns `measured` so the disclosure can distinguish "untested" from "zero sites".
- 7 tests, including a negative control that a zero-site wired tool renders differently from a
  fully-asserted one, and one asserting the stated count equals the named list.

## Self-correction

The issue classified `run-citations-check.mjs` as "zero report sites". It is not — it has no test
file and was never in the measured population. **The disclosure block corrected its author's own
filed diagnosis on its first render**, the second time an inventory has done that (#4321 was the
first). A verdict cannot do this; only an itemisation can.

## Issues

Closes #4324

## Testing

- [x] `npm run format:check`, `npx eslint . --max-warnings 0`, `npm run type-check` — clean
- [x] `node tools/run-tool-tests.mjs` — **679/679** (was 672)
- [x] All **16** gate scripts exit 0