### PR TITLE
fix(tools): give the gate census a failure path for omission

### DIFF
--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -10106,6 +10106,64 @@ exclusion nobody ever had to declare.** Any verdict derived from such a record i
 spot located exactly at its most certain content -- the entry that is true in every tree, every
 checkout, and every build state is the one that never had to be written down.
 
+## A census needs a failure path in both directions
+
+`check-gate-enforcement` asked whether every claimed gate reaches a workflow. It never asked
+whether every workflow-reached control is claimed. The first question is answered from a
+hand-maintained list, so the second is where the answer rots: a tool wired into CI and left out of
+`CLAIMED_GATES` was invisible to every check in the file, and the census kept reporting a complete
+set while covering less of the tree.
+
+It had already happened. Deriving the population from the tree instead -- npm scripts that resolve
+to a workflow route **and** execute a file under `tools/` or `scripts/` -- gives 28 members, of
+which 7 run test files and 21 are controls against 16 claimed. Four of the five unaccounted are
+correctly out of scope, and the fifth is not: **`i18n:validate-glossary` is a gate with teeth,
+wired at `ci-lint.yml:123`, that the census never contained.**
+
+Teeth proven by execution rather than asserted, and with the control that makes the result mean
+something:
+
+```
+baseline fixture (valid glossary)   EXIT=0
+one locale value removed            EXIT=1
+  Concept "Balance" is missing a non-blank value for locale "fr-FR".
+```
+
+The baseline passing is the whole proof. An empty fixture also exits 1, for staging reasons with
+no relation to the gate's subject, so an exit code alone would grade a broken fixture as a proven
+gate.
+
+### The classification is derived, because a name-based census has two error modes
+
+Test runners are excluded by what they execute, not by a `:test` suffix -- #4345 was a pattern that
+admitted a non-member on a substring and dropped three quarters of the real members at the same
+time. `build` and `type-check` fall out of the population because they run no repository tool,
+which stays true if either is renamed.
+
+That is not free of naming: the runner class still keys on `.test.mjs`. It is a load-bearing
+convention -- it is how `run-tool-tests.mjs` discovers what to run -- and the residual risk, a
+control that happens to match, is asserted against rather than assumed.
+
+### Fixing one route moved the defect onto another
+
+The population work exposed a second bug: `directRoute`'s file-path route matched when **any** file
+a script executes appeared in the corpus. `i18n:validate` runs two validators, only one is wired,
+and the resolver called the whole script reached.
+
+Measured before changing it: one partially-wired script, and **no claimed gate executes more than
+one file** -- so the over-credit could not yet produce a false verdict for a claimed gate.
+Unexercised rather than harmless, the same shape as #4345's inverted negation.
+
+Then the fix pushed `i18n:validate`'s false verdict onto `runsEquivalentCommand`, which had the
+identical any-vs-all form one route over. **The same defect sat in two places and the second was
+only visible once the first stopped hiding it** -- which is a specific argument for fixing a defect
+rather than only recording it, since a recorded one goes on masking its neighbour.
+
+### Recorded, not fixed
+
+`scripts/i18n/validate-locale-catalogs.js` has teeth and is executed by no workflow. Wiring it
+changes CI behaviour and deserves its own verification rather than being bundled here.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:

--- a/tools/check-gate-enforcement.mjs
+++ b/tools/check-gate-enforcement.mjs
@@ -56,12 +56,18 @@ export function commandSegments(body) {
  *
  * Matching is by prefix, because a workflow commonly appends flags the script omits.
  *
+ * Every segment must appear, for the reason `directRoute` requires every executed path: a script
+ * chaining two commands is not enforced by a workflow running only the first. Fixing the file-path
+ * route alone moved `i18n:validate`'s false verdict onto this one, so the same defect sat in two
+ * routes and the second was only visible once the first stopped hiding it (#4347).
+ *
  * @param {string} body Script body.
  * @param {string} corpus Concatenated workflow text.
- * @returns {boolean} True when some command segment also runs directly in a workflow.
+ * @returns {boolean} True when every command segment also runs directly in a workflow.
  */
 export function runsEquivalentCommand(body, corpus) {
-  return commandSegments(body).some((segment) => corpus.includes(segment));
+  const segments = commandSegments(body);
+  return segments.length > 0 && segments.every((segment) => corpus.includes(segment));
 }
 
 /**
@@ -101,9 +107,16 @@ export function directRoute(name, body, corpus) {
   if (NPM_LIFECYCLES.includes(name) && new RegExp(`npm ${escaped}(?![\\w:-])`).test(corpus)) {
     return 'npm lifecycle';
   }
-  for (const p of scriptPaths(body)) {
-    if (corpus.includes(p)) return 'file path';
-  }
+  // Every executed file must appear, not merely one. A script chaining two validators is not
+  // gated by a workflow that runs only the first: the second can start failing with CI green.
+  // `i18n:validate` runs validate-locale-catalogs.js && validate-glossary.js and only the glossary
+  // half is wired, which the any-match form graded as fully reached (#4347).
+  //
+  // Measured before changing it: 1 script is partially wired, and no claimed gate executes more
+  // than one file -- so this could not yet produce a false verdict for a claimed gate. Unexercised
+  // rather than harmless, and cheaper to correct before something depends on it.
+  const paths = scriptPaths(body);
+  if (paths.length > 0 && paths.every((p) => corpus.includes(p))) return 'file path';
   return null;
 }
 
@@ -181,6 +194,9 @@ export const CLAIMED_GATES = [
   'markdown:primitives:check',
   'gate:enforcement',
   'gate:teeth',
+  // Wired at ci-lint.yml:123 since long before this census existed, and absent from it until
+  // #4347 derived the population from the tree instead of reading the list.
+  'i18n:validate-glossary',
 ];
 
 /**
@@ -222,6 +238,115 @@ export function staleExclusions(routes, excluded = NOT_GATES) {
     .filter((name) => (routes[name] ?? null) !== null)
     .map((name) => ({ name, route: routes[name] }));
 }
+
+/**
+ * Scripts reached by a workflow that execute a repository tool, and so could be controls.
+ *
+ * The claimed set is hand-maintained, so it has an omission direction with no failure path: a tool
+ * wired into CI and left out of `CLAIMED_GATES` is invisible to every check here, and the census
+ * keeps reporting a complete set while covering less of the tree. This derives the population from
+ * the tree instead, so membership cannot decay silently (#4347).
+ *
+ * `build`, `type-check` and the like are excluded by measurement rather than by name: they execute
+ * no file under `tools/` or `scripts/`.
+ *
+ * @param {Record<string, string>} scripts Script name to body.
+ * @param {Record<string, string | null>} routes Script name to matching route.
+ * @returns {string[]} Reached, tool-executing script names, ascending.
+ */
+export function toolBackedScripts(scripts, routes) {
+  return Object.keys(scripts)
+    .filter((name) => (routes[name] ?? null) !== null && ownedPaths(scripts[name]).length > 0)
+    .sort();
+}
+
+/**
+ * The files a script executes that this repository owns.
+ *
+ * @param {string} body Script body.
+ * @returns {string[]} Executed paths under `tools/` or `scripts/`.
+ */
+export function ownedPaths(body) {
+  return scriptPaths(body).filter((p) => p.startsWith('tools/') || p.startsWith('scripts/'));
+}
+
+/**
+ * Whether a script runs test files rather than asserting a repository invariant.
+ *
+ * Derived from what the script executes, not from a `:test` suffix. A name-based census has two
+ * independent error modes and neither is visible in its output -- #4345 admitted a non-member on a
+ * substring and dropped three quarters of the real ones in the same pattern.
+ *
+ * This is still partly a naming convention (`.test.mjs`), but a load-bearing one: it is how
+ * `run-tool-tests.mjs` discovers what to run. The residual risk is a control named `*.test.mjs`,
+ * which `runnerMisreadsControl` in the tests asserts does not happen.
+ *
+ * @param {string} body Script body.
+ * @returns {boolean} True when every owned path is a test file or the tool-test runner.
+ */
+export function isTestRunner(body) {
+  const owned = ownedPaths(body);
+  return (
+    owned.length > 0 &&
+    owned.every((p) => p.endsWith('.test.mjs') || p.endsWith('run-tool-tests.mjs'))
+  );
+}
+
+/**
+ * Controls reached by a workflow that no list accounts for.
+ *
+ * This is the failure path the claimed set never had. `unenforcedClaims` asks whether every claim
+ * is true; this asks whether every truth is claimed, which is the direction that rots without
+ * anyone editing a file.
+ *
+ * @param {Record<string, string>} scripts Script name to body.
+ * @param {Record<string, string | null>} routes Script name to matching route.
+ * @param {string[]} claimed Scripts asserted to be CI gates.
+ * @param {Record<string, object>} excluded Non-gates and their reasons.
+ * @returns {{name: string, route: string}[]} Unaccounted controls, ascending by name.
+ */
+export function unclaimedControls(
+  scripts,
+  routes,
+  claimed = CLAIMED_GATES,
+  excluded = NOT_GATES,
+  known = NOT_CONTROLS,
+) {
+  return toolBackedScripts(scripts, routes)
+    .filter((name) => !isTestRunner(scripts[name]))
+    .filter(
+      (name) =>
+        !claimed.includes(name) && !Object.hasOwn(excluded, name) && !Object.hasOwn(known, name),
+    )
+    .map((name) => ({ name, route: routes[name] }));
+}
+
+/**
+ * Reached, tool-executing scripts that are not controls, with what was checked rather than a label.
+ *
+ * Distinct from `NOT_GATES`: those are unreached by design, and `staleExclusions` fails if one ever
+ * becomes wired. These are *expected* to be reached -- they run in CI legitimately -- they simply
+ * assert no repository invariant, so the gate census is not the right instrument for them.
+ *
+ * Each reason is a criterion rather than a state, so it survives the tree changing (#4337).
+ */
+export const NOT_CONTROLS = {
+  'ai:manifest': {
+    criterion:
+      'generates the manifest; the control over it is ai:manifest:check, which is claimed. A ' +
+      'generator failing means it could not write, not that the tree violates an invariant',
+  },
+  'build:kmp': {
+    criterion:
+      'gradle build driver. Its failure reports a compile error, which the build job already ' +
+      'owns and reports better than a gate census could',
+  },
+  'test:kmp': {
+    criterion:
+      'gradle test driver. Its failure reports a failing test rather than a violated repository ' +
+      'invariant, the same distinction that keeps the tool-test runners out of the control set',
+  },
+};
 
 /**
  * Claimed gates that reach no workflow, so the claim is false rather than merely unverified.
@@ -288,6 +413,37 @@ export function claimedGateLines(routes, claimed = CLAIMED_GATES) {
       ...stale.map((s) => `  ${s.name}: now reached by ${s.route}`),
       'The exclusion rests on a sentence that has stopped holding. Either add it to CLAIMED_GATES,',
       'or restate why a workflow-reached script still is not a gate.',
+    );
+  }
+  return lines;
+}
+
+/**
+ * The omission direction, reported per script.
+ *
+ * @param {Record<string, string>} scripts Script name to body.
+ * @param {Record<string, string | null>} routes Script name to matching route.
+ * @returns {string[]} Report lines.
+ */
+export function unclaimedControlLines(scripts, routes) {
+  const population = toolBackedScripts(scripts, routes);
+  const runners = population.filter((n) => isTestRunner(scripts[n]));
+  const unclaimed = unclaimedControls(scripts, routes);
+  const lines = [
+    '',
+    `Workflow-reached scripts executing a repository tool: ${population.length}`,
+    `  ${runners.length} run test files rather than asserting an invariant, derived from what they`,
+    '  execute rather than from a name suffix.',
+    `  ${population.length - runners.length} are controls; each must be claimed or excluded with a`,
+    '  reason. This is the direction the census lacked: a tool wired into CI and left out of',
+    '  CLAIMED_GATES used to be invisible here (#4347).',
+  ];
+  if (unclaimed.length > 0) {
+    lines.push(
+      '',
+      'Workflow-reached control(s) accounted for by no list:',
+      ...unclaimed.map((u) => `  ${u.name}: reached by ${u.route}`),
+      'Either claim it as a gate, or record in NOT_CONTROLS what makes it not one.',
     );
   }
   return lines;
@@ -373,11 +529,19 @@ function main() {
   for (const line of scopeLines(routes, count)) console.log(line);
   for (const line of unreachedLines(routes)) console.log(line);
   for (const line of claimedGateLines(routes)) console.log(line);
+  for (const line of unclaimedControlLines(pkg.scripts ?? {}, routes)) console.log(line);
   // Until now this tool was itself wired and toothless: it printed a census and always exited 0, so
   // it satisfied "runs in CI" without being able to fail it. It now fails on exactly one claim --
   // that every declared gate can fail CI -- which is narrow enough to be true and checkable, and is
   // the claim whose prose version was wrong for fifteen rounds (#4333).
-  if (unenforcedClaims(routes).length > 0 || staleExclusions(routes).length > 0)
+  //
+  // #4347 adds the second direction: that every workflow-reached control is accounted for. The
+  // first claim can be true while the set it ranges over silently shrinks.
+  if (
+    unenforcedClaims(routes).length > 0 ||
+    staleExclusions(routes).length > 0 ||
+    unclaimedControls(pkg.scripts ?? {}, routes).length > 0
+  )
     process.exitCode = 1;
 }
 

--- a/tools/check-gate-enforcement.test.mjs
+++ b/tools/check-gate-enforcement.test.mjs
@@ -1,8 +1,10 @@
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
 import test from 'node:test';
 
 import {
   CLAIMED_GATES,
+  NOT_CONTROLS,
   NOT_GATES,
   NPM_LIFECYCLES,
   ROUTES,
@@ -15,7 +17,13 @@ import {
   scopeLines,
   scriptDeps,
   scriptPaths,
+  isTestRunner,
+  ownedPaths,
+  readWorkflows,
   staleExclusions,
+  toolBackedScripts,
+  unclaimedControlLines,
+  unclaimedControls,
   unenforcedClaims,
   unreachedLines,
 } from './check-gate-enforcement.mjs';
@@ -273,4 +281,123 @@ test('the stale-exclusion report names the route and is distinct from the unenfo
   const lines = claimedGateLines({ 'a:check': 'npm run' }, ['a:check']);
   assert.ok(!lines.some((l) => l.includes('no longer true')), 'clean tree reports no staleness');
   assert.ok(lines.some((l) => l.includes('criterion:')) && lines.some((l) => l.includes('state:')));
+});
+
+// --- #4347: the omission direction -------------------------------------------------------------
+// `unenforcedClaims` asks whether every claim is true. Nothing asked whether every truth was
+// claimed, so a tool wired into CI and left out of CLAIMED_GATES was invisible. It had already
+// happened: i18n:validate-glossary was wired at ci-lint.yml:123 and uncensused.
+
+test('a wired, tool-executing script in no list is reported', () => {
+  const scripts = { 'rogue:check': 'node tools/check-rogue.mjs' };
+  const routes = { 'rogue:check': 'npm run' };
+  const unclaimed = unclaimedControls(scripts, routes, [], {}, {});
+  assert.deepEqual(
+    unclaimed.map((u) => u.name),
+    ['rogue:check'],
+  );
+  assert.equal(unclaimed[0].route, 'npm run', 'the verdict carries the route that produced it');
+});
+
+test('claiming, excluding, or being a test runner each account for a script', () => {
+  const scripts = {
+    'a:check': 'node tools/a.mjs',
+    'b:check': 'node tools/b.mjs',
+    'c:test': 'node --test tools/c.test.mjs',
+  };
+  const routes = { 'a:check': 'npm run', 'b:check': 'npm run', 'c:test': 'npm run' };
+  assert.deepEqual(unclaimedControls(scripts, routes, ['a:check'], { 'b:check': {} }, {}), []);
+});
+
+test('an unreached script is outside the population, so this cannot double-report an orphan', () => {
+  const scripts = { 'a:check': 'node tools/a.mjs' };
+  assert.deepEqual(unclaimedControls(scripts, { 'a:check': null }, [], {}, {}), []);
+});
+
+test('the population is derived from what a script executes, not from its name', () => {
+  // `build` and `type-check` are excluded because they run no repository tool, which stays true
+  // if either is renamed. A name-based census has two error modes and neither shows in its output.
+  const scripts = {
+    build: 'vite build',
+    'type-check': 'tsc --noEmit',
+    'a:check': 'node tools/a.mjs',
+  };
+  const routes = { build: 'npm run', 'type-check': 'npm run', 'a:check': 'npm run' };
+  assert.deepEqual(toolBackedScripts(scripts, routes), ['a:check']);
+  assert.deepEqual(ownedPaths('vite build'), []);
+  assert.deepEqual(ownedPaths('node scripts/i18n/validate-glossary.js'), [
+    'scripts/i18n/validate-glossary.js',
+  ]);
+});
+
+test('a control is never misread as a test runner', () => {
+  // The runner class is derived from `.test.mjs`, which is still a naming convention -- a
+  // load-bearing one, since it is how run-tool-tests.mjs discovers what to run. The residual risk
+  // is a control that happens to match, so it is asserted rather than assumed.
+  const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+  const misread = CLAIMED_GATES.filter((n) => pkg.scripts[n] && isTestRunner(pkg.scripts[n]));
+  assert.deepEqual(misread, [], 'no claimed gate is classified as a test runner');
+  assert.ok(isTestRunner('node --test tools/x.test.mjs'), 'a runner is recognised');
+  assert.ok(!isTestRunner('node tools/check-x.mjs'), 'a control is not');
+  assert.ok(!isTestRunner('vite build'), 'a script running no repository tool is not a runner');
+});
+
+test('NOT_CONTROLS states a criterion, and its members are really reached', () => {
+  // A NOT_CONTROLS entry for an unreached script would be dead weight that reads like coverage.
+  // This is the mirror of staleExclusions: NOT_GATES members must stay unreached, these must not.
+  const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+  const { corpus } = readWorkflows();
+  const routes = resolveRoutes(pkg.scripts, corpus);
+  for (const [name, reason] of Object.entries(NOT_CONTROLS)) {
+    assert.ok(reason.criterion?.trim(), `${name} states a criterion`);
+    assert.ok(Object.hasOwn(pkg.scripts, name), `${name} is a real script`);
+    assert.notEqual(routes[name], null, `${name} is reached, so excluding it is not dead weight`);
+    assert.ok(
+      !isTestRunner(pkg.scripts[name]),
+      `${name} is not already covered by the runner class`,
+    );
+  }
+});
+
+test('the real tree has no unaccounted control', () => {
+  const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+  const { corpus } = readWorkflows();
+  const unclaimed = unclaimedControls(pkg.scripts, resolveRoutes(pkg.scripts, corpus));
+  assert.deepEqual(
+    unclaimed.map((u) => u.name),
+    [],
+  );
+});
+
+test('the report states the population and only names offenders when there are some', () => {
+  const clean = unclaimedControlLines(
+    { 'bounds:check': 'node tools/check-assertion-bounds.mjs' },
+    { 'bounds:check': 'npm run' },
+  );
+  assert.ok(!clean.some((l) => l.includes('accounted for by no list')));
+  const dirty = unclaimedControlLines({ 'z:check': 'node tools/z.mjs' }, { 'z:check': 'npm run' });
+  assert.ok(dirty.some((l) => l.includes('z:check')));
+});
+
+// --- #4347: the any-vs-all over-credit ----------------------------------------------------------
+// A script running two files was graded reached when one of them was wired. The defect sat in two
+// routes, and the second was only visible after fixing the first stopped hiding it.
+
+test('a file-path route requires every executed file, not one of them', () => {
+  const body = 'node scripts/a.js && node scripts/b.js';
+  assert.equal(directRoute('x', body, 'run: node scripts/a.js'), null, 'half-wired is not wired');
+  assert.equal(directRoute('x', body, 'node scripts/a.js\nnode scripts/b.js'), 'file path');
+  // The single-file case, which is every claimed gate, is unchanged.
+  assert.equal(directRoute('x', 'node tools/a.mjs', 'node tools/a.mjs'), 'file path');
+});
+
+test('an equivalent-command route requires every segment', () => {
+  const body = 'node scripts/a.js && node scripts/b.js';
+  assert.equal(runsEquivalentCommand(body, 'node scripts/a.js'), false);
+  assert.equal(runsEquivalentCommand(body, 'node scripts/a.js\nnode scripts/b.js'), true);
+  assert.equal(runsEquivalentCommand('', 'anything'), false, 'no segments is not a match');
+});
+
+test('i18n:validate-glossary is claimed, because it was wired long before it was censused', () => {
+  assert.ok(CLAIMED_GATES.includes('i18n:validate-glossary'));
 });

--- a/tools/check-gate-teeth.mjs
+++ b/tools/check-gate-teeth.mjs
@@ -138,6 +138,23 @@ export const PROVEN = {
     },
     expect: 'reached by no workflow',
   },
+  'i18n:validate-glossary': {
+    script: 'scripts/i18n/validate-glossary.js',
+    files: {
+      'config/i18n/locales.json':
+        '{"defaultPlatformResource":"config/i18n/locales.json","locales":{"en-US":{},"es-ES":{},"fr-FR":{}}}\n',
+      // Valid in every respect except one missing locale value, so a non-zero exit is attributable
+      // to the injected defect. Verified against a baseline of this fixture with "fr-FR":"Solde"
+      // restored, which exits 0. An empty fixture also exits 1, for staging reasons that have
+      // nothing to do with the gate's subject -- which is why the expected substring, not the exit
+      // code, is what separates a proven gate from a broken staging (#4347).
+      'config/i18n/glossary.json':
+        '{"description":"fixture","sourceLocale":"en-US","locales":["en-US","es-ES","fr-FR"],' +
+        '"terms":[{"concept":"Balance","en-US":"Balance","es-ES":"Saldo"}]}\n',
+      'apps/web/src/lib/education/glossary.ts': 'export const glossary = [];\n',
+    },
+    expect: 'missing a non-blank value for locale "fr-FR"',
+  },
 };
 
 /**


### PR DESCRIPTION
## Summary

`check-gate-enforcement` asked whether every claimed gate reaches a workflow. It never asked the inverse — whether every workflow-reached control is claimed. The claimed set is hand-maintained, so omission was the direction with no failure path: a tool wired into CI and forgotten in `CLAIMED_GATES` was invisible, and the census kept reporting a complete set while covering less of the tree.

It had already decayed.

## Measured

Deriving the population from the tree — npm scripts that resolve to a workflow route **and** execute a file under `tools/` or `scripts/`:

| | count |
| --- | --- |
| workflow-reached, tool-executing | 28 |
| test runners (derived) | 7 |
| controls | 21 |
| claimed | 16 |
| unclaimed | 5 |

Four are correctly out of scope (`build:kmp`, `test:kmp` are gradle drivers; `ai:manifest` is the generator whose control is `ai:manifest:check`) and now carry a recorded criterion in `NOT_CONTROLS`. The fifth is not out of scope: **`i18n:validate-glossary` is a gate with teeth, wired at `ci-lint.yml:123`, absent from the census the whole time it existed.**

Teeth proven by execution, with the control that makes the result mean anything:

```
baseline fixture (valid glossary)   EXIT=0
one locale value removed            EXIT=1
  Concept "Balance" is missing a non-blank value for locale "fr-FR".
```

The baseline passing is the proof. An empty fixture also exits 1, for staging reasons unrelated to the gate's subject — so an exit code alone would grade broken staging as a proven gate.

## The classification is derived, not name-based

Test runners are excluded by what they execute. #4345 was a name pattern that admitted a non-member on a substring *and* dropped three quarters of the real members in the same expression, so a `:test` suffix rule was not available here. `build` and `type-check` leave the population because they run no repository tool, which survives a rename.

It is not free of naming — the runner class keys on `.test.mjs`, a load-bearing convention since it is how `run-tool-tests.mjs` discovers what to run. The residual risk, a control that matches, is asserted against rather than assumed.

## An any-vs-all over-credit, in two routes

`directRoute`'s file-path route matched when **any** file a script executes appeared in the corpus. `i18n:validate` runs two validators, one is wired, and the resolver called the whole script reached.

Measured before changing it: 1 partially-wired script, and **no claimed gate executes more than one file**, so it could not yet produce a false verdict for a claimed gate — unexercised rather than harmless.

Fixing it moved the false verdict onto `runsEquivalentCommand`, which had the identical form one route over. The same defect sat in two places and the second was only visible once the first stopped hiding it.

## Recorded, not fixed

`scripts/i18n/validate-locale-catalogs.js` has teeth and is executed by no workflow. Wiring it changes CI behaviour and deserves its own verification.

## Issues

Closes #4347

## Testing

- [x] `node tools/run-tool-tests.mjs` — 745 pass / 0 fail (was 734; 11 new)
- [x] all 17 declared gates exit 0
- [x] the new check demonstrated failing live on `i18n:validate` before it was accounted for
- [x] `npm run format:check` / `npx eslint . --max-warnings 0` / `npm run type-check`

Credit: the engineering session, whose own gate census turned out to be a floor rather than a count for the structurally identical reason.