### PR TITLE
fix(tools): execute the recorded blockers, three of which were false

### DIFF
--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -9989,6 +9989,76 @@ position, not the specifier: a specifier is always inside a literal, so it canno
 two cases, whereas the keyword can. Reference count moved 164 to 169. The same guard corrected a
 pre-existing over-report at `tools/ai-manifest.js:39`, a `require` inside a line comment.
 
+## A recorded reason is a claim, and three of mine were false
+
+`gate:teeth` shipped with 12 gates marked unproven, each carrying a criterion naming what blocked
+a fixture from demonstrating its teeth. The criteria were written by reading the tools. **None was
+executed.**
+
+Three were wrong. `encoding:check`, `docs:links:check`, and `gate:enforcement` each named "the
+fixture needs a git repository and an index" as the obstacle -- accurate as a description of the
+requirement, and false as a blocker, because a fixture can be a repository. `git init` plus
+`git add` costs milliseconds. All three now prove teeth: exit 1, with the report naming the
+violation.
+
+`test:independence:check` was tested too and stays unproven -- a fixture pairing a tool and test
+on an identical object literal did not trigger it, so the shape it detects is narrower than a
+shared literal. That is recorded as an executed criterion rather than quietly left in the pile.
+
+The remaining entries now declare `tested: false`. A criterion is itself a claim about behaviour,
+so it carries exactly the burden this gate exists to enforce; one that has never been run should
+not read like a measurement. The distinction is asserted by a test, so a new entry must decide.
+
+### Unproven understates it: the enforcement is also unguarded
+
+Measured by mutation. Deleting `process.exit(1)` from `tools/check-upstream-refs.mjs`:
+
+```
+gate:teeth        EXIT=0
+gate:enforcement  EXIT=0
+the gate itself   EXIT=0
+full test suite   EXIT=0   (729 pass, 0 fail)
+```
+
+Nothing in the repository notices a gate losing its enforcement. The same mutation applied to
+each proven gate is caught (`EXIT=1` in every case). So proving teeth is not only documentation --
+it is the only thing standing between a gate and silent removal of its failure path. That is the
+argument for shrinking the unproven set rather than maintaining a tidy list of excuses.
+
+A test that re-derives its tool's logic cannot detect this, because there is no execution for a
+behavioural claim to attach to. Of 18 tool test files, 3 spawn a gate and assert its exit status.
+
+### A census that collides on a name
+
+The first pass at that count matched `.status` across the test files and reported 5. Two of those
+are `check-ai-manifest.test.mjs` asserting a _domain_ field named `status` -- nothing to do with an
+exit code. A name-based census has two independent error modes, over- and under-inclusion, and
+neither is visible in its output.
+
+### Deleting by name is not enough if the enumeration crossed a link
+
+During cleanup in the previous round, a scratch fixture directory contained a `node_modules`
+junction pointing into this worktree. The removal enumerated recursively, followed the junction,
+and deleted through it: `node_modules` plus **2,825 tracked files**. Everything was committed, so
+`git reset --hard` and `npm ci` restored it fully, and the anomaly surfaced because the file counts
+disagreed (412,014 enumerated against 68,669 deleted).
+
+The repository rule is to delete by name and never recursively. The incident names the part the
+rule leaves implicit: **deleting by name is only bounded if the enumeration that produced the names
+was bounded.** A recursive walk that crosses a reparse point produces names outside the tree you
+believe you are deleting, and every individual deletion then looks compliant.
+
+`walkFixture` in `check-gate-teeth.mjs` stops at a symlink or junction rather than descending.
+
+### The leak that the same walk fixed
+
+Adding it exposed an unrelated defect in the original cleanup, which removed `dirname()` of every
+file it wrote. An intermediate directory created on the way to a nested one is never any file's
+dirname, so the gradle fixture's `.github` survived every run and left its root non-empty. **24
+orphaned directories** had accumulated, while the tool reported clean removal each time. The
+population of directories created is not the population of dirnames written -- a population error
+of the same shape as the `tools\*.mjs` glob, in the cleanup rather than the census.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:

--- a/tools/check-gate-teeth.mjs
+++ b/tools/check-gate-teeth.mjs
@@ -45,9 +45,11 @@
  */
 
 import {
+  chmodSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  readdirSync,
   rmdirSync,
   unlinkSync,
   writeFileSync,
@@ -73,9 +75,13 @@ const LIB = ['tools/lib/markdown.mjs', 'tools/lib/source.mjs'];
  *
  * `files` is written into a throwaway directory alongside a copy of the gate. `expect` is a
  * substring the report must contain; without it a fixture that failed to scaffold would count as
- * a pass. Every fixture here runs with no git repository and no `node_modules`, verified
- * deterministic across repeated passes -- a fixture that needs either is a fixture whose result
- * depends on the machine.
+ * a pass. `repo: true` initialises a git repository and stages the files, for gates that
+ * enumerate their population through git rather than the filesystem.
+ *
+ * No fixture here uses `node_modules`. An earlier round linked one in and `git add -A` ingested
+ * it, changing the tracked population between runs; the cleanup that followed traversed the link
+ * and deleted through it. Fixtures stay dependency-free so that both the result and the removal
+ * are bounded by what this file wrote.
  */
 export const PROVEN = {
   'tool:imports:check': {
@@ -110,6 +116,28 @@ export const PROVEN = {
     },
     expect: 'Prefetch Gradle distribution',
   },
+  'encoding:check': {
+    script: 'tools/check-text-encoding.mjs',
+    repo: true,
+    files: { 'lost.txt': 'hi\uFFFD\n' },
+    expect: 'U+FFFD replacement character',
+  },
+  'docs:links:check': {
+    script: 'tools/check-doc-links.mjs',
+    repo: true,
+    files: { 'docs/a.md': '# A\n\nSee [gone](./nowhere-at-all.md).\n' },
+    expect: './nowhere-at-all.md',
+  },
+  'gate:enforcement': {
+    script: 'tools/check-gate-enforcement.mjs',
+    repo: true,
+    files: {
+      'package.json': '{"name":"fixture","scripts":{"bounds:check":"node tools/x.mjs"}}\n',
+      '.github/workflows/ci.yml':
+        'name: CI\non: [push]\njobs:\n  a:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n',
+    },
+    expect: 'reached by no workflow',
+  },
 };
 
 /**
@@ -118,42 +146,50 @@ export const PROVEN = {
  * These are open, not excused. The criterion is what a reader checks to decide whether the entry
  * still belongs; none of them is "nobody has written it yet," which would be a state and would
  * silently stop being true.
+ *
+ * `tested` records whether the criterion was executed or reasoned from reading the gate. The
+ * distinction is here because the first version of this table reasoned all twelve and three were
+ * wrong: `encoding:check`, `docs:links:check`, and `gate:enforcement` each named a git repository
+ * as the obstacle, and a fixture can be one (#4343). A criterion that has never been run is a
+ * claim about behaviour with no execution behind it, which is the defect this whole file exists
+ * to catch -- so an untested criterion says so rather than reading like a measurement.
  */
 export const UNPROVEN = {
   'eng:citations': {
+    tested: false,
     criterion: 'scans the whole repository, so a fixture large enough to trigger it is the tree',
   },
   'eng:vendor:check': {
+    tested: false,
     criterion: 'compares against a vendored upstream tree, which a fixture would have to vendor',
   },
   'ai:manifest:check': {
+    tested: false,
     criterion: 'requires a signed manifest whose stamp a fixture would have to forge',
   },
-  'encoding:check': {
-    criterion: 'enumerates tracked files via git, so the fixture needs a repository and an index',
-  },
   'workflow:security:check': {
+    tested: false,
     criterion: 'imports js-yaml, so the fixture depends on an installed node_modules',
   },
   'upstream:refs:check': {
+    tested: false,
     criterion: 'resolves references against sibling repositories that a fixture cannot supply',
   },
   'citations:enumerations:check': {
+    tested: false,
     criterion: 'already executed with a non-zero assertion by check-citation-enumerations.test.mjs',
   },
   'node:version:check': {
+    tested: false,
     criterion: 'imports semver, so the fixture depends on an installed node_modules',
   },
-  'docs:links:check': {
-    criterion: 'enumerates tracked files via git, so the fixture needs a repository and an index',
-  },
   'test:independence:check': {
-    criterion: 'pairs tools with tests via git-tracked paths, so the fixture needs an index',
-  },
-  'gate:enforcement': {
-    criterion: 'reads package.json scripts and workflow files together, so its fixture is a repo',
+    tested: true,
+    criterion:
+      'a git-backed fixture pairing a tool and test on an identical object literal did not trigger it, so the shape it detects is narrower than a shared literal',
   },
   'gate:teeth': {
+    tested: false,
     criterion:
       'its fixture would need a copy of every gate it proves, so the fixture is the repository',
   },
@@ -185,18 +221,61 @@ function writeFixtureFile(root, rel, content) {
  * @param {string} root Fixture root.
  * @returns {void}
  */
+/**
+ * Every file under a directory, without following links.
+ *
+ * `git init` creates several hundred entries this file did not write, so removal by remembered
+ * name is not enough for a repo-backed fixture. Recursion stops at a symlink or junction: an
+ * earlier round enumerated through one and deleted the files it pointed at (#4340).
+ *
+ * @param {string} dir Directory to walk.
+ * @returns {{files: string[], dirs: string[]}} Absolute paths, directories deepest last.
+ */
+function walkFixture(dir) {
+  const files = [];
+  const dirs = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isSymbolicLink()) {
+      files.push(full);
+      continue;
+    }
+    if (entry.isDirectory()) {
+      dirs.push(full);
+      const nested = walkFixture(full);
+      files.push(...nested.files);
+      dirs.push(...nested.dirs);
+      continue;
+    }
+    files.push(full);
+  }
+  return { files, dirs };
+}
+
 function removeFixture(files, root) {
-  for (const file of files) {
+  let all = files;
+  let dirs = [...new Set(files.map((file) => path.dirname(file)))];
+  try {
+    const walked = walkFixture(root);
+    all = [...new Set([...files, ...walked.files])];
+    dirs = [...new Set([...dirs, ...walked.dirs])];
+  } catch {
+    /* root already gone */
+  }
+  for (const file of all) {
     try {
       unlinkSync(file);
     } catch {
-      /* already gone */
+      try {
+        // git writes its object and pack files read-only.
+        chmodSync(file, 0o666);
+        unlinkSync(file);
+      } catch {
+        /* already gone */
+      }
     }
   }
-  const dirs = [...new Set(files.map((file) => path.dirname(file)))].sort(
-    (a, b) => b.length - a.length,
-  );
-  for (const dir of [...dirs, root]) {
+  for (const dir of [...dirs.sort((a, b) => b.length - a.length), root]) {
     try {
       rmdirSync(dir);
     } catch {
@@ -226,6 +305,22 @@ export function proveTeeth(name, spec, repoRoot = REPO_ROOT) {
     }
     for (const [rel, content] of Object.entries(spec.files)) {
       written.push(writeFixtureFile(root, rel, content));
+    }
+    if (spec.repo) {
+      const git = (...args) => spawnSync('git', args, { cwd: root, encoding: 'utf8' });
+      git('init', '-q');
+      git('config', 'user.email', 'fixture@example.invalid');
+      git('config', 'user.name', 'fixture');
+      const staged = git('add', '-A');
+      if (staged.status !== 0) {
+        return {
+          name,
+          status: staged.status,
+          named: false,
+          ok: false,
+          first: 'fixture could not stage files, so the gate never ran',
+        };
+      }
     }
     const result = spawnSync(process.execPath, [path.join(root, spec.script)], {
       cwd: root,

--- a/tools/check-gate-teeth.test.mjs
+++ b/tools/check-gate-teeth.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdtempSync, rmdirSync, unlinkSync, writeFileSync, mkdirSync } from 'node:fs';
+import { mkdtempSync, readdirSync, rmdirSync, unlinkSync, writeFileSync, mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
@@ -175,5 +175,49 @@ test('the report itemises every gate rather than summarising a count', () => {
   const text = result.lines.join('\n');
   for (const gate of [...Object.keys(PROVEN), ...Object.keys(UNPROVEN)]) {
     assert.ok(text.includes(gate), `${gate} is absent from a report a reader must check by name`);
+  }
+});
+
+test('a repo-backed fixture leaves no directory behind', () => {
+  // Regression for a leak in the first version (#4340): cleanup enumerated
+  // dirname() of each written file, which never yields an intermediate
+  // directory created on the way to a nested one. The gradle fixture writes
+  // .github/workflows/x.yml, so .github survived every run and left the root
+  // non-empty -- 24 orphaned directories accumulated before anything counted
+  // them. The population of directories created is not the population of
+  // dirnames written.
+  const before = new Set(
+    readdirSync(tmpdir(), { withFileTypes: true })
+      .filter((e) => e.isDirectory() && e.name.startsWith('gate-teeth-'))
+      .map((e) => e.name),
+  );
+  const repoBacked = Object.entries(PROVEN).filter(([, spec]) => spec.repo);
+  assert.ok(repoBacked.length > 0, 'no repo-backed fixture to exercise');
+  for (const [name, spec] of repoBacked) proveTeeth(name, spec);
+  const after = readdirSync(tmpdir(), { withFileTypes: true })
+    .filter((e) => e.isDirectory() && e.name.startsWith('gate-teeth-'))
+    .map((e) => e.name)
+    .filter((n) => !before.has(n));
+  assert.deepEqual(after, [], 'a fixture directory outlived the run that made it');
+});
+
+test('a repo-backed fixture is actually a repository, so the gate is not passing by accident', () => {
+  // Without this, a gate that enumerates via git would report an empty
+  // population and exit 0, and the entry would look like a wrong criterion
+  // rather than a broken fixture.
+  for (const [name, spec] of Object.entries(PROVEN)) {
+    if (!spec.repo) continue;
+    const result = proveTeeth(name, spec);
+    assert.notEqual(result.status, 0, `${name} exited zero against its violation`);
+    assert.ok(result.named, `${name} failed without naming ${spec.expect}`);
+  }
+});
+
+test('an unproven criterion declares whether it was executed or reasoned', () => {
+  // Three of the original twelve criteria were reasoned from reading the tool
+  // and were false (#4343). A criterion is itself a claim about behaviour, so
+  // it carries the same burden as the prose this file exists to check.
+  for (const [name, spec] of Object.entries(UNPROVEN)) {
+    assert.equal(typeof spec.tested, 'boolean', `${name} does not say whether it was tested`);
   }
 });


### PR DESCRIPTION
## Summary

`gate:teeth` (#4340) recorded 12 gates as unproven, each with a `criterion` naming what blocked a
fixture from demonstrating its teeth. The criteria were written by reading the tools. **None had
been executed.**

Three were false. `encoding:check`, `docs:links:check`, and `gate:enforcement` each named "the
fixture needs a git repository and an index" — accurate as a description of the requirement, wrong
that it blocked, because a fixture can be a repository. Proven gates go **4 → 7**.

## Unproven understates it

Measured by mutation. Deleting `process.exit(1)` from `tools/check-upstream-refs.mjs`:

```
gate:teeth        EXIT=0
gate:enforcement  EXIT=0
the gate itself   EXIT=0
full test suite   EXIT=0   (729 pass, 0 fail)
```

Nothing notices a gate losing its enforcement. The same mutation against each *proven* gate is
caught (`EXIT=1` in all three tested). Proving teeth is therefore not documentation — it is the
only thing standing between a gate and silent removal of its failure path.

## Changes

- Git-backed fixtures (`repo: true`), with an explicit failure result if staging fails, so a
  broken fixture cannot be mistaken for a wrong criterion.
- `encoding:check`, `docs:links:check`, `gate:enforcement` moved to `PROVEN`, each with an
  `expect` substring naming its violation.
- `test:independence:check` **tested and left unproven** — a fixture pairing a tool and test on an
  identical object literal did not trigger it. Recorded as executed rather than quietly left.
- Remaining criteria declare `tested: false`; a test asserts every entry decides. A criterion is
  itself a behavioural claim and carries the burden this gate exists to enforce.
- **Cleanup leak fixed.** The original removed `dirname()` of each written file; an intermediate
  directory created on the way to a nested one is never any file's dirname, so the gradle
  fixture's `.github` survived every run. **24 orphaned directories** had accumulated while the
  tool reported clean removal. Regression test included.
- **`walkFixture` stops at symlinks and junctions.** In #4340 a scratch fixture held a
  `node_modules` junction into this worktree; a recursive removal followed it and deleted 2,825
  tracked files (fully restored from HEAD). Deleting by name is only bounded if the enumeration
  that produced the names was bounded.

## Issues

Closes #4343

## Testing

- [x] `node tools/run-tool-tests.mjs` — 732 pass / 0 fail
- [x] All 16 gates EXIT=0; 0 leftover fixture directories
- [x] `format:check`, `eslint --max-warnings 0`, `type-check` — clean