### PR TITLE
fix(tools): refuse a staleness verdict over a generated population (#4338)

### DIFF
--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -9866,6 +9866,63 @@ lucky. The correct run: 0 ghosts. `eng:citations` already gates this and scans a
 when an `ALLOWED` key matches no detected site. Each reason is now split into a `criterion` that
 survives the tree changing and a `state` that is re-derived rather than trusted.
 
+## A membership test is itself a criterion or a state (#4338)
+
+A sibling session ran the membership audit on their own exclusion list, got `5 of 6 entries are
+not instances`, and then withdrew it: the tool ships to consumer repos, so `dist`, `build`,
+`.svelte-kit`, and `vendor` are exclusions for the _consumer_ trees it walks. They had measured
+against the population the list **lives in** rather than the one it **governs**.
+
+finance is one of those consumer trees, so the same list could be measured where it is aimed.
+
+### Measured against the tree it actually governs
+
+`SKIP_DIR` in the vendored `check-citations.mjs`, run over finance:
+
+| entry          | dirs | scannable files skipped |
+| -------------- | ---- | ----------------------- |
+| `node_modules` | 2    | 72,073                  |
+| `vendor`       | 1    | 9                       |
+| `.git`         | 0    | 0                       |
+| `build`        | 0    | 0                       |
+| `dist`         | 0    | 0                       |
+| `.svelte-kit`  | 0    | 0                       |
+
+Correct population, and four entries still read as dead. They are not:
+
+- **`.git` is a _file_ in this checkout.** finance works in git worktrees, where `.git` is a link
+  file, not a directory -- so a directory-name exclusion never matches it. In the main clone at
+  `C:\Users\jrmou\src\finance` it is a directory. **Membership varies with checkout mode.**
+- **`build` and `dist` are `.gitignore`-declared build outputs.** Zero on a clean tree, non-zero
+  after a Gradle or web build. **Membership varies with build state.**
+- `.svelte-kit` is the only genuinely inapplicable entry -- finance is React.
+
+So the sibling's correction is right and incomplete. Fixing the population is necessary and not
+sufficient: **a membership test is itself either a criterion or a state**, and theirs and mine were
+both states, arrived at by different routes. Theirs varied over _which tree_; mine varies over
+_which moment_.
+
+### It is a latent bug in what shipped the day before
+
+`staleAllowances()` (#4335) fails when an allowlist key matches no site. Applied to finance's own
+`SKIPPED_DIRECTORIES`, it reports **5 of 7 entries dead and is wrong about all five**. It is correct
+today only because its population happens to be tracked source files -- a constraint nothing
+recorded and nothing checked.
+
+`generatedAllowances()` now checks it: an allowance whose path contains any `.gitignore`-declared
+segment fails, because a staleness verdict over a generated path is a state. The verdict is derived
+from `.gitignore` rather than a second hand-kept list of generated directories, since such a list is
+the same kind of object this check exists to distrust and would need its own staleness check.
+
+The mirror hazard is fixed alongside it: `SCANNED_DIRECTORIES` is an **inclusion** list, and an
+entry that disappears narrows the scan silently while still passing. The roots are now asserted.
+
+### Both instruments under-reported `.git`, for different reasons
+
+The sibling's probe skipped hidden directories. Mine treats `.git` as absent because it is a file in
+a worktree. Two independent instruments, the same wrong answer about the same entry, from unrelated
+causes -- and in both cases in the direction that made the finding look stronger.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:

--- a/tools/check-markdown-primitives.mjs
+++ b/tools/check-markdown-primitives.mjs
@@ -29,7 +29,7 @@
  * so a tool scanning documents that happen to contain no fenced example never learns it needs the
  * guard. Nobody decides the rule is narrow; the rule is simply never observed to fail.
  */
-import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { insideLiteral, literalSpans } from './lib/source.mjs';
@@ -243,6 +243,13 @@ export function classify(sites, owner = OWNER, allowed = ALLOWED) {
  * The reason strings are state-shaped ("require() cannot load the ESM owner"), and a state can stop
  * being true with nobody editing this file (#4335).
  *
+ * Precondition, and it is not decorative: this test is only meaningful over a population that does
+ * not vary with build state or checkout mode. Run against a directory allowlist it reports
+ * `build`, `dist`, `.gradle`, and `coverage` as dead on a clean tree and alive on a built one, and
+ * `.git` as dead in a worktree -- where it is a file -- and alive in a clone. The test would be
+ * confidently wrong in whichever direction the moment of measurement happened to fall (#4338).
+ * `governedPopulation()` turns that precondition into a check rather than this paragraph.
+ *
  * @param {{file: string}[]} sites Per-file predicate locations actually detected.
  * @param {Record<string, string>} allowed File to the reason it may keep its own implementation.
  * @returns {string[]} Allowed files matched by no site, ascending.
@@ -252,6 +259,33 @@ export function staleAllowances(sites, allowed = ALLOWED) {
   return Object.keys(allowed)
     .filter((file) => !seen.has(file))
     .sort();
+}
+
+/**
+ * Allowlist keys that name a generated path, so a staleness verdict over them would be a state.
+ *
+ * An entry is disqualified when any of its path segments is declared in `.gitignore`, which is the
+ * tree's own record of what it generates. Deriving it from `.gitignore` rather than a second
+ * hand-maintained list matters: a hand-maintained list of generated directories is the same kind of
+ * object this whole check exists to distrust.
+ *
+ * @param {string[]} keys Allowlist keys to audit.
+ * @param {string} root Repository root.
+ * @returns {string[]} Keys naming generated paths, ascending.
+ */
+export function generatedAllowances(keys, root) {
+  let ignored;
+  try {
+    ignored = new Set(
+      readFileSync(path.join(root, '.gitignore'), 'utf8')
+        .split('\n')
+        .map((line) => line.trim().replace(/^\/+|\/+$/g, ''))
+        .filter((line) => line && !line.startsWith('#') && !line.includes('*')),
+    );
+  } catch {
+    return [];
+  }
+  return keys.filter((key) => key.split(/[/\\]/).some((segment) => ignored.has(segment))).sort();
 }
 
 /**
@@ -322,6 +356,20 @@ export function main(root) {
   const sources = scripts.map((file) => ({ file, text: readFileSync(file, 'utf8') }));
   let failed = 0;
   const out = [];
+  // An inclusion list whose entry disappears narrows the scan and still passes, so the census would
+  // report a clean tree it never looked at. Asserted here rather than assumed, for the same reason
+  // the allowlists are (#4338).
+  const missingRoots = SCANNED_DIRECTORIES.filter(
+    (dir) => !existsSync(path.join(root, dir)),
+  ).sort();
+  if (missingRoots.length > 0) {
+    out.push(
+      `Scan root(s) that do not exist: ${missingRoots.join(', ')}.`,
+      'The census would silently cover less than it claims. Fix SCANNED_DIRECTORIES.',
+      '',
+    );
+    failed += 1;
+  }
   for (const primitive of PRIMITIVES) {
     const sites = [];
     for (const { file, text } of sources) {
@@ -332,6 +380,16 @@ export function main(root) {
     out.push(...censusLines(groups, scripts.length, scripts.skippedTests.length, primitive), '');
     if (groups.unowned.length > 0) failed += 1;
     if (staleAllowances(sites, primitive.allowed).length > 0) failed += 1;
+    const generated = generatedAllowances(Object.keys(primitive.allowed), root);
+    if (generated.length > 0) {
+      out.push(
+        `${primitive.label} allowance(s) naming a generated path: ${generated.join(', ')}.`,
+        'A staleness verdict over a generated path is a state -- it reads dead on a clean tree and',
+        'alive on a built one. Move the allowance to a tracked path, or stop auditing it here.',
+        '',
+      );
+      failed += 1;
+    }
   }
   process.stdout.write(`${out.join('\n')}\n`);
   if (failed > 0) process.exitCode = 1;

--- a/tools/check-markdown-primitives.test.mjs
+++ b/tools/check-markdown-primitives.test.mjs
@@ -24,6 +24,7 @@ import {
   isScannedFile,
   PRIMITIVES,
   predicateLines,
+  generatedAllowances,
   staleAllowances,
 } from './check-markdown-primitives.mjs';
 
@@ -305,4 +306,55 @@ test('every declared primitive allowance describes a file that exists on disk', 
       );
     }
   }
+});
+
+test('a staleness verdict over a generated path would be a state, so it is refused (#4338)', () => {
+  // The same membership test that is correct over tracked source files reports build/, dist/,
+  // .gradle/ and coverage/ dead on a clean tree and alive on a built one -- and .git dead in a
+  // worktree, where it is a file, alive in a clone. The precondition is checked, not asserted in a
+  // comment, because a comment stating a precondition is exactly the artifact this tool distrusts.
+  const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+  assert.deepEqual(generatedAllowances(['tools/a.mjs'], repoRoot), []);
+  assert.deepEqual(generatedAllowances(['coverage/b.mjs', 'build/a.mjs'], repoRoot), [
+    'build/a.mjs',
+    'coverage/b.mjs',
+  ]);
+});
+
+test('a generated segment is detected anywhere in the path, not only at the root', () => {
+  const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+  assert.deepEqual(generatedAllowances(['apps/web/dist/x.js'], repoRoot), ['apps/web/dist/x.js']);
+});
+
+test('the generated set is derived from .gitignore rather than a second hand-kept list', () => {
+  // A hand-maintained list of generated directories is the same kind of object this check exists
+  // to distrust, and it would need its own staleness check.
+  const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+  const ignored = readFileSync(path.join(repoRoot, '.gitignore'), 'utf8');
+  assert.match(ignored, /^\s*build\/?\s*$/m, '.gitignore is the source of the verdict');
+  assert.deepEqual(generatedAllowances(['build/x.mjs'], repoRoot), ['build/x.mjs']);
+  assert.deepEqual(
+    generatedAllowances(['build/x.mjs'], mkdtempSync(path.join(tmpdir(), 'ng-'))),
+    [],
+  );
+});
+
+test('every shipped allowance names a tracked path, so staleAllowances stays meaningful', () => {
+  const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+  for (const primitive of PRIMITIVES) {
+    assert.deepEqual(
+      generatedAllowances(Object.keys(primitive.allowed), repoRoot),
+      [],
+      `${primitive.label} allowances are all tracked paths`,
+    );
+  }
+});
+
+test('a scan root that does not exist is detectable rather than silently narrowing', () => {
+  // The mirror hazard: an inclusion list whose entry disappears covers less and still passes.
+  const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+  for (const dir of SCANNED_DIRECTORIES) {
+    assert.ok(existsSync(path.join(repoRoot, dir)), `scan root ${dir} exists`);
+  }
+  assert.ok(!existsSync(path.join(repoRoot, 'no-such-scan-root')));
 });


### PR DESCRIPTION
## Summary

A sibling session ran a membership audit on their own exclusion list, got *"5 of 6 entries are not instances"*, and then withdrew it — the tool ships to consumer repos, so `dist`, `build`, `.svelte-kit` and `vendor` are exclusions for the **consumer** trees it walks. They had measured against the population the list *lives in* rather than the one it *governs*.

finance is one of those consumer trees, so the list could be measured where it is actually aimed.

## Measured against the tree it governs — and four entries still read as dead

`SKIP_DIR` in the vendored `check-citations.mjs`, over finance:

| entry | dirs | scannable files skipped |
| --- | --- | --- |
| `node_modules` | 2 | 72,073 |
| `vendor` | 1 | 9 |
| `.git` | 0 | 0 |
| `build` | 0 | 0 |
| `dist` | 0 | 0 |
| `.svelte-kit` | 0 | 0 |

They are not dead:

- **`.git` is a *file* here.** finance works in git worktrees, where `.git` is a link file, not a directory — so a directory-name exclusion never matches. In the main clone it *is* a directory. **Membership varies with checkout mode.**
- **`build` and `dist` are `.gitignore`-declared outputs.** Zero on a clean tree, non-zero after a Gradle or web build. **Membership varies with build state.**
- `.svelte-kit` is the only genuinely inapplicable entry — finance is React.

**So fixing the population is necessary and not sufficient. A membership test is itself either a criterion or a state.** Theirs varied over *which tree*; mine varies over *which moment*.

## It is a latent bug in what merged yesterday

`staleAllowances()` (#4335) fails when an allowlist key matches no site. Applied to finance's own `SKIPPED_DIRECTORIES` it reports **5 of 7 entries dead and is wrong about all five**. It is correct today only because its population happens to be tracked source files — a constraint nothing recorded and nothing checked.

## Changes

- **`generatedAllowances()`** — fails an allowance whose path contains any `.gitignore`-declared segment, at any depth. The verdict is derived from `.gitignore` rather than a second hand-kept list of generated directories, because such a list is *the same kind of object this check exists to distrust* and would need its own staleness check.
- **`SCANNED_DIRECTORIES` roots are now asserted** — the mirror hazard: an inclusion list whose entry disappears narrows the scan silently while still passing.
- 5 tests, including the real shipped allowlists and a temp-dir control proving the verdict follows `.gitignore` rather than the path string.

## Both instruments under-reported `.git`, for unrelated reasons

Theirs skipped hidden directories. Mine treats `.git` as absent because it is a file in a worktree. Two independent instruments, same wrong answer about the same entry, different causes — and in both cases in the direction that made the finding look stronger.

## Issues

Closes #4338
Refs #4029, #4335, #4330

## Testing

- [x] `npm run format:check` — clean
- [x] `npx eslint . --max-warnings 0` — 0 warnings
- [x] `npm run type-check` — pass
- [x] `node tools/run-tool-tests.mjs` — **714/714**
- [x] **15/15** declared gates pass