### PR TITLE
fix(tools): ask git rather than reimplementing .gitignore

### DIFF
--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -10059,6 +10059,53 @@ orphaned directories** had accumulated, while the tool reported clean removal ea
 population of directories created is not the population of dirnames written -- a population error
 of the same shape as the `tools\*.mjs` glob, in the cleanup rather than the census.
 
+## Do not reimplement a format the tool that owns it will answer for you
+
+`generatedAllowances()` parsed `.gitignore` to decide which allowlist keys name an untracked path.
+That is a reimplementation of a format with negation, globs, anchoring, and per-directory files,
+and it was wrong in two ways at once.
+
+`.gitignore:85` is `!tools/windows/dev-cert/.gitkeep` -- a **re-inclusion**. The parser dropped
+comments and glob lines, so the `!` line entered the set of declared exclusions with its sign
+inverted. No allowlist key could equal the whole string, so it never produced a wrong verdict.
+**Unexercised rather than absent** is the harder kind to find: nothing failed, nothing looked
+wrong, and no test could have caught it because the defect had no reachable consequence.
+
+Separately, every line containing `*` was discarded, so a key excluded only by a pattern such as
+`*.swp` was reported tracked. That one is a live functional gap, not a latent one.
+
+The fix is `git check-ignore --stdin`. It answers the same question with the semantics git
+actually uses, and needs no parser. This is the previous round's lesson applied one level up: _if
+the property is "what does this program do," run the program_ -- where the program is `git`, and
+the property is its own exclusion rules.
+
+A status other than 0 or 1 is treated as no verdict. Outside a repository git exits 128, and
+returning "nothing is excluded" there would assert every key is tracked, which the function has no
+basis to claim.
+
+### The name asserted a criterion the mechanism does not test
+
+The docstring described `.gitignore` as "the tree's own record of what it generates". Of finance's
+48 literal entries: **9** build output, **6** secrets, **4** editor or OS files, **29**
+unclassified. Skipping all of them is the right action -- an untracked file's presence depends on
+the machine whatever the reason -- but only nine are generated, and the reason is printed to a
+reader. Renamed to `untrackedAllowances`.
+
+Second time in three rounds that a claim was broader than the matcher inside the same file, after
+`bounds:check`. The pattern is specific enough to name: **a function's docstring tends to describe
+the motivating case, while the code implements the mechanism, and nothing compares them.**
+
+### The exclusion a declared record cannot contain
+
+Git excludes `.git` unconditionally rather than through an ignore rule, so `check-ignore` reports
+it as tracked. Nothing here is wrong today, because allowlist keys name source files and no key
+can be `.git`.
+
+It is recorded because the shape generalises: **a record of declared exclusions cannot contain the
+exclusion nobody ever had to declare.** Any verdict derived from such a record inherits a blind
+spot located exactly at its most certain content -- the entry that is true in every tree, every
+checkout, and every build state is the one that never had to be written down.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:

--- a/tools/check-markdown-primitives.mjs
+++ b/tools/check-markdown-primitives.mjs
@@ -30,6 +30,7 @@
  * guard. Nobody decides the rule is narrow; the rule is simply never observed to fail.
  */
 import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { insideLiteral, literalSpans } from './lib/source.mjs';
@@ -262,30 +263,47 @@ export function staleAllowances(sites, allowed = ALLOWED) {
 }
 
 /**
- * Allowlist keys that name a generated path, so a staleness verdict over them would be a state.
+ * Allowlist keys git excludes, so a staleness verdict over them would be a state.
  *
- * An entry is disqualified when any of its path segments is declared in `.gitignore`, which is the
- * tree's own record of what it generates. Deriving it from `.gitignore` rather than a second
- * hand-maintained list matters: a hand-maintained list of generated directories is the same kind of
- * object this whole check exists to distrust.
+ * Asks git rather than parsing `.gitignore`. The parser this replaced reimplemented a format with
+ * negation, globs, anchoring, and per-directory files, then discarded every glob line and treated
+ * a leading `!` re-inclusion as an exclusion -- finance's `.gitignore:85` carries exactly one
+ * (`!tools/windows/dev-cert/.gitkeep`), which the parser kept with its sign inverted. It could not
+ * match any key, so the defect was unexercised rather than wrong, which is the harder kind to
+ * find. `git check-ignore` decides the same question with the semantics git actually uses.
+ *
+ * The criterion is "git excludes this", not "the tree generates this". The earlier name and
+ * docstring claimed the latter, and `.gitignore` does not record it: of finance's 48 literal
+ * entries, 9 are build output, 6 are secrets, and 4 are editor or OS files. Skipping all three is
+ * right -- an untracked file's presence depends on the machine either way -- but only one of them
+ * is generated, and the disqualification reason is printed to a reader.
+ *
+ * Not covered, and structurally so: git excludes `.git` unconditionally rather than by an ignore
+ * rule, so `check-ignore` reports it as not-ignored. Allowlist keys name tracked source files, so
+ * no key can be `.git`; this is recorded because the same derivation applied to a population of
+ * directory names would inherit the gap.
  *
  * @param {string[]} keys Allowlist keys to audit.
  * @param {string} root Repository root.
- * @returns {string[]} Keys naming generated paths, ascending.
+ * @returns {string[]} Keys git excludes, ascending.
  */
-export function generatedAllowances(keys, root) {
-  let ignored;
-  try {
-    ignored = new Set(
-      readFileSync(path.join(root, '.gitignore'), 'utf8')
-        .split('\n')
-        .map((line) => line.trim().replace(/^\/+|\/+$/g, ''))
-        .filter((line) => line && !line.startsWith('#') && !line.includes('*')),
-    );
-  } catch {
-    return [];
-  }
-  return keys.filter((key) => key.split(/[/\\]/).some((segment) => ignored.has(segment))).sort();
+export function untrackedAllowances(keys, root) {
+  if (keys.length === 0) return [];
+  const result = spawnSync('git', ['check-ignore', '--stdin'], {
+    cwd: root,
+    input: `${keys.join('\n')}\n`,
+    encoding: 'utf8',
+  });
+  // 0 = some path ignored, 1 = none ignored. Anything else (128 outside a repository, or git
+  // missing) is not a verdict, and returning [] there would assert every key is tracked.
+  if (result.status !== 0 && result.status !== 1) return [];
+  const excluded = new Set(
+    (result.stdout ?? '')
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean),
+  );
+  return keys.filter((key) => excluded.has(key)).sort();
 }
 
 /**
@@ -380,11 +398,11 @@ export function main(root) {
     out.push(...censusLines(groups, scripts.length, scripts.skippedTests.length, primitive), '');
     if (groups.unowned.length > 0) failed += 1;
     if (staleAllowances(sites, primitive.allowed).length > 0) failed += 1;
-    const generated = generatedAllowances(Object.keys(primitive.allowed), root);
-    if (generated.length > 0) {
+    const untracked = untrackedAllowances(Object.keys(primitive.allowed), root);
+    if (untracked.length > 0) {
       out.push(
-        `${primitive.label} allowance(s) naming a generated path: ${generated.join(', ')}.`,
-        'A staleness verdict over a generated path is a state -- it reads dead on a clean tree and',
+        `${primitive.label} allowance(s) naming a path git excludes: ${untracked.join(', ')}.`,
+        'A staleness verdict over an excluded path is a state -- it reads dead on a clean tree and',
         'alive on a built one. Move the allowance to a tracked path, or stop auditing it here.',
         '',
       );

--- a/tools/check-markdown-primitives.test.mjs
+++ b/tools/check-markdown-primitives.test.mjs
@@ -24,7 +24,7 @@ import {
   isScannedFile,
   PRIMITIVES,
   predicateLines,
-  generatedAllowances,
+  untrackedAllowances,
   staleAllowances,
 } from './check-markdown-primitives.mjs';
 
@@ -308,42 +308,78 @@ test('every declared primitive allowance describes a file that exists on disk', 
   }
 });
 
-test('a staleness verdict over a generated path would be a state, so it is refused (#4338)', () => {
+test('a staleness verdict over an excluded path would be a state, so it is refused (#4338)', () => {
   // The same membership test that is correct over tracked source files reports build/, dist/,
-  // .gradle/ and coverage/ dead on a clean tree and alive on a built one -- and .git dead in a
-  // worktree, where it is a file, alive in a clone. The precondition is checked, not asserted in a
-  // comment, because a comment stating a precondition is exactly the artifact this tool distrusts.
+  // .gradle/ and coverage/ dead on a clean tree and alive on a built one. The precondition is
+  // checked, not asserted in a comment, because a comment stating a precondition is exactly the
+  // artifact this tool distrusts.
+  //
+  // Not covered, structurally: git excludes .git unconditionally rather than by an ignore rule,
+  // so check-ignore reports it tracked. Allowlist keys name source files, so no key can be .git --
+  // but a derivation like this applied to directory names would inherit the gap, because a record
+  // of declared exclusions cannot contain the exclusion nobody ever had to declare.
   const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
-  assert.deepEqual(generatedAllowances(['tools/a.mjs'], repoRoot), []);
-  assert.deepEqual(generatedAllowances(['coverage/b.mjs', 'build/a.mjs'], repoRoot), [
+  assert.deepEqual(untrackedAllowances(['tools/a.mjs'], repoRoot), []);
+  assert.deepEqual(untrackedAllowances(['coverage/b.mjs', 'build/a.mjs'], repoRoot), [
     'build/a.mjs',
     'coverage/b.mjs',
   ]);
+  assert.deepEqual(untrackedAllowances(['.git/config'], repoRoot), []);
 });
 
-test('a generated segment is detected anywhere in the path, not only at the root', () => {
+test('an excluded segment is detected anywhere in the path, not only at the root', () => {
   const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
-  assert.deepEqual(generatedAllowances(['apps/web/dist/x.js'], repoRoot), ['apps/web/dist/x.js']);
+  assert.deepEqual(untrackedAllowances(['apps/web/dist/x.js'], repoRoot), ['apps/web/dist/x.js']);
 });
 
-test('the generated set is derived from .gitignore rather than a second hand-kept list', () => {
-  // A hand-maintained list of generated directories is the same kind of object this check exists
-  // to distrust, and it would need its own staleness check.
+test('the verdict comes from git rather than a hand-kept list or a reimplemented parser', () => {
+  // A hand-maintained list of excluded directories is the same kind of object this check exists
+  // to distrust. Parsing .gitignore instead is the other trap: it reimplements negation, globs,
+  // anchoring and per-directory files, and the version this replaced got the negation backwards.
   const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
   const ignored = readFileSync(path.join(repoRoot, '.gitignore'), 'utf8');
   assert.match(ignored, /^\s*build\/?\s*$/m, '.gitignore is the source of the verdict');
-  assert.deepEqual(generatedAllowances(['build/x.mjs'], repoRoot), ['build/x.mjs']);
+  assert.deepEqual(untrackedAllowances(['build/x.mjs'], repoRoot), ['build/x.mjs']);
+  // Outside a repository git cannot answer. Returning [] there asserts every key is tracked,
+  // which is a verdict this has no basis to give, so the caller sees no allowance rather than a
+  // wrong one.
   assert.deepEqual(
-    generatedAllowances(['build/x.mjs'], mkdtempSync(path.join(tmpdir(), 'ng-'))),
+    untrackedAllowances(['build/x.mjs'], mkdtempSync(path.join(tmpdir(), 'ng-'))),
     [],
   );
+});
+
+test('a re-inclusion is not read as an exclusion (#4345)', () => {
+  // .gitignore:85 carries `!tools/windows/dev-cert/.gitkeep`. The parser this replaced kept that
+  // line, sign inverted, as a declared exclusion. No key could match the whole string, so the
+  // defect never produced a wrong verdict -- it was unexercised rather than absent, which is why
+  // it survived review. git applies the negation, so the path is correctly reported as tracked.
+  const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+  const ignored = readFileSync(path.join(repoRoot, '.gitignore'), 'utf8');
+  assert.match(
+    ignored,
+    /^\s*!tools\/windows\/dev-cert\/\.gitkeep\s*$/m,
+    'the negation still exists',
+  );
+  assert.deepEqual(untrackedAllowances(['tools/windows/dev-cert/.gitkeep'], repoRoot), []);
+});
+
+test('a glob-only exclusion is honoured, which the literal parser discarded', () => {
+  // The parser dropped every line containing `*`, so a key excluded only by a glob was reported
+  // tracked. git honours the pattern.
+  const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+  const ignored = readFileSync(path.join(repoRoot, '.gitignore'), 'utf8');
+  const glob = ignored.split('\n').find((l) => l.trim().startsWith('*.') && !l.includes(' '));
+  assert.ok(glob, 'no glob pattern to exercise');
+  const sample = `sample${glob.trim().slice(1)}`;
+  assert.deepEqual(untrackedAllowances([sample], repoRoot), [sample]);
 });
 
 test('every shipped allowance names a tracked path, so staleAllowances stays meaningful', () => {
   const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
   for (const primitive of PRIMITIVES) {
     assert.deepEqual(
-      generatedAllowances(Object.keys(primitive.allowed), repoRoot),
+      untrackedAllowances(Object.keys(primitive.allowed), repoRoot),
       [],
       `${primitive.label} allowances are all tracked paths`,
     );


### PR DESCRIPTION
## Summary

`generatedAllowances()` (shipped in #4339) parsed `.gitignore` by hand. Parsing `.gitignore` means reimplementing negation, globs, anchoring, and per-directory files, and the implementation got two of those wrong. Replaced with `git check-ignore --stdin`.

## The two defects

- **A negation was read as an exclusion.** `.gitignore:85` is `!tools/windows/dev-cert/.gitkeep`. The parser dropped comments and glob lines, so the `!` line entered the declared-exclusion set with its sign inverted. No allowlist key can equal a path containing slashes, so it produced no wrong verdict — **unexercised rather than absent**, which is why nothing caught it.
- **Every glob line was discarded.** A key excluded only by `*.swp` was reported tracked. This one was live. Now covered by a test that discovers the first `*.`-style line in the real `.gitignore` and asserts the resulting file is excluded.

## The rename

The docstring called `.gitignore` "the tree's own record of what it generates". Of the 48 literal entries: **9** build output, **6** secrets, **4** editor/OS, **29** unclassified. Skipping all of them is the right action; only nine are generated, and the reason is printed to a reader. Renamed to `untrackedAllowances`, criterion restated as "git excludes this".

Second time in three rounds that a docstring described the motivating case while the code implemented a broader mechanism, after `bounds:check`.

## Recorded, not fixed

Git excludes `.git` unconditionally rather than via an ignore rule, so `check-ignore` reports it as tracked. No allowlist key can be `.git`, so nothing is wrong today. Recorded with an assertion because the shape generalises: a record of declared exclusions cannot contain the exclusion nobody ever had to declare.

Non-zero-non-one exit status (128 outside a repository, or git missing) returns `[]` rather than asserting every key is tracked.

## Issues

Closes #4345

## Testing

- [x] `node tools/run-tool-tests.mjs` — 734 pass / 0 fail
- [x] all 16 declared gates exit 0
- [x] `npm run format:check` / `npx eslint . --max-warnings 0` / `npm run type-check`
- [x] glob test verified non-vacuous (`sample.swp` ignored, `sample.txt` not)