### PR TITLE
fix(tools): make the declared CI gate set a checked manifest (#4333)

### DIFF
--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -9734,6 +9734,71 @@ different set: it missed nothing the grep found that was real, and it found
 `scripts/i18n/validate-glossary.js:150`, a genuine member, which the grep never saw. Neither
 instrument was a subset of the other.
 
+## The gate set was prose, and it was wrong for fifteen rounds (#4333)
+
+A sibling session closed a nine-round-old finding by enumerating CI routes exhaustively, and
+narrowed its own claim on the way: not _"8 of 13 tools cannot fail CI"_ — mostly true of any repo
+with a `scripts/` directory — but _"three tools are **written as gates** and nothing runs them."_
+A mismatch between a tool's form and its wiring, which is checkable.
+
+Run against this tree, that class landed on the reporting rather than the tools.
+
+### `agent:check` was never a gate
+
+`agent:check` appeared in the phrase **"16/16 gates pass"** in every verification summary of this
+workstream. Two independent instruments agree it is reached by nothing:
+
+| instrument                                               | verdict                     |
+| -------------------------------------------------------- | --------------------------- |
+| `check-gate-enforcement.mjs` route resolution (5 routes) | `reached by no workflow`    |
+| raw substring scan of the joined 394 KB workflow corpus  | `byName=False byFile=False` |
+
+And it is worse than unwired. It runs `tools/agent-scripts/pre-push-check.js`, which exits 1 on
+failure and 0 on success — gate form — and is named for a hook that **exists and does not call
+it**: `.husky/pre-push` runs `prettier --check`, `eslint`, and a secret scan. The only two
+references in the whole tree are its own `package.json` entry and a paragraph in this guide.
+
+### The defect is the aggregate, not the script
+
+The sibling's §4 formulation — _a verdict can only be right or wrong about the question you asked;
+an itemisation can be right about a question you didn't ask_ — has a mechanism, which they supplied
+this round: an itemisation is checkable against a reader's independent knowledge, an aggregate is
+not. The reader is the second instrument, and they can only act as one if the output has the
+resolution to disagree with them.
+
+`16/16 gates pass` had no such resolution. It was true of a set that existed only in prose, so a
+member that never gated could not be detected by anything. `CLAIMED_GATES` is now a checked
+manifest: a script listed there that resolves to no route fails the build, and the report prints a
+row per gate with its matching route.
+
+```
+Declared CI gates: 15.
+  ai:manifest:check              file path
+  bounds:check                   npm run
+  ...
+Gate-shaped scripts deliberately excluded:
+  agent:check
+    developer pre-push helper ... invoked by no workflow AND by no hook
+```
+
+### The tool asserting this was itself toothless
+
+`check-gate-enforcement.mjs` is wired into CI and, until this change, **never set an exit code**. It
+satisfied _"runs in CI"_ without being able to fail it — a third variant of the form/wiring
+mismatch, and one neither tree had named: not unwired, not unwritten, but _wired and unable to
+fail_. It now fails on exactly one claim, which is narrow enough to be both true and checkable.
+
+### What is not claimed
+
+31 of 66 root scripts reach no workflow. That is not a finding — `format`, `clean`, `doctor`, and
+the `agent:*` helpers should not gate anything. Following the sibling's own restraint: the correct
+claim is the narrow one about **form/wiring mismatch**, not the larger number that sounds more
+impressive.
+
+`agent:check` is recorded in `NOT_GATES` rather than wired into `.husky/pre-push`. Wiring it would
+change local behaviour for every human in the repo, which is a different decision from correcting a
+miscounted report, and only the second one is in scope here.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:

--- a/tools/check-gate-enforcement.mjs
+++ b/tools/check-gate-enforcement.mjs
@@ -147,6 +147,112 @@ export function resolveRoutes(scripts, corpus) {
 }
 
 /**
+ * The scripts this repository *claims* are CI gates, and the evidence for scripts excluded (#4333).
+ *
+ * Until now the gate set existed only in prose -- "16/16 gates pass" appeared in every verification
+ * summary of this workstream, and nothing derived or checked that list. An aggregate a reader
+ * cannot check is one a reader cannot disagree with, so a member that never gated was undetectable.
+ *
+ * `agent:check` was in that reported set for fifteen rounds. It runs
+ * `tools/agent-scripts/pre-push-check.js`, which exits 1 on failure and 0 on success -- gate form --
+ * and is invoked by **nothing**. Not CI: two independent instruments (this tool's route resolution
+ * and a raw substring scan of the joined workflow corpus) agree it resolves to no route. Not the
+ * hook it is named for either: `.husky/pre-push` exists and runs `prettier --check`, `eslint`, and
+ * a secret scan, and never mentions it. The only two references in the tree are its own
+ * `package.json` entry and a guide paragraph.
+ *
+ * Membership here is a claim that a script must be able to fail CI. Adding a script to this list
+ * without wiring it fails this gate, which is the property the prose version could not have.
+ */
+export const CLAIMED_GATES = [
+  'eng:citations',
+  'eng:vendor:check',
+  'ai:manifest:check',
+  'encoding:check',
+  'workflow:security:check',
+  'upstream:refs:check',
+  'gradle:prefetch:check',
+  'tool:imports:check',
+  'citations:enumerations:check',
+  'node:version:check',
+  'docs:links:check',
+  'test:independence:check',
+  'bounds:check',
+  'markdown:primitives:check',
+  'gate:enforcement',
+];
+
+/**
+ * Scripts that look like gates and deliberately are not, with the evidence rather than the verdict.
+ *
+ * A bare exclusion list records that someone decided; naming what was checked lets the next reader
+ * disagree with the decision instead of trusting it.
+ */
+export const NOT_GATES = {
+  'agent:check':
+    'developer pre-push helper. Runs tools/agent-scripts/pre-push-check.js, which is in gate form ' +
+    '(exit 1 on failure) but is invoked by no workflow AND by no hook -- .husky/pre-push does not ' +
+    'call it. Recorded rather than wired: wiring it would change local behaviour for humans, which ' +
+    'is a separate decision from correcting the reported gate set',
+};
+
+/**
+ * Claimed gates that reach no workflow, so the claim is false rather than merely unverified.
+ *
+ * @param {Record<string, string | null>} routes Script name to matching route.
+ * @param {string[]} claimed Scripts asserted to be CI gates.
+ * @returns {{name: string, reason: string}[]} Failing claims, ascending by name.
+ */
+export function unenforcedClaims(routes, claimed = CLAIMED_GATES) {
+  const failing = [];
+  for (const name of [...claimed].sort()) {
+    if (!Object.hasOwn(routes, name)) {
+      failing.push({ name, reason: 'claimed as a gate but not defined in package.json' });
+    } else if (routes[name] === null) {
+      failing.push({ name, reason: 'claimed as a gate but reached by no workflow' });
+    }
+  }
+  return failing;
+}
+
+/**
+ * The claimed-gate census, itemised on both paths.
+ *
+ * Per gate with its route rather than `15/15`, because a count is true at the same moment the set
+ * is wrong, and a reader cannot check a count against what they already know.
+ *
+ * @param {Record<string, string | null>} routes Script name to matching route.
+ * @param {string[]} claimed Scripts asserted to be CI gates.
+ * @returns {string[]} Report lines.
+ */
+export function claimedGateLines(routes, claimed = CLAIMED_GATES) {
+  const failing = unenforcedClaims(routes, claimed);
+  const lines = [
+    '',
+    `Declared CI gates: ${claimed.length}. Each must resolve to a workflow route; the set is`,
+    '  checked here rather than stated in prose, because the reported set was wrong for fifteen',
+    '  rounds and nothing could detect it (#4333).',
+  ];
+  for (const name of [...claimed].sort()) {
+    lines.push(`  ${name.padEnd(30)} ${routes[name] ?? 'NO ROUTE'}`);
+  }
+  const excluded = Object.keys(NOT_GATES).sort();
+  lines.push(
+    `Gate-shaped scripts deliberately excluded: ${excluded.length === 0 ? 'none.' : ''}`,
+    ...excluded.flatMap((name) => [`  ${name}`, `    ${NOT_GATES[name]}`]),
+  );
+  if (failing.length > 0) {
+    lines.push(
+      '',
+      'Declared gate(s) that cannot fail CI:',
+      ...failing.map((f) => `  ${f.name}: ${f.reason}`),
+      'Either wire it into a workflow, or move it to NOT_GATES with the evidence.',
+    );
+  }
+  return lines;
+}
+
+/**
  * Summarise a census.
  *
  * @param {Record<string, string | null>} routes Script name to matching route.
@@ -225,6 +331,12 @@ function main() {
   console.log('');
   for (const line of scopeLines(routes, count)) console.log(line);
   for (const line of unreachedLines(routes)) console.log(line);
+  for (const line of claimedGateLines(routes)) console.log(line);
+  // Until now this tool was itself wired and toothless: it printed a census and always exited 0, so
+  // it satisfied "runs in CI" without being able to fail it. It now fails on exactly one claim --
+  // that every declared gate can fail CI -- which is narrow enough to be true and checkable, and is
+  // the claim whose prose version was wrong for fifteen rounds (#4333).
+  if (unenforcedClaims(routes).length > 0) process.exitCode = 1;
 }
 
 if (process.argv[1] && process.argv[1].endsWith('check-gate-enforcement.mjs')) {

--- a/tools/check-gate-enforcement.test.mjs
+++ b/tools/check-gate-enforcement.test.mjs
@@ -2,8 +2,11 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import {
+  CLAIMED_GATES,
+  NOT_GATES,
   NPM_LIFECYCLES,
   ROUTES,
+  claimedGateLines,
   commandSegments,
   directRoute,
   reportLines,
@@ -12,6 +15,7 @@ import {
   scopeLines,
   scriptDeps,
   scriptPaths,
+  unenforcedClaims,
   unreachedLines,
 } from './check-gate-enforcement.mjs';
 
@@ -173,4 +177,63 @@ test('unreachedLines names each unreached script', () => {
 
 test('unreachedLines returns nothing when everything is reached', () => {
   assert.deepEqual(unreachedLines({ a: 'npm run' }), []);
+});
+
+test('a claimed gate that reaches no workflow is a failure, not an omission (#4333)', () => {
+  // The defect this closes: `agent:check` was reported as a gate for fifteen rounds while being
+  // invoked by nothing. The prose version of the set could not fail, because prose has no failure
+  // path. Membership is now a claim the tool checks.
+  const routes = { 'a:check': 'npm run', 'b:check': null };
+  assert.deepEqual(unenforcedClaims(routes, ['a:check']), [], 'a wired claim passes');
+  assert.deepEqual(unenforcedClaims(routes, ['a:check', 'b:check']), [
+    { name: 'b:check', reason: 'claimed as a gate but reached by no workflow' },
+  ]);
+});
+
+test('a claimed gate that no longer exists fails differently from one that is unwired', () => {
+  // Two distinct ways the claim goes stale, and they need different fixes: a renamed script must be
+  // renamed here, an unwired one must be wired. A single message would send the reader to the wrong
+  // remedy in one of the two cases.
+  const [gone] = unenforcedClaims({ 'a:check': 'npm run' }, ['ghost:check']);
+  assert.match(gone.reason, /not defined in package\.json/);
+  const [unwired] = unenforcedClaims({ 'a:check': null }, ['a:check']);
+  assert.match(unwired.reason, /reached by no workflow/);
+  assert.notEqual(gone.reason, unwired.reason);
+});
+
+test('the claimed-gate census itemises the route per gate on the passing path', () => {
+  // A `15/15` line is true at the same moment the set is wrong, and a reader cannot check it
+  // against what they already know. A row per gate can be disagreed with.
+  const lines = claimedGateLines({ 'a:check': 'npm run', 'b:check': 'file path' }, [
+    'a:check',
+    'b:check',
+  ]);
+  assert.ok(lines.some((l) => l.includes('a:check') && l.includes('npm run')));
+  assert.ok(lines.some((l) => l.includes('b:check') && l.includes('file path')));
+  assert.ok(!lines.some((l) => l.includes('cannot fail CI')), 'no failure block when all resolve');
+});
+
+test('the failing census is distinguishable from the passing one and states both remedies', () => {
+  const lines = claimedGateLines({ 'a:check': 'npm run', 'b:check': null }, ['a:check', 'b:check']);
+  assert.ok(lines.some((l) => l.includes('Declared gate(s) that cannot fail CI')));
+  assert.ok(
+    lines.some((l) => l.includes('NO ROUTE')),
+    'the unwired gate is marked in the listing',
+  );
+  assert.ok(lines.some((l) => /wire it into a workflow, or move it to NOT_GATES/.test(l)));
+});
+
+test('every excluded gate-shaped script records evidence, not just a verdict', () => {
+  // A bare exclusion list records that someone decided. Naming what was checked lets the next
+  // reader disagree with the decision instead of trusting it.
+  for (const [name, reason] of Object.entries(NOT_GATES)) {
+    assert.ok(String(reason).trim().length > 0, `${name} states why it is not a gate`);
+    assert.ok(!CLAIMED_GATES.includes(name), `${name} cannot be both claimed and excluded`);
+  }
+});
+
+test('the declared set is named, distinct, and excludes the script that motivated it', () => {
+  assert.deepEqual([...new Set(CLAIMED_GATES)], CLAIMED_GATES, 'no duplicate claims');
+  assert.ok(!CLAIMED_GATES.includes('agent:check'), 'the fifteen-round miscount stays corrected');
+  assert.ok(Object.hasOwn(NOT_GATES, 'agent:check'), 'and is recorded rather than dropped');
 });


### PR DESCRIPTION
## Summary

`agent:check` has been counted in the phrase **"16/16 gates pass"** in every verification summary of this workstream. It is invoked by **no workflow and no hook**.

It is worse than unwired: it runs `tools/agent-scripts/pre-push-check.js`, which exits 1 on failure and 0 on success — gate form — and is named for `.husky/pre-push`, a hook that **exists and calls something else** (`prettier --check`, `eslint`, a secret scan). The only two references in the entire tree are its `package.json` entry and one paragraph of the adoption guide.

Verified two independent ways:

| instrument | verdict |
| --- | --- |
| `check-gate-enforcement.mjs` route resolution (5 routes) | `reached by no workflow` |
| raw substring scan over the joined 394 KB workflow corpus | `byName=False byFile=False` |

**The defect is the aggregate, not the script.** A gate set stated in prose has no failure path, so a member that never gated could not be detected by anything. An aggregate a reader cannot check is one a reader cannot disagree with.

## Changes

- `CLAIMED_GATES` / `NOT_GATES` — membership is declared, and each exclusion records *why* it is not a gate rather than being silently dropped.
- `unenforcedClaims()` — distinguishes *"not defined in `package.json`"* from *"reached by no workflow"*. The two staleness modes need different remedies; one message would send the reader to the wrong one half the time.
- `claimedGateLines()` — prints a **row per gate with its matching route**, so the output has the resolution for a reader to disagree with it.
- `check-gate-enforcement.mjs` now sets a non-zero exit code. It was previously wired into CI and **unable to fail it** — a third form/wiring variant neither tree had named: not unwired, not unwritten, but *toothless*.
- 6 tests, including negative controls that a wired gate renders differently from an unwired one and that the two failure reasons are distinct.

## What is not claimed

31 of 66 root scripts reach no workflow. That is **not** a finding — `format`, `clean`, `doctor` and the `agent:*` helpers should not gate anything. The correct claim is the narrow one about form/wiring mismatch, not the larger number that sounds more impressive.

`agent:check` is recorded in `NOT_GATES` rather than wired into `.husky/pre-push`. Wiring it changes local behaviour for every human in the repo — a different decision from correcting a miscounted report, and only the second is in scope.

## Issues

Closes #4333
Refs #4029

## Testing

- [x] `npm run format:check` — clean
- [x] `npx eslint . --max-warnings 0` — 0 warnings
- [x] `npm run type-check` — pass
- [x] `node tools/run-tool-tests.mjs` — **702/702**
- [x] **15/15** declared gates pass (the number is 15, not 16, because the set is now checked rather than recited)