### PR TITLE
fix(tools): attach doc-link baseline reasons to entries, not to positions

### DIFF
--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -9596,6 +9596,56 @@ its first render**, which is the second time an inventory has done that (the fir
 where the reason `-->` surfaced on run one). A verdict cannot do this. Only an itemisation can, and
 that is now twice observed rather than argued.
 
+### A reason addressed to a position (#4327)
+
+The sibling `jrmoulckers/engineering` session found that its coverage ratchet **demands a reason
+its schema cannot store**: `practices/uncovered.json` is a `string[]`, while the file's own comment
+and the gate's failure text both instruct the author to record a reason. All 7 entries are bare
+IDs. They offered the instrument that found it — an escape-hatch census — rather than the finding.
+
+Run against finance:
+
+```
+27 of 51 tools carry at least one escape hatch
+ 9 allowlist/baseline constants declared
+ 1 of 9 can hold a per-entry reason   (ALLOWED, added by #4323)
+```
+
+**The hit.** `check-doc-links.mjs` recorded its reasons in prose above the array, addressed to a
+position: _"The last two entries are the second kind."_ The array is sorted; those entries sit at
+positions 9 and 10 of 11. `git show` on the commit that wrote the sentence shows the prose and the
+entries landed together — **the reference was false on arrival, not rotted.** The author appended
+mentally while the sort placed them mid-list. The genuinely last entry had no reason at all.
+
+**Attaching a reason per entry then falsified the classification.** Verifying each against
+`git log --all --full-history` moved four entries from "never true" to "moved": `sync-architecture.md`
+resolves to `0002-backend-sync-architecture.md` in the same directory, and `fire-calculator.ts`
+existed from #1830 until #3512 deleted it. Derived split **4 moved / 7 never written**; the prose
+had it backwards for every repointable one. A third finding fell out: **there is no ADR 0008** —
+the sequence skips 0007 to 0009.
+
+The guarding test was named `separates never-true targets from moved ones` and asserted
+`length === 2` over entries matching `fire-calculator.ts`. That holds under either classification.
+**A test can name a property and assert a different one**, and the name is what a reader audits.
+
+**The general form, which is stronger than the positional case.** A reason addressed to a _set_ —
+"these entries are the second kind", "this list is all X" — cannot be checked against any member,
+so it cannot be wrong about a member, so it survives every member changing. Positional reference is
+one instance; "the list is a ratchet of never-written targets" is another, and it was wrong about
+four of eleven for as long as nobody could ask it about one.
+
+**It reproduced inside the fix, at one paragraph's distance.** The docstring I wrote to explain all
+this stated the split as "3 moved / 8 never-written" — hand-counted. The report line, which derives
+the same split from the data, printed **4 / 7** on the next run and contradicted it. Same defect,
+same file, same commit, one paragraph above the code that computes the correct value. The count was
+only caught because something else computed it; had I written the sentence without also deriving
+the number, it would have shipped and read as authoritative.
+
+**What finance already had that engineering lacks.** Staleness is enforced: an entry that stops
+being broken fails the build with `recorded gap(s) no longer broken -- remove them`. So the list
+cannot rot toward over-exemption. It rotted in the other direction — unexplained exemption — which
+is the direction with no reader-visible signal, and is the same direction engineering's does.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:

--- a/tools/check-doc-links.mjs
+++ b/tools/check-doc-links.mjs
@@ -69,26 +69,103 @@ export const STALE_ANCHOR_BASELINE = [];
  *
  * The distinction this list encodes is between a target that *moved* and one that was
  * *never true*, which any resolver reports identically and only the first of which is a
- * regression. The last two entries are the second kind and are the reason it is worth
- * stating: `fire-calculator.ts` reads like a rename of `fire-planning.ts`, and repointing
- * it there would have turned the gate green while making the citing sentence false --
- * `calculateFINumber` and `calculateCoastFI` exist nowhere in this repository. The design
- * document specifies a web reference implementation that was never built. A link that is
- * red because the thing does not exist is doing its job.
+ * regression. That distinction used to be recorded as prose naming "the last two entries",
+ * and it was false the moment it was written (#4327): the two entries it described were
+ * inserted into an alphabetically sorted array at positions 9 and 10 of 11, so they were
+ * never last, and the entry that genuinely was last carried no reason at all.
+ *
+ * Attaching a reason to each entry then falsified the classification itself. Verified
+ * against `git log --all --full-history`, the split is 4 moved / 7 never-written, and the
+ * prose had it backwards for most of the list -- `./sync-architecture.md` resolves to
+ * `0002-backend-sync-architecture.md` in the same directory, and `fire-calculator.ts`
+ * existed from #1830 until #3512 deleted it. Both were describable as "never true" for as
+ * long as the description named no entry. **A reason addressed to a position, or to a set,
+ * cannot be checked against any member of it.**
+ *
+ * The 4/7 split above is stated here only because the report derives it independently; the
+ * first draft of this sentence said 3/8, hand-counted, and the derived line contradicted it
+ * on the next run -- which is the same defect one paragraph up, at one paragraph's distance.
+ *
+ * @type {{target: string, reason: string}[]}
  */
-export const UNRESOLVED_BASELINE = [
-  'docs/architecture/0005-design-system-approach.md -> ./0002-cross-platform-framework-selection.md',
-  'docs/architecture/0006-cicd-strategy.md -> ./0002-cross-platform-framework-selection.md',
-  'docs/architecture/0009-legal-monetization-analysis.md -> ./0008-competitive-protection-strategy.md',
-  'docs/architecture/0018-offline-conflict-resolution.md -> ./sync-architecture.md',
-  'docs/architecture/overview.md -> ./sync-architecture.md',
-  'docs/business/marketing/marketing-plan-sprints-6-10.md -> growth-strategy-post-launch.md',
-  'docs/business/marketing/marketing-plan-sprints-6-10.md -> launch-retrospective-week-1.md',
-  'docs/business/marketing/marketing-plan-sprints-6-10.md -> review-strategy.md',
-  'docs/design/ios-fi-calculator-flow.md -> ../../apps/web/src/lib/investment/fire-calculator.ts',
-  'docs/design/ios-fire-results-goal-integration.md -> ../../apps/web/src/lib/investment/fire-calculator.ts',
-  'docs/guides/release-process.md -> ../audits/accessibility-checklist.md',
+export const UNRESOLVED_ENTRIES = [
+  {
+    target:
+      'docs/architecture/0005-design-system-approach.md -> ./0002-cross-platform-framework-selection.md',
+    reason:
+      'never written: no file of this name has ever been committed. The cross-platform ' +
+      'framework ADR is 0001-cross-platform-framework.md -- wrong number and wrong slug.',
+  },
+  {
+    target:
+      'docs/architecture/0006-cicd-strategy.md -> ./0002-cross-platform-framework-selection.md',
+    reason:
+      'never written: same wrong reference as 0005, pointing at a number and slug that ' +
+      'have never coexisted.',
+  },
+  {
+    target:
+      'docs/architecture/0009-legal-monetization-analysis.md -> ./0008-competitive-protection-strategy.md',
+    reason:
+      'never written: there is no ADR 0008 at all -- the sequence skips from 0007 to 0009. ' +
+      'The nearest surviving content is docs/marketing/competitive-positioning.md.',
+  },
+  {
+    target: 'docs/architecture/0018-offline-conflict-resolution.md -> ./sync-architecture.md',
+    reason:
+      'moved: resolves to 0002-backend-sync-architecture.md in the same directory. ' +
+      'Repointable, and the prose that called this list never-written was wrong about it.',
+  },
+  {
+    target: 'docs/architecture/overview.md -> ./sync-architecture.md',
+    reason: 'moved: same target as 0018, same resolution to 0002-backend-sync-architecture.md.',
+  },
+  {
+    target:
+      'docs/business/marketing/marketing-plan-sprints-6-10.md -> growth-strategy-post-launch.md',
+    reason:
+      'never written: docs/business/marketing/ holds three files and this is not among them; ' +
+      'zero commits have ever touched this path.',
+  },
+  {
+    target:
+      'docs/business/marketing/marketing-plan-sprints-6-10.md -> launch-retrospective-week-1.md',
+    reason: 'never written: planned companion document, zero commits against this path.',
+  },
+  {
+    target: 'docs/business/marketing/marketing-plan-sprints-6-10.md -> review-strategy.md',
+    reason: 'never written: planned companion document, zero commits against this path.',
+  },
+  {
+    target:
+      'docs/design/ios-fi-calculator-flow.md -> ../../apps/web/src/lib/investment/fire-calculator.ts',
+    reason:
+      'moved: the file existed from #1830 until #3512 deleted it, consolidating the FIRE ' +
+      'engines. calculateFINumber and calculateCoastFI occur zero times in the tree today, ' +
+      'so repointing at fire-planning.ts would green the gate while making the citing ' +
+      'sentence false.',
+  },
+  {
+    target:
+      'docs/design/ios-fire-results-goal-integration.md -> ../../apps/web/src/lib/investment/fire-calculator.ts',
+    reason: 'moved: same deleted file as ios-fi-calculator-flow.md, deleted by #3512.',
+  },
+  {
+    target: 'docs/guides/release-process.md -> ../audits/accessibility-checklist.md',
+    reason:
+      'never written: zero commits against this path. This is the entry the positional ' +
+      'prose left unexplained -- it was last, and the prose that said "the last two ' +
+      'entries" named two others.',
+  },
 ];
+
+/**
+ * Baseline targets, derived from the reason-bearing entries.
+ *
+ * Derived rather than maintained separately: a second literal list would let the two drift,
+ * and the drift would be invisible because only this one is consumed.
+ */
+export const UNRESOLVED_BASELINE = UNRESOLVED_ENTRIES.map((e) => e.target);
 
 /**
  * Slugify a heading the way GitHub's renderer does.
@@ -421,6 +498,16 @@ export function reportLines(result, options = {}) {
   const staleBaseline = options.staleBaseline ?? STALE_ANCHOR_BASELINE;
 
   const baselineSet = new Set(baseline);
+  // Derived from the baseline actually in use, not from the module default: an injected
+  // baseline must not be described by the real list's classification. An entry with no
+  // recorded reason is counted as unclassified rather than silently folded into either kind.
+  const reasonFor = new Map(
+    (options.entries ?? UNRESOLVED_ENTRIES).map((e) => [e.target, e.reason]),
+  );
+  const kindOf = (target) => (reasonFor.get(target) ?? '').split(':')[0];
+  const moved = baseline.filter((t) => kindOf(t) === 'moved').length;
+  const neverWritten = baseline.filter((t) => kindOf(t) === 'never written').length;
+  const unclassified = baseline.length - moved - neverWritten;
   const unexpected = broken.filter((b) => !baselineSet.has(b));
   const fixed = [...baselineSet].filter((b) => !broken.includes(b));
   const unexpectedAnchors = staleAnchors.filter((a) => !staleBaseline.includes(a));
@@ -471,7 +558,7 @@ export function reportLines(result, options = {}) {
   );
   lines.push(...scopeLines(result));
   lines.push(
-    `${distinctBroken} recorded gap(s) remain across ${broken.length} link(s), where the target names a document this repository has never contained.`,
+    `${distinctBroken} recorded gap(s) remain across ${broken.length} link(s). ${moved} moved and are repointable; ${neverWritten} name a document this repository has never contained${unclassified > 0 ? `; ${unclassified} carry no recorded reason` : ''}.`,
   );
   if (fixed.length > 0) {
     lines.push('');

--- a/tools/check-doc-links.test.mjs
+++ b/tools/check-doc-links.test.mjs
@@ -6,6 +6,7 @@ import test from 'node:test';
 import {
   STALE_ANCHOR_BASELINE,
   UNRESOLVED_BASELINE,
+  UNRESOLVED_ENTRIES,
   census,
   collectLinks,
   headingSlugs,
@@ -410,7 +411,7 @@ test('occurrences and distinct targets are not interchangeable in the report', (
   const verdict = lines.at(-1);
   assert.equal(
     verdict,
-    '1 recorded gap(s) remain across 2 link(s), where the target names a document this repository has never contained.',
+    '1 recorded gap(s) remain across 2 link(s). 0 moved and are repointable; 0 name a document this repository has never contained; 1 carry no recorded reason.',
   );
 });
 
@@ -896,9 +897,43 @@ test('the disclaimer no longer claims non-markdown links are unmeasured (#4301)'
 });
 
 test('the unresolved baseline separates never-true targets from moved ones (#4301)', () => {
-  // fire-calculator.ts reads like a rename of fire-planning.ts. Repointing it there would
-  // have turned the gate green while making the citing sentence false: calculateFINumber
-  // and calculateCoastFI exist nowhere in this repository.
-  const neverBuilt = UNRESOLVED_BASELINE.filter((e) => e.includes('fire-calculator.ts'));
-  assert.equal(neverBuilt.length, 2);
+  // Rewritten in #4327. The original asserted `length === 2` over entries matching
+  // fire-calculator.ts, under a test name claiming it separated never-true from moved. That
+  // assertion is satisfied by either classification, so the property in the name was never
+  // checked -- and when the entries were finally verified against git history, both turned
+  // out to be *moved*, the opposite of what the surrounding comment said.
+  const classified = UNRESOLVED_ENTRIES.filter((e) => /^(moved|never written):/.test(e.reason));
+  assert.equal(classified.length, UNRESOLVED_ENTRIES.length);
+  const fire = UNRESOLVED_ENTRIES.filter((e) => e.target.includes('fire-calculator.ts'));
+  assert.equal(fire.length, 2);
+  for (const entry of fire) assert.match(entry.reason, /^moved:/);
+});
+
+test('every baselined target carries a reason (#4327)', () => {
+  for (const entry of UNRESOLVED_ENTRIES) {
+    assert.equal(typeof entry.reason, 'string', `${entry.target} has no reason`);
+    assert.match(entry.reason, /[a-z]/, `${entry.target} reason has no prose`);
+    // unsourced-bound: 40 characters is a judgement, not a measurement -- it is long enough
+    // to require a clause rather than a word, and short enough that no current reason is near
+    // it. Its purpose is to reject `reason: 'legacy'`, not to certify anything above it.
+    assert.ok(entry.reason.length >= 40, `${entry.target} reason is too thin to check`);
+  }
+});
+
+test('a reason is attached to an entry, not to a position in the list', () => {
+  // The defect this replaced: prose above the array said "the last two entries" are the
+  // never-true kind. Those entries sat at positions 9 and 10 of 11, because the array is
+  // sorted and the author appended mentally rather than positionally. Sorting the entries
+  // must not change any reason's subject.
+  const sorted = [...UNRESOLVED_ENTRIES].sort((a, b) => a.target.localeCompare(b.target));
+  const shuffled = [...UNRESOLVED_ENTRIES].reverse();
+  const pairs = (list) => list.map((e) => `${e.target}::${e.reason}`).sort();
+  assert.deepEqual(pairs(sorted), pairs(shuffled));
+});
+
+test('the derived baseline cannot drift from the reason-bearing entries', () => {
+  assert.deepEqual(
+    UNRESOLVED_BASELINE,
+    UNRESOLVED_ENTRIES.map((e) => e.target),
+  );
 });


### PR DESCRIPTION
## Summary

Adopting the escape-hatch census offered by the sibling `jrmoulckers/engineering` session found
the same class here. Engineering's `uncovered.json` **demands a reason its `string[]` schema cannot
store**. finance's `UNRESOLVED_BASELINE` stored the reason in prose above the array, addressed to a
**position**.

```
27 of 51 tools carry at least one escape hatch
 9 allowlist/baseline constants declared
 1 of 9 could hold a per-entry reason  (ALLOWED, added by #4323)
```

## The defect was false on arrival, not rotted

The docstring said *"The last two entries are the second kind."* The array is sorted; those entries
sit at positions **9 and 10 of 11**. `git show 3cac6b52` (#4302) shows the prose and both entries
landed in the same commit — the author appended mentally while the sort placed them mid-list. The
genuinely last entry, `release-process.md -> ../audits/accessibility-checklist.md`, had no reason at
all and had been unexplained since #4263.

## Attaching a reason per entry falsified the classification

Each reason verified against `git log --all --full-history`:

| target | prose said | truth |
| --- | --- | --- |
| `./sync-architecture.md` (x2) | never true | **moved** — resolves to `0002-backend-sync-architecture.md` in the same directory |
| `fire-calculator.ts` (x2) | never true, "reads like a rename" | **moved** — added #1830, deleted #3512 consolidating the FIRE engines |
| `./0002-cross-platform-framework-selection.md` (x2) | uncovered | never written — the ADR is `0001-cross-platform-framework.md`, wrong number *and* slug |
| `./0008-competitive-protection-strategy.md` | uncovered | never written — **there is no ADR 0008**; the sequence skips 0007 to 0009 |

Derived split **4 moved / 7 never written**. The guarding test, named
`separates never-true targets from moved ones`, asserted `length === 2` over `fire-calculator.ts`
entries — satisfied under either classification, so the property in its name was never checked, and
both entries turned out to be the other kind.

## It reproduced inside the fix

The docstring explaining all this stated the split as **3 moved / 8 never-written**, hand-counted.
The report line, which derives the same split from the data, printed **4 / 7** on the next run and
contradicted it — same defect, same commit, one paragraph above the code that computes the correct
value. Corrected, and the near-miss recorded in the docstring.

## Changes

- `UNRESOLVED_ENTRIES`: `{target, reason}[]`, every reason verified against git history.
  `UNRESOLVED_BASELINE` derived from it, so the two cannot drift.
- Report derives the moved/never-written split from the baseline **in use**, and reports entries
  with no recorded reason as `carry no recorded reason` rather than folding them into either kind.
- 4 tests: every entry carries a reason; reasons survive re-sorting (the positional defect made
  executable); the derived list matches; the classification test now checks the classification.

## What finance already had

Staleness is enforced — `recorded gap(s) no longer broken -- remove them` — so this list cannot rot
toward over-exemption. It rotted in the other direction, unexplained exemption, which is the one
with no reader-visible signal.

## Issues

Closes #4327

## Testing

- [x] `npm run format:check`, `npx eslint . --max-warnings 0`, `npm run type-check` — clean
- [x] `node tools/run-tool-tests.mjs` — **682/682**
- [x] All **16** gate scripts exit 0 (`bounds:check` rejected an invented `>= 40`; annotated)