### PR TITLE
fix(tools): re-derive exclusion state instead of trusting it (#4335)

### DIFF
--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -9799,6 +9799,73 @@ impressive.
 change local behaviour for every human in the repo, which is a different decision from correcting a
 miscounted report, and only the second one is in scope here.
 
+## A reason can be a criterion or a state, and only one of them survives (#4335)
+
+A sibling session tested the rule that a claim addressed to a set cannot be wrong about a member,
+and found the first instance that had _not_ rotted. Their explanation is the useful part, and it
+corrects my version of the rule:
+
+> The distinguishing property isn't the scope of the address, it's whether the sentence names a
+> **criterion** or a **state**.
+
+"A cross-reference is not an implementation" stays true as members change. "The last two entries are
+the second kind" cannot. I had been attributing the durability to _who the sentence is about_; it is
+actually _what kind of sentence it is_.
+
+### Turned on the exclusion list shipped the day before
+
+`NOT_GATES` (#4333) records why `agent:check` is not a gate. The reason:
+
+> invoked by no workflow AND by no hook -- `.husky/pre-push` does not call it
+
+**A state.** Wire it tomorrow and that sentence is false, nobody has edited this file, and the
+exclusion persists -- so a script that is now a real gate sits permanently outside the checked gate
+set, justified by a claim that no longer holds. #4333 gave the _claimed_ set a failure path and left
+the _excluded_ set without one. Same defect, one column over, shipped in the same commit that fixed
+its neighbour.
+
+### Census of the class
+
+Eleven exclusion lists in `tools/`. Staleness enforcement:
+
+| list                                                         | staleness                                                 |
+| ------------------------------------------------------------ | --------------------------------------------------------- |
+| `check-doc-links.mjs` baselines                              | **enforced** -- "N recorded gap(s) no longer broken"      |
+| `check-upstream-refs.mjs` baselines                          | one direction; over-count fails, under-count only advises |
+| `check-gate-enforcement.mjs` `NOT_GATES`                     | none -- printed, never re-derived                         |
+| `check-markdown-primitives.mjs` `ALLOWED`, `LITERAL_ALLOWED` | none                                                      |
+
+The primitives case is the subtler one. `Object.hasOwn(allowed, site.file)` is a **one-way lookup**:
+it asks whether a detected site is permitted, never whether a permission still describes a site. An
+allowance for a deleted or rewritten file is not wrong -- it is _unfalsifiable_, because nothing
+reaches it. And an unfalsifiable allowance reads to the next author as evidence the class was
+considered here.
+
+### The first census pattern missed the list that motivated it
+
+`\b(?:const|let)\s+([A-Z][A-Z0-9_]*(?:ALLOWED|...|NOT_GATES|...))` reported **6** lists. The correct
+figure is **11**. `NOT_GATES` was missed because the leading `[A-Z]` consumes the `N`, leaving
+`OT_GATES`, which cannot match the `NOT_GATES` alternative -- so the pattern written _to find this
+list_ excluded it. The five it missed included two of the four defects.
+
+### And a probe that agreed with a known constant
+
+Checking finance for ghost IDs, `new Set(Object.keys(idx.principles))` printed **66** -- exactly the
+published count of ratified principles -- so I did not question it. `principles` is an **array**;
+`Object.keys` returns `"0".."65"`. The set was 66 wrong things, and every one of finance's 41 cited
+IDs read as a ghost. 41/41 was absurd enough to catch instantly; **66 was not, because it matched.**
+
+A validation that agrees with an independently known constant is the most convincing possible wrong
+answer, and an array's key count _is_ its length, so the coincidence is structural rather than
+lucky. The correct run: 0 ghosts. `eng:citations` already gates this and scans a wider extension set
+(44 principles across 4,719 files, vs. my probe's 41) -- my probe was both redundant and narrower.
+
+### Fix
+
+`staleExclusions()` fails when a `NOT_GATES` entry now resolves to a route; `staleAllowances()` fails
+when an `ALLOWED` key matches no detected site. Each reason is now split into a `criterion` that
+survives the tree changing and a `state` that is re-derived rather than trusted.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:

--- a/tools/check-gate-enforcement.mjs
+++ b/tools/check-gate-enforcement.mjs
@@ -189,12 +189,38 @@ export const CLAIMED_GATES = [
  * disagree with the decision instead of trusting it.
  */
 export const NOT_GATES = {
-  'agent:check':
-    'developer pre-push helper. Runs tools/agent-scripts/pre-push-check.js, which is in gate form ' +
-    '(exit 1 on failure) but is invoked by no workflow AND by no hook -- .husky/pre-push does not ' +
-    'call it. Recorded rather than wired: wiring it would change local behaviour for humans, which ' +
-    'is a separate decision from correcting the reported gate set',
+  'agent:check': {
+    criterion:
+      'developer pre-push helper. Wiring it would change local behaviour for every human in the ' +
+      'repo, which is a separate decision from correcting the reported gate set',
+    state:
+      'runs tools/agent-scripts/pre-push-check.js, which is in gate form (exit 1 on failure) but ' +
+      'is invoked by no workflow AND by no hook -- .husky/pre-push does not call it',
+  },
 };
+
+/**
+ * Exclusions whose recorded state has stopped being true.
+ *
+ * The reason attached to an exclusion is either a criterion or a state, and only the criterion
+ * survives the tree changing. `agent:check`'s criterion -- gating it would change local behaviour
+ * for humans -- stays true whatever CI does. Its state -- reached by nothing -- becomes false the
+ * day somebody wires it, with nobody editing this file. At that moment a real gate would sit
+ * permanently outside the checked set, justified by a sentence that no longer holds.
+ *
+ * So the state half is re-derived here rather than trusted. #4333 gave the claimed set a failure
+ * path and left the exclusion list without one, which is the same defect one column over.
+ *
+ * @param {Record<string, string | null>} routes Script name to matching route.
+ * @param {Record<string, {criterion: string, state: string}>} excluded Non-gates and their reasons.
+ * @returns {{name: string, route: string}[]} Exclusions now reached by a workflow.
+ */
+export function staleExclusions(routes, excluded = NOT_GATES) {
+  return Object.keys(excluded)
+    .sort()
+    .filter((name) => (routes[name] ?? null) !== null)
+    .map((name) => ({ name, route: routes[name] }));
+}
 
 /**
  * Claimed gates that reach no workflow, so the claim is false rather than merely unverified.
@@ -239,14 +265,28 @@ export function claimedGateLines(routes, claimed = CLAIMED_GATES) {
   const excluded = Object.keys(NOT_GATES).sort();
   lines.push(
     `Gate-shaped scripts deliberately excluded: ${excluded.length === 0 ? 'none.' : ''}`,
-    ...excluded.flatMap((name) => [`  ${name}`, `    ${NOT_GATES[name]}`]),
+    ...excluded.flatMap((name) => [
+      `  ${name}`,
+      `    criterion: ${NOT_GATES[name].criterion}`,
+      `    state:     ${NOT_GATES[name].state}`,
+    ]),
   );
+  const stale = staleExclusions(routes);
   if (failing.length > 0) {
     lines.push(
       '',
       'Declared gate(s) that cannot fail CI:',
       ...failing.map((f) => `  ${f.name}: ${f.reason}`),
       'Either wire it into a workflow, or move it to NOT_GATES with the evidence.',
+    );
+  }
+  if (stale.length > 0) {
+    lines.push(
+      '',
+      'Excluded script(s) whose recorded state is no longer true:',
+      ...stale.map((s) => `  ${s.name}: now reached by ${s.route}`),
+      'The exclusion rests on a sentence that has stopped holding. Either add it to CLAIMED_GATES,',
+      'or restate why a workflow-reached script still is not a gate.',
     );
   }
   return lines;
@@ -336,7 +376,8 @@ function main() {
   // it satisfied "runs in CI" without being able to fail it. It now fails on exactly one claim --
   // that every declared gate can fail CI -- which is narrow enough to be true and checkable, and is
   // the claim whose prose version was wrong for fifteen rounds (#4333).
-  if (unenforcedClaims(routes).length > 0) process.exitCode = 1;
+  if (unenforcedClaims(routes).length > 0 || staleExclusions(routes).length > 0)
+    process.exitCode = 1;
 }
 
 if (process.argv[1] && process.argv[1].endsWith('check-gate-enforcement.mjs')) {

--- a/tools/check-gate-enforcement.test.mjs
+++ b/tools/check-gate-enforcement.test.mjs
@@ -15,6 +15,7 @@ import {
   scopeLines,
   scriptDeps,
   scriptPaths,
+  staleExclusions,
   unenforcedClaims,
   unreachedLines,
 } from './check-gate-enforcement.mjs';
@@ -236,4 +237,40 @@ test('the declared set is named, distinct, and excludes the script that motivate
   assert.deepEqual([...new Set(CLAIMED_GATES)], CLAIMED_GATES, 'no duplicate claims');
   assert.ok(!CLAIMED_GATES.includes('agent:check'), 'the fifteen-round miscount stays corrected');
   assert.ok(Object.hasOwn(NOT_GATES, 'agent:check'), 'and is recorded rather than dropped');
+});
+
+test('an exclusion that becomes workflow-reached is a failure, not a silent survivor (#4335)', () => {
+  // #4333 gave the claimed set a failure path and left the exclusion list without one. A reason
+  // that describes a state stops being true when the tree changes, with nobody editing this file.
+  const excluded = { 'x:check': { criterion: 'c', state: 's' } };
+  assert.deepEqual(
+    staleExclusions({ 'x:check': null }, excluded),
+    [],
+    'still unreached, still valid',
+  );
+  assert.deepEqual(staleExclusions({ 'x:check': 'npm run' }, excluded), [
+    { name: 'x:check', route: 'npm run' },
+  ]);
+});
+
+test('an exclusion missing from package.json is not reported as stale', () => {
+  // Deleted is not the same as wired. Only the second invalidates the recorded state, and
+  // conflating them would send the reader to add a deleted script to CLAIMED_GATES.
+  assert.deepEqual(staleExclusions({}, { 'x:check': { criterion: 'c', state: 's' } }), []);
+});
+
+test('every exclusion separates the durable criterion from the checked state', () => {
+  // The criterion survives the tree changing; the state is re-derived rather than trusted. Fusing
+  // them into one prose blob is what made neither checkable.
+  for (const [name, reason] of Object.entries(NOT_GATES)) {
+    assert.ok(reason.criterion?.trim(), `${name} states a criterion`);
+    assert.ok(reason.state?.trim(), `${name} states a checkable state`);
+    assert.notEqual(reason.criterion, reason.state);
+  }
+});
+
+test('the stale-exclusion report names the route and is distinct from the unenforced-claim block', () => {
+  const lines = claimedGateLines({ 'a:check': 'npm run' }, ['a:check']);
+  assert.ok(!lines.some((l) => l.includes('no longer true')), 'clean tree reports no staleness');
+  assert.ok(lines.some((l) => l.includes('criterion:')) && lines.some((l) => l.includes('state:')));
 });

--- a/tools/check-markdown-primitives.mjs
+++ b/tools/check-markdown-primitives.mjs
@@ -233,6 +233,28 @@ export function classify(sites, owner = OWNER, allowed = ALLOWED) {
 }
 
 /**
+ * Allowances that no longer describe anything in the tree.
+ *
+ * `Object.hasOwn(allowed, site.file)` is a one-way lookup: it asks whether a detected site is
+ * permitted, never whether a permission still describes a site. An entry whose file was deleted, or
+ * which stopped implementing the primitive, is not wrong -- it is unfalsifiable, because nothing
+ * reaches it. It then reads to the next author as evidence the class was considered here.
+ *
+ * The reason strings are state-shaped ("require() cannot load the ESM owner"), and a state can stop
+ * being true with nobody editing this file (#4335).
+ *
+ * @param {{file: string}[]} sites Per-file predicate locations actually detected.
+ * @param {Record<string, string>} allowed File to the reason it may keep its own implementation.
+ * @returns {string[]} Allowed files matched by no site, ascending.
+ */
+export function staleAllowances(sites, allowed = ALLOWED) {
+  const seen = new Set(sites.map((site) => site.file));
+  return Object.keys(allowed)
+    .filter((file) => !seen.has(file))
+    .sort();
+}
+
+/**
  * The full census, named rather than counted, on both the passing and failing path.
  *
  * A gate that prints only on failure cannot be audited when it passes, and a wrongly-allowed
@@ -267,6 +289,19 @@ export function censusLines(groups, scanned, skippedTests = 0, primitive = PRIMI
   } else {
     lines.push('allowed: none.');
   }
+  const stale = staleAllowances(
+    [...groups.owner, ...groups.allowed, ...groups.unowned],
+    primitive.allowed,
+  );
+  if (stale.length > 0) {
+    lines.push(
+      '',
+      `Allowance(s) matching no ${primitive.label.toLowerCase()} site:`,
+      ...stale.map((file) => `  ${file}`),
+      'The permission describes nothing, so nothing can contradict it. Remove it, or restore the',
+      'implementation it was written for.',
+    );
+  }
   if (groups.unowned.length > 0) {
     lines.push(
       '',
@@ -296,6 +331,7 @@ export function main(root) {
     const groups = classify(sites, primitive.owner, primitive.allowed);
     out.push(...censusLines(groups, scripts.length, scripts.skippedTests.length, primitive), '');
     if (groups.unowned.length > 0) failed += 1;
+    if (staleAllowances(sites, primitive.allowed).length > 0) failed += 1;
   }
   process.stdout.write(`${out.join('\n')}\n`);
   if (failed > 0) process.exitCode = 1;

--- a/tools/check-markdown-primitives.test.mjs
+++ b/tools/check-markdown-primitives.test.mjs
@@ -1,6 +1,14 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, rmdirSync } from 'node:fs';
+import {
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  rmSync,
+  rmdirSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -16,6 +24,7 @@ import {
   isScannedFile,
   PRIMITIVES,
   predicateLines,
+  staleAllowances,
 } from './check-markdown-primitives.mjs';
 
 // The fence delimiters below are assembled, for the same reason the tool assembles its own: a
@@ -264,5 +273,36 @@ test('each primitive detects its own owner, so a census cannot pass by seeing no
       predicateLines(source, primitive.signatures).length > 0,
       `${primitive.label}: the owner ${primitive.owner} must match its own signatures`,
     );
+  }
+});
+
+test('an allowance matching no detected site is a failure, not a survivor (#4335)', () => {
+  // `Object.hasOwn(allowed, site.file)` only ever asks whether a detected site is permitted. It
+  // never asks whether a permission still describes a site, so an entry for a deleted or rewritten
+  // file is unfalsifiable -- nothing reaches it -- while reading as evidence the class was handled.
+  const sites = [{ file: 'a.mjs', lines: [1] }];
+  assert.deepEqual(staleAllowances(sites, { 'a.mjs': 'reason' }), []);
+  assert.deepEqual(staleAllowances(sites, { 'gone.mjs': 'reason' }), ['gone.mjs']);
+});
+
+test('stale allowances are reported ascending and independently per primitive', () => {
+  const sites = [{ file: 'b.mjs', lines: [2] }];
+  assert.deepEqual(staleAllowances(sites, { 'z.mjs': 'r', 'a.mjs': 'r', 'b.mjs': 'r' }), [
+    'a.mjs',
+    'z.mjs',
+  ]);
+});
+
+test('every declared primitive allowance describes a file that exists on disk', () => {
+  const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+  // The shipped lists, not a fixture: an allowance naming a path no longer in the tree is the
+  // real-world form of the defect above.
+  for (const primitive of PRIMITIVES) {
+    for (const file of Object.keys(primitive.allowed)) {
+      assert.ok(
+        existsSync(path.join(repoRoot, file)),
+        `${primitive.label} allowance ${file} exists`,
+      );
+    }
   }
 });


### PR DESCRIPTION
## Summary

A sibling session corrected the rule for when a set-level claim survives its members changing. I had attributed durability to *who the sentence is about*; they showed it is *what kind of sentence it is*:

> The distinguishing property isn't the scope of the address, it's whether the sentence names a **criterion** or a **state**.

Turned on the exclusion list I shipped the day before. `NOT_GATES` (#4333) justifies excluding `agent:check` with:

> invoked by no workflow AND by no hook — `.husky/pre-push` does not call it

**That is a state.** Wire it tomorrow and the sentence is false, nobody has edited the file, and the exclusion persists — so a script that is now a real gate sits permanently outside the checked gate set, justified by a claim that no longer holds. **#4333 gave the claimed set a failure path and left the excluded set without one: the same defect one column over, shipped in the commit that fixed its neighbour.**

## Census — 11 exclusion lists in `tools/`

| list | staleness |
| --- | --- |
| `check-doc-links.mjs` baselines | **enforced** — "N recorded gap(s) no longer broken" |
| `check-upstream-refs.mjs` baselines | one direction; over-count fails, under-count only advises |
| `check-gate-enforcement.mjs` `NOT_GATES` | **none** — printed, never re-derived |
| `check-markdown-primitives.mjs` `ALLOWED` / `LITERAL_ALLOWED` | **none** |

The primitives case is subtler. `Object.hasOwn(allowed, site.file)` is a **one-way lookup**: it asks whether a detected site is permitted, never whether a permission still describes a site. An allowance for a deleted file is not wrong — it is *unfalsifiable*, because nothing reaches it — and it reads to the next author as evidence the class was considered.

## Changes

- `staleExclusions()` — fails when a `NOT_GATES` entry now resolves to a route; distinguishes that from an entry deleted from `package.json` (opposite remedies).
- `staleAllowances()` — fails when an `ALLOWED` key matches no detected site.
- Each reason is split into a durable **`criterion`** and a re-derived **`state`**. Fusing them into one prose blob is what made neither checkable.
- 7 tests, including a real-tree assertion that every shipped allowance names a file that still exists.

## Two instrument failures worth recording

**The census pattern missed the list that motivated it.** The first pass reported **6** lists; the correct figure is **11**. `NOT_GATES` was missed because the leading `[A-Z]` consumes the `N`, leaving `OT_GATES`, which cannot match the `NOT_GATES` alternative. The pattern written *to find this list* excluded it — and the five it missed contained two of the four defects.

**A probe that agreed with a known constant.** Checking finance for ghost IDs, `new Set(Object.keys(idx.principles))` printed **66** — exactly the published count of ratified principles — so I did not question it. `principles` is an **array**; `Object.keys` returns `"0".."65"`. The set was 66 wrong things, and all 41 of finance's cited IDs read as ghosts. 41/41 was absurd enough to catch instantly; **66 was not, because it matched.** An array's key count *is* its length, so the coincidence is structural, not lucky. Correct run: **0 ghosts** — and `eng:citations` already gates this over a wider extension set (44 principles, 4,719 files), so the probe was both redundant and narrower.

## Issues

Closes #4335
Refs #4029, #4333, #4330

## Testing

- [x] `npm run format:check` — clean
- [x] `npx eslint . --max-warnings 0` — 0 warnings
- [x] `npm run type-check` — pass
- [x] `node tools/run-tool-tests.mjs` — **709/709**
- [x] **15/15** declared gates pass