### PR TITLE
fix(tools): prove gate teeth by execution

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -168,6 +168,15 @@ jobs:
       # implementations instead, which needs no extraction to have happened first.
       - name: One definition of a markdown fence
         run: npm run markdown:primitives:check
+
+      # `gate:enforcement` answers whether a gate is wired, which is a property of the workflow
+      # files and readable. It cannot answer whether the invoked program can fail, which is
+      # behavioural: check-gate-enforcement.mjs was itself wired here and had no exit code at all
+      # until #4333, and was found by hand. This executes each gate against a violating fixture and
+      # requires the report to name the violation, because a fixture that fails to scaffold also
+      # exits non-zero.
+      - name: Every declared gate can fail
+        run: npm run gate:teeth
   pr-title:
     name: Semantic PR Title
     needs: changes

--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -9923,6 +9923,72 @@ The sibling's probe skipped hidden directories. Mine treats `.git` as absent bec
 a worktree. Two independent instruments, the same wrong answer about the same entry, from unrelated
 causes -- and in both cases in the direction that made the finding look stronger.
 
+## Wired is not the same as able to fail
+
+`check-gate-enforcement.mjs` proves every declared gate is a real workflow step. It cannot prove
+any of them can fail. A gate that is wired, resolves, and returns zero on every input is
+indistinguishable from a working one by everything the repo previously ran. `gate:teeth`
+(`tools/check-gate-teeth.mjs`) closes that: it executes each proven gate against a minimal
+violating fixture and requires **both** a non-zero exit **and** a report containing a declared
+substring naming the violation.
+
+The second requirement is the load-bearing one. Four fixtures exited non-zero for reasons that
+had nothing to do with the defect they contained -- no git repository, no `package.json`, and one
+that tripped the scan-root assertion added in an earlier change. An exit code is a verdict on
+whichever question the program actually asked; only the report says which question that was.
+
+Four gates are proven (`tool:imports:check`, `markdown:primitives:check`, `bounds:check`,
+`gradle:prefetch:check`). Twelve are recorded as unproven, each with the criterion that blocks it
+-- most need a dependency (`js-yaml`, `semver`) or a whole-tree population a fixture cannot
+supply. The table is asserted against the declared-gate list, so a gate added without a decision
+fails the check rather than silently defaulting to unproven.
+
+### Detectors that were wrong, and how each was caught
+
+Five predictions about this repository's own tools were refuted, all by execution:
+
+1. A `tools\*.mjs` glob missed 2 of 15 gates -- `ai:manifest:check` runs a `.js` file and
+   `eng:vendor:check` lives in `scripts/`. Enumerate from the declared list, never a glob.
+2. A `process.exit(1)` matcher missed `process.exit(result.ok ? 0 : 1)` in
+   `check-assertion-bounds.mjs` -- a ternary is a third syntactic form of the same semantics.
+3. A predicted Windows path defect in `check-gradle-prefetch.mjs` (``new URL(`file://${argv[1]}`)``)
+   does not exist; WHATWG `URL` normalises the drive letter.
+4. Accepting any non-zero exit produced false teeth, as above.
+5. A comment in `check-tool-imports.test.mjs` claimed the new literal guard ignores comments. It
+   does not: `literalSpans` ends a line at `//`, so line comments are excluded -- but block and
+   JSDoc comments are still read as code, because it tracks nothing across lines. The test now
+   pins the measured behaviour in both directions.
+
+The common shape: a regular expression answers _how is this program written_, which correlates
+with _what does this program do_ without being it. If the property is behavioural, run the
+program.
+
+### A gate can be correct and narrower than its own header
+
+`bounds:check` requires every invented numeric bound to name its source. Its header claimed the
+population was "precisely the set of invented numbers". The census extracts only
+`numericInequalities` and `reversedComparisons`, so `assert.equal(census.files, 68)` -- an
+invented number over a real-tree population -- is out of scope. Measured: **265
+equality-against-literal sites across 16 test files**, none in non-test tool files.
+
+Widening was rejected rather than deferred. Most of those sites are sound: a count asserted
+against a fixture the test just built is sourced by construction, and putting them under an
+annotation requirement would add noise proportional to the sound majority to reach a residue that
+is small and not separable by any available signal. The header was narrowed to "in a comparison"
+and the excluded class recorded in the file, so the gap is stated where a reader meets the claim.
+
+This is the failure mode that survives every check: wired, toothed, correct, and about less than
+its name implies. Nothing detects it except reading what the matcher compares.
+
+### An over-report found by its own fixture
+
+The `gate:teeth` fixture content tripped `check-tool-imports.mjs`, which counts `import` and
+`require` keywords appearing inside string literals -- violating its own stated contract,
+"under-decide, never over-report". Fixed with a literal-span guard keyed on the **keyword**
+position, not the specifier: a specifier is always inside a literal, so it cannot distinguish the
+two cases, whereas the keyword can. Reference count moved 164 to 169. The same guard corrected a
+pre-existing over-report at `tools/ai-manifest.js:39`, a `require` inside a line comment.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "test:independence:check": "node tools/check-test-independence.mjs",
     "tools:test": "node tools/run-tool-tests.mjs",
     "gate:enforcement": "node tools/check-gate-enforcement.mjs",
+    "gate:teeth": "node tools/check-gate-teeth.mjs",
     "bounds:check": "node tools/check-assertion-bounds.mjs",
     "markdown:primitives:check": "node tools/check-markdown-primitives.mjs",
     "docs:links:check": "node tools/check-doc-links.mjs",

--- a/tools/check-assertion-bounds.mjs
+++ b/tools/check-assertion-bounds.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Every numeric bound must name where its number came from (#4296).
+ * Every numeric bound in a comparison must name where its number came from (#4296).
  *
  * A sibling session measured `jrmoulckers/engineering`'s bounded assertions and found the good
  * ones did not invent their constants -- they took them from an artifact that had already
@@ -23,9 +23,18 @@
  *
  * A bound compared against an *expression* never enters the population, because that is the fixed
  * form -- the constant then moves with its source. So the population is precisely the set of
- * invented numbers, and the annotation forces the author to record which artifact they looked for
- * and failed to find. Per the sibling's formulation: if nothing in the repo commits to a number,
- * that absence is itself the finding, and an inequality papers over it.
+ * invented numbers *in comparisons*, and the annotation forces the author to record which artifact
+ * they looked for and failed to find. Per the sibling's formulation: if nothing in the repo commits
+ * to a number, that absence is itself the finding, and an inequality papers over it.
+ *
+ * Out of scope, stated because the sentence above used to claim the population was every invented
+ * number and a reader would reasonably have believed it (#4340): equality against a bare numeric
+ * literal. `assert.equal(census.files, 68)` invents a number over a real-tree population and is not
+ * detected -- there are 265 such sites across 16 test files. Most are sound, because a count taken
+ * from a fixture the test just built is sourced by construction; the residue that rots is equality
+ * against a population the test did not create. Widening the matcher to all 265 would put the sound
+ * majority under an annotation requirement, so the narrower class is left open rather than papered
+ * over with a baseline.
  *
  * Usage: node tools/check-assertion-bounds.mjs
  */

--- a/tools/check-gate-enforcement.mjs
+++ b/tools/check-gate-enforcement.mjs
@@ -180,6 +180,7 @@ export const CLAIMED_GATES = [
   'bounds:check',
   'markdown:primitives:check',
   'gate:enforcement',
+  'gate:teeth',
 ];
 
 /**

--- a/tools/check-gate-teeth.mjs
+++ b/tools/check-gate-teeth.mjs
@@ -1,0 +1,346 @@
+#!/usr/bin/env node
+/**
+ * A gate is only a gate if it can fail, and the only proof of that is running it (#4340).
+ *
+ * `check-gate-enforcement.mjs` answers whether a gate is *wired* -- whether a workflow invokes it.
+ * That is a property of the workflow files, and it is checkable by reading them. It says nothing
+ * about whether the invoked program can produce a non-zero exit. A gate that is wired and cannot
+ * fail is worse than one that is unwired, because it contributes a green check.
+ *
+ * finance has shipped exactly that: `check-gate-enforcement.mjs` was itself wired into CI and had
+ * no exit code at all until #4333. It was found by hand. The tool whose subject is enforcement
+ * gaps could not see the enforcement gap in itself, because the property is behavioural and every
+ * instrument pointed at it was syntactic.
+ *
+ * A sibling session in `jrmoulckers/engineering` reached the same rule from three consecutive
+ * detector failures -- a module reference assembled with `path.join` rather than `import`, a
+ * `require` inside a string literal, and `process.exit(main(...))` with `return 1` rather than
+ * `process.exit(1)`. Each was semantically ordinary and syntactically unanticipated. Their
+ * formulation: if the property is "what does this program do," run the program. A grep answers
+ * "how is this program written," which is a different question that happens to correlate.
+ *
+ * Four detectors written against finance's own tools were wrong before this file existed:
+ *
+ *   - `tools/*.mjs` as a population missed 2 of 15 gates, because `ai:manifest:check` runs a `.js`
+ *     file and `eng:vendor:check` lives in `scripts/`.
+ *   - `process.exit(1)` missed `process.exit(result.ok ? 0 : 1)`, a third form of the sibling's
+ *     defect.
+ *   - A predicted Windows-path defect in `check-gradle-prefetch.mjs` was refuted by running it:
+ *     WHATWG `URL` normalises a drive letter, so the guard fires.
+ *   - Accepting any non-zero exit as proof of teeth passed fixtures that had failed on a missing
+ *     git repository, a missing `package.json`, and on the scan-root assertion added in #4339.
+ *
+ * The last one is why a proven entry must name a substring the output has to contain. An exit code
+ * is a verdict; it can only be right or wrong about the question asked. Requiring the report to
+ * name the violation asks the second question -- did it fail *for this reason* -- which a status
+ * code cannot answer.
+ *
+ * Every gate in `CLAIMED_GATES` must appear in exactly one of `PROVEN` or `UNPROVEN`, so declaring
+ * a new gate forces an answer rather than allowing silence. `UNPROVEN` reasons are criteria, not
+ * states: a state ("no fixture written yet") stops being true without anything noticing, whereas a
+ * criterion ("needs a populated node_modules, which makes the fixture depend on an install") stays
+ * checkable.
+ *
+ * Usage: node tools/check-gate-teeth.mjs
+ */
+
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmdirSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { CLAIMED_GATES } from './check-gate-enforcement.mjs';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, '..');
+
+/**
+ * Modules every fixture receives, because several gates import them and a missing one fails the
+ * run for a reason that is not the violation.
+ */
+const LIB = ['tools/lib/markdown.mjs', 'tools/lib/source.mjs'];
+
+/**
+ * Gates whose teeth are demonstrated by executing them against a fixture.
+ *
+ * `files` is written into a throwaway directory alongside a copy of the gate. `expect` is a
+ * substring the report must contain; without it a fixture that failed to scaffold would count as
+ * a pass. Every fixture here runs with no git repository and no `node_modules`, verified
+ * deterministic across repeated passes -- a fixture that needs either is a fixture whose result
+ * depends on the machine.
+ */
+export const PROVEN = {
+  'tool:imports:check': {
+    script: 'tools/check-tool-imports.mjs',
+    files: {
+      'package.json': '{"name":"fixture","version":"1.0.0"}\n',
+      'tools/undeclared.mjs': "import x from 'totally-undeclared-package';\nexport default x;\n",
+    },
+    expect: 'totally-undeclared-package',
+  },
+  'markdown:primitives:check': {
+    script: 'tools/check-markdown-primitives.mjs',
+    files: {
+      'scripts/.keep': '',
+      'tools/rogue.mjs': 'const FENCE = /^\\s*(```|~~~)/;\nexport { FENCE };\n',
+    },
+    expect: 'rogue',
+  },
+  'bounds:check': {
+    script: 'tools/check-assertion-bounds.mjs',
+    files: {
+      'tools/invented.test.mjs':
+        "import assert from 'node:assert/strict';\nassert.ok(total() >= 4173);\n",
+    },
+    expect: '4173',
+  },
+  'gradle:prefetch:check': {
+    script: 'tools/check-gradle-prefetch.mjs',
+    files: {
+      '.github/workflows/unprefetched.yml':
+        'name: unprefetched\non: [push]\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - run: ./gradlew build\n',
+    },
+    expect: 'Prefetch Gradle distribution',
+  },
+};
+
+/**
+ * Gates whose teeth are not demonstrated here, each with the criterion that keeps it out.
+ *
+ * These are open, not excused. The criterion is what a reader checks to decide whether the entry
+ * still belongs; none of them is "nobody has written it yet," which would be a state and would
+ * silently stop being true.
+ */
+export const UNPROVEN = {
+  'eng:citations': {
+    criterion: 'scans the whole repository, so a fixture large enough to trigger it is the tree',
+  },
+  'eng:vendor:check': {
+    criterion: 'compares against a vendored upstream tree, which a fixture would have to vendor',
+  },
+  'ai:manifest:check': {
+    criterion: 'requires a signed manifest whose stamp a fixture would have to forge',
+  },
+  'encoding:check': {
+    criterion: 'enumerates tracked files via git, so the fixture needs a repository and an index',
+  },
+  'workflow:security:check': {
+    criterion: 'imports js-yaml, so the fixture depends on an installed node_modules',
+  },
+  'upstream:refs:check': {
+    criterion: 'resolves references against sibling repositories that a fixture cannot supply',
+  },
+  'citations:enumerations:check': {
+    criterion: 'already executed with a non-zero assertion by check-citation-enumerations.test.mjs',
+  },
+  'node:version:check': {
+    criterion: 'imports semver, so the fixture depends on an installed node_modules',
+  },
+  'docs:links:check': {
+    criterion: 'enumerates tracked files via git, so the fixture needs a repository and an index',
+  },
+  'test:independence:check': {
+    criterion: 'pairs tools with tests via git-tracked paths, so the fixture needs an index',
+  },
+  'gate:enforcement': {
+    criterion: 'reads package.json scripts and workflow files together, so its fixture is a repo',
+  },
+  'gate:teeth': {
+    criterion:
+      'its fixture would need a copy of every gate it proves, so the fixture is the repository',
+  },
+};
+
+/**
+ * Write one file inside a fixture, creating parents.
+ *
+ * @param {string} root Fixture root.
+ * @param {string} rel Repository-relative path.
+ * @param {string} content File contents.
+ * @returns {string} The absolute path written.
+ */
+function writeFixtureFile(root, rel, content) {
+  const abs = path.join(root, rel);
+  mkdirSync(path.dirname(abs), { recursive: true });
+  writeFileSync(abs, content);
+  return abs;
+}
+
+/**
+ * Remove exactly the files a fixture created, by name, deepest directory first.
+ *
+ * Recursive deletion is forbidden in this repository even against a temporary directory, so the
+ * fixture tracks what it wrote and unlinks that. A path this function was not given survives,
+ * which is the intended failure mode.
+ *
+ * @param {string[]} files Absolute file paths written.
+ * @param {string} root Fixture root.
+ * @returns {void}
+ */
+function removeFixture(files, root) {
+  for (const file of files) {
+    try {
+      unlinkSync(file);
+    } catch {
+      /* already gone */
+    }
+  }
+  const dirs = [...new Set(files.map((file) => path.dirname(file)))].sort(
+    (a, b) => b.length - a.length,
+  );
+  for (const dir of [...dirs, root]) {
+    try {
+      rmdirSync(dir);
+    } catch {
+      /* non-empty or already gone */
+    }
+  }
+}
+
+/**
+ * Execute one gate against its fixture.
+ *
+ * @param {string} name Gate name.
+ * @param {{script: string, files: Record<string, string>, expect: string}} spec Fixture.
+ * @param {string} [repoRoot] Source of the gate and its libraries.
+ * @returns {{name: string, status: number|null, named: boolean, ok: boolean, first: string}} What
+ *   happened.
+ */
+export function proveTeeth(name, spec, repoRoot = REPO_ROOT) {
+  const root = mkdtempSync(path.join(tmpdir(), 'gate-teeth-'));
+  const written = [];
+  try {
+    written.push(
+      writeFixtureFile(root, spec.script, readFileSync(path.join(repoRoot, spec.script), 'utf8')),
+    );
+    for (const lib of LIB) {
+      written.push(writeFixtureFile(root, lib, readFileSync(path.join(repoRoot, lib), 'utf8')));
+    }
+    for (const [rel, content] of Object.entries(spec.files)) {
+      written.push(writeFixtureFile(root, rel, content));
+    }
+    const result = spawnSync(process.execPath, [path.join(root, spec.script)], {
+      cwd: root,
+      encoding: 'utf8',
+    });
+    const output = `${result.stdout ?? ''}${result.stderr ?? ''}`;
+    const named = output.includes(spec.expect);
+    const first = output.split('\n').find((line) => line.trim()) ?? '';
+    return {
+      name,
+      status: result.status,
+      named,
+      ok: result.status !== 0 && named,
+      first: first.trim(),
+    };
+  } finally {
+    removeFixture(written, root);
+  }
+}
+
+/**
+ * Gates that answer the teeth question in neither table, and gates that answer it twice.
+ *
+ * @param {string[]} [claimed] Declared gates.
+ * @param {object} [proven] Proven table.
+ * @param {object} [unproven] Unproven table.
+ * @returns {{undeclared: string[], doubled: string[], unknown: string[]}} Drift.
+ */
+export function tableDrift(claimed = CLAIMED_GATES, proven = PROVEN, unproven = UNPROVEN) {
+  const undeclared = claimed.filter(
+    (gate) => !Object.hasOwn(proven, gate) && !Object.hasOwn(unproven, gate),
+  );
+  const doubled = claimed.filter(
+    (gate) => Object.hasOwn(proven, gate) && Object.hasOwn(unproven, gate),
+  );
+  const known = new Set(claimed);
+  const unknown = [...Object.keys(proven), ...Object.keys(unproven)].filter(
+    (gate) => !known.has(gate),
+  );
+  return { undeclared, doubled, unknown };
+}
+
+/**
+ * Run every proven fixture and describe the result.
+ *
+ * @param {object} [proven] Proven table.
+ * @param {string} [repoRoot] Source of the gates.
+ * @returns {{lines: string[], failed: boolean}} Report.
+ */
+export function report(proven = PROVEN, repoRoot = REPO_ROOT) {
+  const lines = [];
+  const results = Object.entries(proven).map(([name, spec]) => proveTeeth(name, spec, repoRoot));
+  const drift = tableDrift();
+
+  lines.push(`Executed ${results.length} gate(s) against a violating fixture:`);
+  for (const result of results) {
+    const verdict = result.ok
+      ? 'teeth'
+      : result.status === 0
+        ? 'NO TEETH (exited 0 over a violation)'
+        : 'FAILED FOR ANOTHER REASON (report did not name the violation)';
+    lines.push(`  ${result.name} -> exit ${result.status} ${verdict}`);
+    if (!result.ok) lines.push(`      first line: ${result.first}`);
+  }
+
+  lines.push('');
+  lines.push(`${Object.keys(UNPROVEN).length} declared gate(s) have teeth unproven here:`);
+  for (const [name, entry] of Object.entries(UNPROVEN)) {
+    lines.push(`  ${name}`);
+    lines.push(`      criterion: ${entry.criterion}`);
+  }
+
+  const failures = results.filter((result) => !result.ok);
+  if (drift.undeclared.length > 0) {
+    lines.push('');
+    lines.push('Declared gate(s) answering the teeth question in neither table:');
+    for (const gate of drift.undeclared) lines.push(`  ${gate}`);
+    lines.push('Add a fixture to PROVEN, or a criterion to UNPROVEN.');
+  }
+  if (drift.doubled.length > 0) {
+    lines.push('');
+    lines.push('Gate(s) present in both tables:');
+    for (const gate of drift.doubled) lines.push(`  ${gate}`);
+  }
+  if (drift.unknown.length > 0) {
+    lines.push('');
+    lines.push('Table entr(ies) naming no declared gate:');
+    for (const gate of drift.unknown) lines.push(`  ${gate}`);
+  }
+
+  lines.push('');
+  lines.push(
+    'A non-zero exit alone is not proof: a fixture that fails to scaffold also exits non-zero.',
+  );
+  lines.push('Each row above required the report to name the violation it was given.');
+
+  return {
+    lines,
+    failed:
+      failures.length > 0 ||
+      drift.undeclared.length > 0 ||
+      drift.doubled.length > 0 ||
+      drift.unknown.length > 0,
+  };
+}
+
+/**
+ * Entry point.
+ *
+ * @returns {void}
+ */
+function main() {
+  const result = report();
+  for (const line of result.lines) console.log(line);
+  process.exitCode = result.failed ? 1 : 0;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) main();

--- a/tools/check-gate-teeth.test.mjs
+++ b/tools/check-gate-teeth.test.mjs
@@ -1,0 +1,179 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmdirSync, unlinkSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import { CLAIMED_GATES } from './check-gate-enforcement.mjs';
+import { PROVEN, UNPROVEN, proveTeeth, report, tableDrift } from './check-gate-teeth.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+/**
+ * Build a throwaway repository containing one script, and clean up by name.
+ *
+ * @param {string} body Script source.
+ * @param {(root: string, script: string) => void} run Receives the fixture root and script path.
+ * @returns {void}
+ */
+function withScript(body, run) {
+  const root = mkdtempSync(path.join(tmpdir(), 'teeth-test-'));
+  const tools = path.join(root, 'tools');
+  const lib = path.join(tools, 'lib');
+  mkdirSync(lib, { recursive: true });
+  const script = path.join(tools, 'subject.mjs');
+  writeFileSync(script, body);
+  writeFileSync(path.join(lib, 'markdown.mjs'), 'export const markFences = () => [];\n');
+  writeFileSync(path.join(lib, 'source.mjs'), 'export const stripLiterals = (s) => s;\n');
+  try {
+    run(root, script);
+  } finally {
+    for (const file of [
+      script,
+      path.join(lib, 'markdown.mjs'),
+      path.join(lib, 'source.mjs'),
+      path.join(root, 'trigger.txt'),
+    ]) {
+      try {
+        unlinkSync(file);
+      } catch {
+        /* not created by this case */
+      }
+    }
+    for (const dir of [lib, tools, root]) {
+      try {
+        rmdirSync(dir);
+      } catch {
+        /* non-empty */
+      }
+    }
+  }
+}
+
+test('every declared gate answers the teeth question in exactly one table', () => {
+  const drift = tableDrift();
+  assert.deepEqual(drift.undeclared, [], 'a declared gate names neither a fixture nor a criterion');
+  assert.deepEqual(drift.doubled, [], 'a gate cannot be both proven and unproven');
+  assert.deepEqual(drift.unknown, [], 'a table entry names a gate that is not declared');
+});
+
+test('the two tables partition the declared gates exactly', () => {
+  const covered = new Set([...Object.keys(PROVEN), ...Object.keys(UNPROVEN)]);
+  for (const gate of CLAIMED_GATES) assert.ok(covered.has(gate), `${gate} is unanswered`);
+  assert.equal(covered.size, CLAIMED_GATES.length);
+});
+
+test('a gate that exits zero over its violation is reported as having no teeth', () => {
+  withScript("console.log('all clear');\n", (root, script) => {
+    const result = proveTeeth(
+      'fake:gate',
+      { script: 'tools/subject.mjs', files: {}, expect: 'all clear' },
+      root,
+    );
+    assert.equal(result.status, 0);
+    assert.equal(result.named, true, 'the expected substring is present, so only the exit fails');
+    assert.equal(result.ok, false, 'naming the violation cannot rescue a zero exit');
+    assert.ok(script.endsWith('subject.mjs'));
+  });
+});
+
+test('a non-zero exit whose report does not name the violation is not proof', () => {
+  withScript("console.error('scaffolding failed');\nprocess.exit(1);\n", (root) => {
+    const result = proveTeeth(
+      'fake:gate',
+      { script: 'tools/subject.mjs', files: {}, expect: 'the-actual-violation' },
+      root,
+    );
+    assert.equal(result.status, 1, 'it did fail');
+    assert.equal(result.named, false, 'but not for the reason under test');
+    assert.equal(result.ok, false, 'which is exactly the false positive this rejects');
+  });
+});
+
+test('a gate that fails and names its violation is proof', () => {
+  withScript("console.log('found the-actual-violation here');\nprocess.exit(1);\n", (root) => {
+    const result = proveTeeth(
+      'fake:gate',
+      { script: 'tools/subject.mjs', files: {}, expect: 'the-actual-violation' },
+      root,
+    );
+    assert.equal(result.ok, true);
+  });
+});
+
+test('a ternary exit is detected, because the exit code is observed rather than matched', () => {
+  withScript(
+    "const ok = false;\nconsole.log('the-actual-violation');\nprocess.exit(ok ? 0 : 1);\n",
+    (root) => {
+      const result = proveTeeth(
+        'fake:gate',
+        { script: 'tools/subject.mjs', files: {}, expect: 'the-actual-violation' },
+        root,
+      );
+      assert.equal(
+        result.ok,
+        true,
+        'process.exit(cond ? 0 : 1) is invisible to a /exit\\(1\\)/ scan',
+      );
+    },
+  );
+});
+
+test('a fixture file reaches the gate under test', () => {
+  withScript(
+    "import fs from 'node:fs';\n" +
+      "const seen = fs.readFileSync(new URL('../trigger.txt', import.meta.url), 'utf8');\n" +
+      'console.log(seen.trim());\n' +
+      'process.exit(1);\n',
+    (root) => {
+      const result = proveTeeth(
+        'fake:gate',
+        {
+          script: 'tools/subject.mjs',
+          files: { 'trigger.txt': 'planted-content\n' },
+          expect: 'planted-content',
+        },
+        root,
+      );
+      assert.equal(result.ok, true, 'the fixture is what the gate read');
+    },
+  );
+});
+
+test('every unproven entry states a criterion rather than a state', () => {
+  for (const [gate, entry] of Object.entries(UNPROVEN)) {
+    assert.equal(typeof entry.criterion, 'string', `${gate} has no criterion`);
+    assert.ok(entry.criterion.length > 0, `${gate} has an empty criterion`);
+    assert.ok(
+      !/\byet\b|\bnot written\b|\btodo\b/i.test(entry.criterion),
+      `${gate} states a condition that stops being true without anything noticing`,
+    );
+  }
+});
+
+test('every proven entry requires the report to name something', () => {
+  for (const [gate, spec] of Object.entries(PROVEN)) {
+    assert.ok(spec.expect && spec.expect.length > 0, `${gate} would accept any non-zero exit`);
+    assert.ok(spec.script.endsWith('.mjs') || spec.script.endsWith('.js'), `${gate} script shape`);
+  }
+});
+
+test('the shipped fixtures all demonstrate teeth', () => {
+  const result = report(PROVEN, repoRoot);
+  assert.equal(result.failed, false, result.lines.join('\n'));
+  for (const gate of Object.keys(PROVEN)) {
+    assert.ok(
+      result.lines.some((line) => line.includes(gate) && line.includes('teeth')),
+      `${gate} is not reported as proven`,
+    );
+  }
+});
+
+test('the report itemises every gate rather than summarising a count', () => {
+  const result = report(PROVEN, repoRoot);
+  const text = result.lines.join('\n');
+  for (const gate of [...Object.keys(PROVEN), ...Object.keys(UNPROVEN)]) {
+    assert.ok(text.includes(gate), `${gate} is absent from a report a reader must check by name`);
+  }
+});

--- a/tools/check-tool-imports.mjs
+++ b/tools/check-tool-imports.mjs
@@ -20,6 +20,8 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { builtinModules } from 'node:module';
 
+import { insideLiteral, literalSpans } from './lib/source.mjs';
+
 const BUILTINS = new Set(builtinModules);
 
 /** Directories whose top-level scripts run from the repository root. */
@@ -78,11 +80,38 @@ export function findModuleReferences(text) {
   ];
   for (const pattern of patterns) {
     for (const match of source.matchAll(pattern)) {
+      if (keywordIsQuoted(source, match)) continue;
       const line = source.slice(0, match.index).split('\n').length;
       references.push({ specifier: match[1], line });
     }
   }
   return references.sort((a, b) => a.line - b.line || a.specifier.localeCompare(b.specifier));
+}
+
+/**
+ * True when the `import`/`export`/`require` keyword of a match is itself inside a string literal.
+ *
+ * A tool that embeds example source as data -- a fixture, a docstring, a generated file -- contains
+ * import statements that are text, not code. Reading them as code is an over-report, which the
+ * contract above forbids and which this checker did against `check-gate-teeth.mjs` (#4340): a
+ * fixture whose whole purpose is an undeclared import was reported as an undeclared import.
+ *
+ * The specifier cannot be used to make this decision, because a specifier is always a literal. The
+ * keyword can: in real code it sits at statement level, and in embedded text it sits inside a
+ * quote. `literalSpans` is escape-aware, so a quote inside a fixture does not end the span early.
+ *
+ * @param {string} source Whole file.
+ * @param {RegExpMatchArray} match A match from one of the reference patterns.
+ * @returns {boolean} Whether this match is embedded text rather than a statement.
+ */
+function keywordIsQuoted(source, match) {
+  const keyword = /\b(?:import|export|require)\b/.exec(match[0]);
+  if (!keyword) return false;
+  const absolute = match.index + keyword.index;
+  const lineStart = source.lastIndexOf('\n', absolute - 1) + 1;
+  const newline = source.indexOf('\n', absolute);
+  const lineText = source.slice(lineStart, newline === -1 ? source.length : newline);
+  return insideLiteral(literalSpans(lineText), absolute - lineStart);
 }
 
 /** Reports references to packages absent from the declared dependency set. */

--- a/tools/check-tool-imports.test.mjs
+++ b/tools/check-tool-imports.test.mjs
@@ -170,3 +170,58 @@ test('a passing run states the same scope, so the two branches agree', () => {
   assert.match(result.stdout, /\d+ module reference\(s\) across \d+ file\(s\)/);
   assert.match(result.stdout, /\d+ test file\(s\) excluded/);
 });
+
+// An over-report is forbidden by findModuleReferences's own contract, and it
+// shipped one: a tool that embeds example source as data had its embedded
+// `import` read as code (#4340). check-gate-teeth.mjs is that tool -- its
+// fixtures are literally undeclared imports -- so the checker reported the
+// fixture whose purpose is to be a fixture.
+
+test('an import inside a string literal is data, not a statement', () => {
+  const refs = findModuleReferences('const fixture = "import x from \'embedded-pkg\';";\n');
+  assert.deepEqual(
+    refs.map((r) => r.specifier),
+    [],
+    'the keyword sits inside a quote, so it is text the file contains rather than code it runs',
+  );
+});
+
+test('a real import is still found when the file also embeds a quoted one', () => {
+  const source =
+    "import real from 'real-pkg';\nconst fixture = \"import fake from 'fake-pkg';\";\n";
+  assert.deepEqual(
+    findModuleReferences(source).map((r) => r.specifier),
+    ['real-pkg'],
+  );
+});
+
+test('a quoted require in a comment is excluded, and a block comment is not', () => {
+  assert.deepEqual(
+    findModuleReferences("// calling require('./thing.js') here would exit\n").map(
+      (r) => r.specifier,
+    ),
+    [],
+    'tools/ai-manifest.js:39 is exactly this shape',
+  );
+  // Stated because the line above could be mistaken for comment awareness. It
+  // is not: literalSpans ends a line at `//`, and tracks nothing across lines,
+  // so a block comment or a JSDoc body is still read as code. Measured, not
+  // assumed -- the first version of this test asserted the opposite and the
+  // run disagreed.
+  assert.deepEqual(
+    findModuleReferences('/* example: import x from "pkg-in-block" */\n').map((r) => r.specifier),
+    ['pkg-in-block'],
+  );
+  assert.deepEqual(
+    findModuleReferences(' * example: import x from "pkg-in-jsdoc"\n').map((r) => r.specifier),
+    ['pkg-in-jsdoc'],
+  );
+});
+
+test('a dynamic import inside a template is left alone rather than guessed at', () => {
+  assert.deepEqual(
+    findModuleReferences("const m = await import('real-dynamic');\n").map((r) => r.specifier),
+    ['real-dynamic'],
+    'the specifier is a literal but the keyword is not, so the guard must not fire',
+  );
+});


### PR DESCRIPTION
## Summary

`gate:enforcement` proves every declared gate is a real workflow step. It cannot prove any of them
can fail. A gate that is wired, resolves, and returns zero on every input is indistinguishable
from a working one by everything this repo previously ran.

`gate:teeth` closes that. It executes each proven gate against a minimal violating fixture and
requires **both** a non-zero exit **and** a report containing a declared substring naming the
violation. The second requirement is load-bearing: four fixtures exited non-zero for reasons
unrelated to the defect they contained (no git repo, no `package.json`, and one that tripped a
scan-root assertion). An exit code is a verdict on whichever question the program asked; only the
report says which question that was.

## Changes

- **New `tools/check-gate-teeth.mjs`** — 4 gates proven by execution, 12 recorded unproven with
  the criterion blocking each. The table is asserted against the declared-gate list, so a new gate
  fails the check rather than silently defaulting to unproven.
- **New `tools/check-gate-teeth.test.mjs`** — 11 tests, including negative controls proving the
  prober rejects a zero exit and rejects a non-zero exit whose report does not name the violation.
- Wired as gate #16: `package.json`, `ci-lint.yml`, and `CLAIMED_GATES`.
- **`check-assertion-bounds.mjs`** — header claimed the population was "precisely the set of
  invented numbers"; the census extracts inequalities only. Narrowed to "in a comparison", with
  the excluded class recorded: 265 equality-against-literal sites across 16 test files. Widening
  was rejected, not deferred — most are sound by construction and the residue is not separable.
- **`check-tool-imports.mjs`** — over-reported `import`/`require` keywords inside string literals,
  violating its own "under-decide, never over-report" contract. Guard keys on the **keyword**
  position, not the specifier (a specifier is always a literal, so it cannot distinguish). Also
  corrects a pre-existing over-report at `tools/ai-manifest.js:39`.
- Adoption guide records the round, including five refuted predictions.

## Five detectors that were wrong

All caught by running the thing, not by reading it:

1. `tools\*.mjs` missed 2 of 15 gates (`.js` file; one in `scripts/`).
2. `process.exit(1)` missed `process.exit(result.ok ? 0 : 1)` — a ternary.
3. A predicted Windows path defect in `check-gradle-prefetch.mjs` does not exist; `URL`
   normalises the drive letter.
4. Accepting any non-zero exit produced false teeth.
5. A comment claiming the literal guard ignores comments was wrong in both directions: line
   comments *are* excluded, block and JSDoc comments are *not*.

## Issues

Closes #4340

## Testing

- [x] `node tools/run-tool-tests.mjs` — 729 pass / 0 fail
- [x] All 16 declared gates EXIT=0
- [x] `npm run format:check`, `npx eslint . --max-warnings 0`, `npm run type-check` — all clean