### PR TITLE
fix(tools): pin that every validator can still report a violation (#4325)

### DIFF
--- a/tools/check-ai-manifest.js
+++ b/tools/check-ai-manifest.js
@@ -534,11 +534,15 @@ function validateAgentRoster(runtimeAgents) {
   return findings;
 }
 
-function validateActivationDoc() {
+// `contentOverride` exists only so a test can construct a violating document and observe that this
+// function still reports it. Blinding this validator to `return []` survived the whole suite: the
+// real doc always complies, and a rule only ever run against a clean corpus is not checked
+// (#4325, .github#996).
+function validateActivationDoc(contentOverride = null) {
   const abs = path.join(ROOT, ACTIVATION_DOC);
-  if (!fs.existsSync(abs)) return [`${ACTIVATION_DOC} is missing`];
+  if (contentOverride === null && !fs.existsSync(abs)) return [`${ACTIVATION_DOC} is missing`];
 
-  const content = fs.readFileSync(abs, 'utf8');
+  const content = contentOverride === null ? fs.readFileSync(abs, 'utf8') : contentOverride;
   const start = content.indexOf('### Canonical Runtime Roster');
   const end = content.indexOf('### Supported AI Tools', start);
   if (start === -1 || end === -1) {
@@ -1726,16 +1730,23 @@ function validateTriggerCoverage() {
 /**
  * Compare the workflow's real drift enforcement with how AGENTS.md describes it.
  *
+ * The two overrides exist only so a test can construct a disagreeing pair and observe that this
+ * function still reports it; blinding it to `return []` survived the whole suite, because the real
+ * workflow and the real prose agree (#4325, .github#996).
+ *
+ * @param {string|null} workflowOverride Workflow text to use instead of reading the file.
+ * @param {string|null} docOverride AGENTS.md text to use instead of reading the file.
  * @returns {string[]} Findings; empty when prose and workflow agree.
  */
-function validateEnforcementDoc() {
+function validateEnforcementDoc(workflowOverride = null, docOverride = null) {
   const workflowPath = path.join(ROOT, ENFORCEMENT_WORKFLOW);
   const docPath = path.join(ROOT, 'AGENTS.md');
-  if (!fs.existsSync(workflowPath)) return [`missing workflow: ${ENFORCEMENT_WORKFLOW}`];
-  if (!fs.existsSync(docPath)) return ['missing AGENTS.md'];
+  if (workflowOverride === null && !fs.existsSync(workflowPath))
+    return [`missing workflow: ${ENFORCEMENT_WORKFLOW}`];
+  if (docOverride === null && !fs.existsSync(docPath)) return ['missing AGENTS.md'];
   return enforcementFindings(
-    fs.readFileSync(workflowPath, 'utf8'),
-    fs.readFileSync(docPath, 'utf8'),
+    workflowOverride === null ? fs.readFileSync(workflowPath, 'utf8') : workflowOverride,
+    docOverride === null ? fs.readFileSync(docPath, 'utf8') : docOverride,
   );
 }
 
@@ -1881,6 +1892,11 @@ if (require.main === module) {
 
 module.exports = {
   toLF,
+  validateAgentRoster,
+  validateActivationDoc,
+  validateEnforcementDoc,
+  GENERATED_AGENTS,
+  ACTIVATION_DOC,
   ENV_INPUTS,
   reachableEnvVars,
   validateEnvInputs,

--- a/tools/check-ai-manifest.test.mjs
+++ b/tools/check-ai-manifest.test.mjs
@@ -18,6 +18,10 @@ import { execFileSync } from 'node:child_process';
 const require = createRequire(import.meta.url);
 const {
   toLF,
+  validateAgentRoster,
+  validateActivationDoc,
+  validateEnforcementDoc,
+  GENERATED_AGENTS,
   reachableEnvVars,
   validateEnvInputs,
   PROVENANCE_LINE,
@@ -1373,6 +1377,83 @@ function delegationFindings(source, ids) {
   }
   return findings;
 }
+
+test('the roster rule reports a corrupted roster, not just a clean one (#4325)', () => {
+  // Blinding this validator to `return []` survived the whole suite. It runs on every invocation
+  // against a corpus that always complies, and a rule only ever run against a clean corpus is not
+  // checked (.github#996). #4314 proves production REACHES the validator; this proves the
+  // validator DETECTS. Neither half implies the other, and both were needed.
+  assert.deepEqual(
+    validateAgentRoster(EXPECTED_AGENTS),
+    [],
+    'PREMISE: the declared roster must be clean, or the constructions below prove nothing',
+  );
+  assert.match(
+    validateAgentRoster(EXPECTED_AGENTS.slice(1)).join('\n'),
+    /runtime roster misses: /,
+    'a roster missing a declared role must be reported',
+  );
+  assert.match(
+    validateAgentRoster([...EXPECTED_AGENTS, 'invented-role']).join('\n'),
+    /runtime roster has unknown roles: invented-role/,
+    'a roster carrying an undeclared role must be reported',
+  );
+});
+
+test('the activation-doc rule reports a disagreeing document (#4325)', () => {
+  assert.deepEqual(
+    validateActivationDoc(),
+    [],
+    'PREMISE: the real document must comply, or the construction below proves nothing',
+  );
+  const narrowed = [
+    '### Canonical Runtime Roster',
+    '',
+    `The generated canonical roster is: \`${GENERATED_AGENTS[0]}\``,
+    '',
+    '### Supported AI Tools',
+  ].join('\n');
+  const findings = validateActivationDoc(narrowed).join('\n');
+  assert.match(
+    findings,
+    new RegExp(`documented generated roster has 1 roles; expected ${GENERATED_AGENTS.length}`),
+    'a document naming fewer roles than the runtime has must be reported',
+  );
+  assert.match(
+    findings,
+    /active runtime count statement is missing/,
+    'a document with no count statement must be reported, not silently accepted',
+  );
+});
+
+test('the enforcement rule reports prose that disagrees with the workflow (#4325)', () => {
+  assert.deepEqual(
+    validateEnforcementDoc(),
+    [],
+    'PREMISE: prose and workflow must agree today, or the constructions below prove nothing',
+  );
+  const workflow = fs.readFileSync(path.join(ROOT, ENFORCEMENT_WORKFLOW), 'utf8');
+  const mode = driftEnforcement(workflow).mode;
+  assert.ok(mode === 'warn-only' || mode === 'blocking', `PREMISE: readable mode, got ${mode}`);
+
+  const agreeing = mode === 'warn-only' ? 'AI Manifest Check is warn-only' : 'AI Manifest Check';
+  const disagreeing = mode === 'warn-only' ? 'AI Manifest Check' : 'AI Manifest Check warn-only';
+  assert.deepEqual(
+    validateEnforcementDoc(workflow, agreeing),
+    [],
+    'prose matching the workflow must stay silent',
+  );
+  assert.equal(
+    validateEnforcementDoc(workflow, disagreeing).length,
+    1,
+    'prose contradicting the workflow must be reported',
+  );
+  assert.match(
+    validateEnforcementDoc(workflow, 'no mention of the check at all').join('\n'),
+    /runtime docs no longer describe the AI Manifest Check workflow/,
+    'docs that stop describing the check must be reported',
+  );
+});
 
 test('every wired runner delegates to the validator its id names (#4314)', () => {
   // #4278 made the advertised set and the wired set one object, so a validator cannot be dropped


### PR DESCRIPTION
## Summary

Blinding a validator -- inserting `return [];` as its first statement -- leaves both existing structural guards satisfied. The runner is still advertised and wired (#4278). The runner still calls the validator, so the delegation guard (#4314) still passes. Only the validator's ability to *report* is gone, and on a clean corpus that is byte-identical to working correctly.

**3 of 8 validators survived that mutation with the suite green.**

```
docCounts         KILLED
syncLock          KILLED    (#4256)
triggerCoverage   KILLED    (#4287/#4292)
citations         KILLED    (#4270/#4300/#4309)
envInputs         KILLED    (#4306)
agentRoster       *** SURVIVED ***
activationDoc     *** SURVIVED ***
enforcementDoc    *** SURVIVED ***
```

The distribution is the finding. The five covered validators are exactly those that some earlier defect in this program forced me to construct a violating state for. The three blind ones are the three no defect ever touched. Coverage here is a by-product of past incidents, not of design.

Wiring, delegation, and detection are three independent properties. None implies the others, and each was found only by a mutation aimed at it specifically.

## Changes

- `validateActivationDoc(contentOverride = null)` and `validateEnforcementDoc(workflowOverride = null, docOverride = null)` gain content seams so a test can supply a disagreeing document without touching the tracked file. Both use an explicit `=== null` ternary rather than `??`, so an empty-string override is still an override.
- Three negative tests, one per blind validator. Each asserts the real input is clean *first* (premise), then constructs the violating state, so the test cannot pass by the corpus happening to be broken.
- `module.exports` extended with the three validators and two path constants.

## Mutation results after the fix

```
B1  agentRoster blinded              KILLED
B2  activationDoc blinded            KILLED
B3  enforcementDoc blinded           KILLED
C1  activationDoc seam ignored       KILLED
C2  enforcementDoc doc seam ignored  KILLED
```

C1 and C2 are seam controls, not blinding mutants: they make the seam read the real file and discard the override. Without them a seam that silently ignored its argument would make all three constructions vacuous while the tests still passed. Every kill is attributed by failing test *name*, not by a count.

## Disclosed

The blinding mutation cannot distinguish a validator that reports nothing from one that is never reached -- both are green on a healthy corpus. It is only a valid probe here *because* #4278 and #4314 already pin reachability independently. On its own it would carry the same ambiguity a dispatch-deletion mutant does.

Two instrument errors while building this. My first activation-doc fixture never matched because `logicalLines` joins adjacent non-blank lines, so a heading needs a blank line after it. And a `node -e` probe reporting "0 roles" was a PowerShell backtick-quoting artifact, not a fact about the code -- the fixture had no code spans at all. Fixtures verified inside the test runner from then on.

## Issues

Closes #4325

## Testing

- [x] `node --test tools/check-ai-manifest.test.mjs` -- 102 pass, 0 fail
- [x] `node tools/check-ai-manifest.js` -- exit 0
- [x] `node tools/check-assertion-bounds.mjs` -- exit 0
- [x] `npx prettier --check` + `npx eslint --max-warnings 0` on both touched files -- clean