### PR TITLE
fix(tools): walk with lstat so a junction is not followed (#4349)

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -169,6 +169,15 @@ jobs:
       - name: One definition of a markdown fence
         run: npm run markdown:primitives:check
 
+      # statSync reports a Windows junction as a directory and lstatSync does not, so the ordinary
+      # walker descends through a link. This worktree carries three from node_modules/@finance/*
+      # back into tracked source; a cleanup that enumerated through one deleted node_modules plus
+      # 2,825 tracked files. Every individual delete was by name. The walk that produced the names
+      # was not. The exposure is also invisible to PowerShell, which stops at a junction, so it
+      # cannot be found by the tool this repository's agents verify cleanliness with (#4349).
+      - name: A directory test does not follow a link
+        run: npm run walk:safety:check
+
       # `gate:enforcement` answers whether a gate is wired, which is a property of the workflow
       # files and readable. It cannot answer whether the invoked program can fail, which is
       # behavioural: check-gate-enforcement.mjs was itself wired here and had no exit code at all

--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -10236,6 +10236,33 @@ hole -- an exemption naming a deleted file -- is pinned by a test rather than pr
 **The report separates error from violation; the control separates gate from fixture.** Both
 fixtures here exited 1, and only the control could tell them apart.
 
+### A third instrument found a third defect, on the same walk
+
+CodeQL then flagged the gate's own walk as `js/file-system-race` (high). The first version listed
+a directory and then `lstatSync`-ed each entry: link-safe, and still a check-then-use. The fix is
+the idiom this same file already documents as safe -- `readdirSync(dir, { withFileTypes: true })`
+-- because a `Dirent` is lstat-semantics _and_ arrives with the listing, so there is no window
+between deciding what an entry is and acting on it.
+
+Worth recording rather than quietly fixing. The property I verified by execution was
+link-following, and I never asked the second question, so the tool that caught it was one I had not
+thought to consult. Three defects in this gate, each found by a different instrument -- its own
+first run, its baseline control, and a static analyser -- and **none of them by the instrument that
+found the previous one**. That is the same shape as the PowerShell result at the top of this
+section, arrived at three more times in a single change.
+
+### An honest negative, and a flake
+
+Live exposure in this repository today is **zero**. The one unguarded walk skipped anything named
+`node_modules`, and the junctions live inside one, so the hazard was latent rather than active.
+The detector is still worth more than the fix, because the idiom is the default and the next walk
+to be written would not have been so lucky.
+
+Two test files also failed CI once with `does not provide an export named`, on modules this
+change never touched, and passed on re-run. Recorded as a flake in the Node 22 runner rather than
+diagnosed -- with the note that local verification here runs Node 24 while CI runs Node 22, so
+"passes locally" has been a weaker claim throughout this work than it sounded.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:

--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -10164,6 +10164,78 @@ rather than only recording it, since a recorded one goes on masking its neighbou
 `scripts/i18n/validate-locale-catalogs.js` has teeth and is executed by no workflow. Wiring it
 changes CI behaviour and deserves its own verification rather than being bundled here.
 
+## A directory test that follows a link
+
+`statSync(p).isDirectory()` is **true** for a Windows junction. `lstatSync(p).isDirectory()` is
+false. So the idiom everyone reaches for first --
+
+```js
+if (statSync(full).isDirectory()) walk(full);
+```
+
+-- descends through a junction into whatever it targets. This worktree carries three, pointing from
+`node_modules/@finance/*` back into tracked source, and the difference is not marginal:
+
+| instrument                      | files seen under `node_modules/@finance` |
+| ------------------------------- | ---------------------------------------- |
+| walk with `statSync`            | 3,720                                    |
+| walk with `lstatSync`           | 3                                        |
+| `Get-ChildItem -Recurse -Force` | 0                                        |
+
+The third row is why this became a gate rather than a note. Every cleanliness check in these
+sessions has been PowerShell, which stops at a junction and reports zero, so the safe tool returns
+a reassuring answer to a question it never asked. A probe carries its runtime's traversal
+semantics, and nobody states traversal semantics. The hazard is not hypothetical here: a cleanup
+enumerated through one of these junctions and deleted `node_modules` plus 2,825 tracked files.
+Every individual delete was by name and compliant. **The walk that produced the names was not.**
+
+### The census that motivated the gate was wrong six times out of six
+
+The first pass grepped `recursive:\s*true` and returned six production hits. All six were false
+positives -- five `mkdirSync(dir, { recursive: true })` and one `watch()`. Creating a directory
+tree and reading one share a spelling and nothing else. That is the fifth consecutive syntactic
+detector here corrected by execution, and the rule it keeps re-teaching is unchanged: _if the
+property is "what does this program do", run the program._
+
+### Three idioms, three different verdicts
+
+The gate's first real run returned four sites of three shapes, which is the finding worth keeping:
+
+| site                                     | shape                                       | resolution                        |
+| ---------------------------------------- | ------------------------------------------- | --------------------------------- |
+| `tools/verify-build-env.mjs`             | recursive walk gated by `statSync`          | fixed to `lstatSync` + skip links |
+| `tools/check-ai-manifest.test.mjs`       | one-shot predicate wanting a real directory | fixed to `lstatSync`              |
+| `tools/check-doc-links.mjs`              | classifies a link _target_                  | exempt, with criterion            |
+| `tools/check-web-performance-budget.mjs` | classifies an operator-supplied path        | exempt, with criterion            |
+
+A fourth idiom is safe and correctly unflagged: `readdirSync(dir, { withFileTypes: true })` yields
+a `Dirent` whose `isDirectory()` is lstat-semantics. Discriminating "recurses" from "merely
+tests" syntactically is the same inference that produced the 6/6 false positives, so the gate does
+not attempt it. It reports the idiom and demands a recorded criterion where following is intended
+-- deliberately **narrow in the opposite direction**: broader than its name, and honest about it.
+
+### The gate flagged its own docstring, and that was a real defect
+
+Its first run reported three violations, all inside its own block comment and regex literals.
+`literalSpans` is line-wise -- it returns on `//` and tracks nothing across lines -- and it
+deliberately omits regex spans, because its existing callers ask "is this quote data?" rather than
+"is this token a call?". Both properties made a file _describing_ an idiom read as one _committing_
+it. The fix added `maskedSpans` to `tools/lib/source.mjs`, covering strings, line comments,
+block comments, and regex literals. `check-tool-imports` shares the same blind spot and is now
+able to adopt it.
+
+### The baseline control caught a defect the violating fixture could not
+
+The `gate:teeth` fixture exited 1, which by exit code alone is a proven gate. Its control -- the
+byte-identical fixture with `lstatSync` -- also exited 1. The cause was in the gate, not the
+fixture: staleness was computed against _every_ exemption, so running anywhere but the real
+repository reported all of them stale. Staleness was rescoped to files actually scanned, which is
+the honest criterion (a justification can only stop applying to a file in scope), and the residual
+hole -- an exemption naming a deleted file -- is pinned by a test rather than pretended away.
+
+**The report separates error from violation; the control separates gate from fixture.** Both
+fixtures here exited 1, and only the control could tell them apart.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "gate:teeth": "node tools/check-gate-teeth.mjs",
     "bounds:check": "node tools/check-assertion-bounds.mjs",
     "markdown:primitives:check": "node tools/check-markdown-primitives.mjs",
+    "walk:safety:check": "node tools/check-walk-safety.mjs",
     "docs:links:check": "node tools/check-doc-links.mjs",
     "docs:links:test": "node --test tools/check-doc-links.test.mjs"
   },

--- a/tools/check-ai-manifest.test.mjs
+++ b/tools/check-ai-manifest.test.mjs
@@ -936,7 +936,9 @@ test('a recorded target the walk cannot reach is reported as unvisited', () => {
   // name that cannot hold a probe. The predicate has to match the thing the walk skips.
   const skipped = [...WALK_SKIP].find((name) => {
     const candidate = path.join(ROOT, name);
-    return fs.existsSync(candidate) && fs.statSync(candidate).isDirectory();
+    // lstat: the probe has to live *in* this directory, and statSync would accept a junction
+    // whose target is elsewhere entirely (#4349).
+    return fs.existsSync(candidate) && fs.lstatSync(candidate).isDirectory();
   });
   assert.ok(skipped, 'PREMISE: at least one excluded directory exists to hide a file behind');
   const rel = `${skipped}/__unvisited_probe_4217__.md`;

--- a/tools/check-gate-enforcement.mjs
+++ b/tools/check-gate-enforcement.mjs
@@ -197,6 +197,9 @@ export const CLAIMED_GATES = [
   // Wired at ci-lint.yml:123 since long before this census existed, and absent from it until
   // #4347 derived the population from the tree instead of reading the list.
   'i18n:validate-glossary',
+  // statSync reports a junction as a directory; the ordinary walker therefore follows a link.
+  // Wired at ci-lint.yml:179 (#4349).
+  'walk:safety:check',
 ];
 
 /**

--- a/tools/check-gate-teeth.mjs
+++ b/tools/check-gate-teeth.mjs
@@ -155,6 +155,25 @@ export const PROVEN = {
     },
     expect: 'missing a non-blank value for locale "fr-FR"',
   },
+  'walk:safety:check': {
+    script: 'tools/check-walk-safety.mjs',
+    files: {
+      // A minimal walker whose only defect is the stat call. Verified against a baseline control
+      // that is byte-identical except for `lstatSync`, which exits 0 with "No unjustified
+      // link-following directory test found." -- so the non-zero exit is attributable to the
+      // injected defect rather than to the fixture, which is the distinction an exit code alone
+      // cannot draw (#4347). The expected substring names the offending file and line, so a gate
+      // that failed for an unrelated reason could not satisfy it.
+      'tools/offender.mjs':
+        "import { readdirSync, statSync } from 'node:fs';\n" +
+        'export function walk(dir) {\n' +
+        '  for (const entry of readdirSync(dir)) {\n' +
+        '    if (statSync(`${dir}/${entry}`).isDirectory()) walk(`${dir}/${entry}`);\n' +
+        '  }\n' +
+        '}\n',
+    },
+    expect: 'tools/offender.mjs:4  statSync().isDirectory()',
+  },
 };
 
 /**

--- a/tools/check-markdown-primitives.mjs
+++ b/tools/check-markdown-primitives.mjs
@@ -29,7 +29,7 @@
  * so a tool scanning documents that happen to contain no fenced example never learns it needs the
  * guard. Nobody decides the rule is narrow; the rule is simply never observed to fail.
  */
-import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { existsSync, lstatSync, readFileSync, readdirSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -207,7 +207,16 @@ export function collectScripts(root) {
     for (const entry of entries.sort()) {
       if (entry === 'node_modules' || entry.startsWith('.')) continue;
       const full = path.join(dir, entry);
-      if (statSync(full).isDirectory()) walk(full);
+      // lstat, not stat: statSync(junction).isDirectory() is true, so the ordinary walker descends
+      // through a Windows junction into whatever it targets. This worktree has three from
+      // node_modules/@finance/* back into tracked source, and a statSync walk of them yields 3720
+      // files against lstat's 3. It is the mechanism that deleted 2,825 tracked files here (#4349).
+      //
+      // The node_modules skip above made this safe by accident rather than by construction: the
+      // junctions live inside a directory excluded by name. A link anywhere else was followed.
+      const stat = lstatSync(full);
+      if (stat.isSymbolicLink()) continue;
+      if (stat.isDirectory()) walk(full);
       else if (isScannedFile(entry)) out.push(full);
       else if (/\.test\.(mjs|cjs|js)$/.test(entry)) skippedTests.push(full);
     }

--- a/tools/check-walk-safety.mjs
+++ b/tools/check-walk-safety.mjs
@@ -93,9 +93,17 @@ export const EXEMPT = {
 /**
  * Read every scanned source file.
  *
- * Walks with `lstatSync` and refuses to descend into a link -- this file must not commit the defect
- * it detects, and a gate that traversed a junction to find traversals of junctions would be the
- * purest possible instance of it.
+ * Uses `readdirSync(dir, { withFileTypes: true })` rather than a stat per entry. That is the
+ * strictly better idiom on both counts this file cares about: a `Dirent` reports a junction as
+ * neither a directory nor a file, so the walk cannot follow a link, and the type arrives with the
+ * listing rather than from a second syscall, so there is no window between deciding what an entry
+ * is and acting on it.
+ *
+ * The first version stat-ed each entry with `lstatSync`, which was link-safe but still a
+ * check-then-use. CodeQL flagged it as `js/file-system-race`, correctly, and on the gate whose
+ * whole subject is unsafe traversal. Worth recording rather than quietly fixing: I verified the
+ * link-following property by execution and never asked the second question, so the tool that
+ * caught it was one I had not thought to consult.
  *
  * @param {string} root Repository root.
  * @returns {{file: string, text: string}[]} Scanned sources, ascending by path.
@@ -105,22 +113,24 @@ export function readSources(root) {
   const walk = (dir) => {
     let entries;
     try {
-      entries = fs.readdirSync(dir);
+      entries = fs.readdirSync(dir, { withFileTypes: true });
     } catch {
       return;
     }
-    for (const entry of entries.sort()) {
-      if (entry === 'node_modules' || entry.startsWith('.')) continue;
-      const full = path.join(dir, entry);
-      const stat = fs.lstatSync(full);
-      if (stat.isSymbolicLink()) continue;
-      if (stat.isDirectory()) {
+    for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+      if (entry.name === 'node_modules' || entry.name.startsWith('.')) continue;
+      if (entry.isSymbolicLink()) continue;
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
         walk(full);
-      } else if (SOURCE_EXTENSIONS.includes(path.extname(entry))) {
-        out.push({
-          file: path.relative(root, full).replaceAll('\\', '/'),
-          text: fs.readFileSync(full, 'utf8'),
-        });
+      } else if (entry.isFile() && SOURCE_EXTENSIONS.includes(path.extname(entry.name))) {
+        let text;
+        try {
+          text = fs.readFileSync(full, 'utf8');
+        } catch {
+          continue;
+        }
+        out.push({ file: path.relative(root, full).replaceAll('\\', '/'), text });
       }
     }
   };

--- a/tools/check-walk-safety.mjs
+++ b/tools/check-walk-safety.mjs
@@ -1,0 +1,277 @@
+#!/usr/bin/env node
+/**
+ * Fail on a directory test that follows a link, unless a criterion records why following is meant.
+ *
+ * `statSync(p).isDirectory()` is **true** for a Windows junction; `lstatSync(p).isDirectory()` is
+ * false. So the idiom everyone reaches for first --
+ *
+ *     if (statSync(full).isDirectory()) walk(full);
+ *
+ * -- descends through a junction into whatever it targets. This worktree carries three, pointing
+ * from `node_modules/@finance/*` back into tracked source, and the difference is not marginal:
+ *
+ *     walk with statSync   3720 files
+ *     walk with lstatSync     3
+ *     PowerShell -Recurse     0
+ *
+ * The third line is why this is a gate rather than a note. Every cleanliness check in this
+ * repository's agent sessions has been PowerShell, which stops at a junction and reports zero. A
+ * probe carries its runtime's traversal semantics, and nobody states traversal semantics, so the
+ * safe tool returns a reassuring answer to a question it never asked. The hazard is real here: a
+ * cleanup in this session enumerated through one of these junctions and deleted `node_modules`
+ * plus 2,825 tracked files. Every individual delete was by name and compliant. The walk that
+ * produced the names was not (#4349).
+ *
+ * ## What this matches, and what it deliberately does not
+ *
+ * Keyed on `readdirSync`/`readdir` and on a `statSync` whose result is tested with `isDirectory`.
+ * The census that motivated this gate used `recursive:\s*true` and returned six production hits,
+ * **all six false positives** -- five `mkdirSync(dir, { recursive: true })` and one `watch()`.
+ * Creating a directory tree and reading one share a spelling and nothing else. A detector that
+ * cannot tell them apart reports a hazard where none exists, so this one names the read.
+ *
+ * Occurrences inside strings, comments, and regex literals are excluded via `maskedSpans` in
+ * `tools/lib/source.mjs`: a file describing an idiom is not committing it, and this file is the
+ * largest instance of that in the tree -- its own first run flagged its own docstring three times.
+ *
+ * ## The criterion is narrower than the name
+ *
+ * This flags a **link-following directory test**, which is broader than "a walk". The first real
+ * run returned four sites of three different shapes: one genuine recursion
+ * (`verify-build-env.mjs`), one one-shot predicate that merely wanted a real directory, and two
+ * one-shot classifications where following a link is the intended semantics. Only the first was
+ * the hazard in the strict sense. Discriminating "recurses" from "tests" syntactically is the same
+ * class of inference that has now produced five consecutive false detectors here, so this gate does
+ * not attempt it: it reports the idiom and requires a recorded criterion where following is meant.
+ *
+ * A third idiom is safe and correctly unflagged: `readdirSync(dir, { withFileTypes: true })` yields
+ * a `Dirent` whose `isDirectory()` is lstat-semantics, reporting a junction as neither a directory
+ * nor a file. `check-web-performance-budget`'s own `walkFiles` is built that way.
+ *
+ * ## Exemptions
+ *
+ * An exemption carries a criterion rather than a name, so the next reader can disagree with it
+ * instead of trusting it, and so it does not silently stop applying (#4337).
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { maskedSpans, insideLiteral } from './lib/source.mjs';
+
+/** Directories whose sources are scanned. */
+export const SCANNED_DIRECTORIES = ['tools', 'scripts'];
+
+/** Extensions treated as executable source. */
+export const SOURCE_EXTENSIONS = ['.mjs', '.cjs', '.js'];
+
+/**
+ * Sites permitted to follow a link, each with the criterion that keeps it permitted.
+ *
+ * Not empty, and the two members are the reason the gate reports an idiom rather than a hazard: at
+ * both, following a link is the intended semantics rather than an oversight. `unusedExemptions`
+ * fails if a key stops naming a real site, so a permission cannot outlive what it justifies.
+ *
+ * @type {Record<string, {criterion: string}>}
+ */
+export const EXEMPT = {
+  'tools/check-doc-links.mjs:582': {
+    criterion:
+      'Classifies a link *target*, not a step in a walk. A markdown link pointing at a symlinked ' +
+      'directory resolves to a directory for every reader and every renderer, so lstat here would ' +
+      'report a valid directory link as a broken file link. Following is the intended semantics.',
+  },
+  'tools/check-web-performance-budget.mjs:141': {
+    criterion:
+      'One-shot classification of an operator-supplied report path, deciding only whether to walk ' +
+      'it or read it as a single file; following a link the operator named by hand is the point. ' +
+      'The walk it enters (walkFiles) uses readdirSync withFileTypes, and a Dirent reports a ' +
+      'junction as neither a directory nor a file, so the traversal itself does not follow links.',
+  },
+};
+
+/**
+ * Read every scanned source file.
+ *
+ * Walks with `lstatSync` and refuses to descend into a link -- this file must not commit the defect
+ * it detects, and a gate that traversed a junction to find traversals of junctions would be the
+ * purest possible instance of it.
+ *
+ * @param {string} root Repository root.
+ * @returns {{file: string, text: string}[]} Scanned sources, ascending by path.
+ */
+export function readSources(root) {
+  const out = [];
+  const walk = (dir) => {
+    let entries;
+    try {
+      entries = fs.readdirSync(dir);
+    } catch {
+      return;
+    }
+    for (const entry of entries.sort()) {
+      if (entry === 'node_modules' || entry.startsWith('.')) continue;
+      const full = path.join(dir, entry);
+      const stat = fs.lstatSync(full);
+      if (stat.isSymbolicLink()) continue;
+      if (stat.isDirectory()) {
+        walk(full);
+      } else if (SOURCE_EXTENSIONS.includes(path.extname(entry))) {
+        out.push({
+          file: path.relative(root, full).replaceAll('\\', '/'),
+          text: fs.readFileSync(full, 'utf8'),
+        });
+      }
+    }
+  };
+  for (const dir of SCANNED_DIRECTORIES) walk(path.join(root, dir));
+  return out;
+}
+
+/**
+ * Find link-following walk sites in one source file.
+ *
+ * Two shapes are unsafe. A `statSync` result tested with `isDirectory` recurses through a junction.
+ * A `readdirSync(..., { recursive: true })` enumerates through one without any stat at all, which
+ * is the harder of the two to spot because there is no visible directory test to review.
+ *
+ * @param {string} text Source text.
+ * @returns {{line: number, shape: string, source: string}[]} Findings, ascending by line.
+ */
+export function findUnsafeWalks(text) {
+  const spans = maskedSpans(text);
+  const findings = [];
+  // `statSync(x).isDirectory()` and the two-step `const st = statSync(x); ... st.isDirectory()`
+  // are both matched, because the second is what the fixed site in check-markdown-primitives was.
+  const statCall = /\bstatSync\s*\(/g;
+  for (const m of text.matchAll(statCall)) {
+    if (insideLiteral(spans, m.index)) continue;
+    // `fstatSync` and `lstatSync` end in `statSync`; require the character before to not be a
+    // word character, which the \b already gives, but `lstatSync` has `l` before `statSync` with
+    // no boundary -- so re-check the full identifier.
+    const before = text.slice(Math.max(0, m.index - 1), m.index);
+    if (/[\w$]/.test(before)) continue;
+    const rest = text.slice(m.index, m.index + 400);
+    if (!/isDirectory\s*\(/.test(rest)) continue;
+    findings.push({
+      line: lineOf(text, m.index),
+      shape: 'statSync().isDirectory()',
+      source: 'statSync reports a junction as a directory; lstatSync does not',
+    });
+  }
+  const recursiveRead = /\breaddirSync?\s*\([^;]{0,200}?recursive\s*:\s*true/gs;
+  for (const m of text.matchAll(recursiveRead)) {
+    if (insideLiteral(spans, m.index)) continue;
+    findings.push({
+      line: lineOf(text, m.index),
+      shape: 'readdirSync({ recursive: true })',
+      source: 'enumerates through a junction with no directory test to review',
+    });
+  }
+  return findings.sort((a, b) => a.line - b.line);
+}
+
+/**
+ * Line number of an offset, 1-based.
+ *
+ * @param {string} text Source text.
+ * @param {number} index Character offset.
+ * @returns {number} Line number.
+ */
+export function lineOf(text, index) {
+  let line = 1;
+  for (let i = 0; i < index; i += 1) if (text[i] === '\n') line += 1;
+  return line;
+}
+
+/**
+ * Unsafe walks that no exemption covers.
+ *
+ * @param {{file: string, text: string}[]} sources Scanned sources.
+ * @param {Record<string, {criterion: string}>} exempt Permitted sites.
+ * @returns {{file: string, line: number, shape: string, source: string}[]} Violations.
+ */
+export function violations(sources, exempt = EXEMPT) {
+  const out = [];
+  for (const { file, text } of sources) {
+    for (const finding of findUnsafeWalks(text)) {
+      if (Object.hasOwn(exempt, `${file}:${finding.line}`)) continue;
+      out.push({ file, ...finding });
+    }
+  }
+  return out;
+}
+
+/**
+ * Exemptions whose file is in scope but whose named site no longer offends.
+ *
+ * Scoped to files that were actually scanned. A key naming a file this tree does not contain is not
+ * stale -- it is out of scope, which is a different fact. Conflating them made the gate report every
+ * exemption as stale whenever it ran anywhere but the real repository, so its own baseline control
+ * exited 1 for a reason unrelated to the injected defect. The control caught it; the violating
+ * fixture could not have, because both cases exit 1 (#4349).
+ *
+ * The remaining hole -- an exemption naming a deleted file -- is a dangling reference rather than a
+ * rotted justification, and is pinned by a test against the real tree instead.
+ *
+ * @param {{file: string, text: string}[]} sources Scanned sources.
+ * @param {Record<string, {criterion: string}>} exempt Permitted sites.
+ * @returns {string[]} Stale exemption keys, ascending.
+ */
+export function unusedExemptions(sources, exempt = EXEMPT) {
+  const inScope = new Set(sources.map(({ file }) => file));
+  const live = new Set();
+  for (const { file, text } of sources) {
+    for (const finding of findUnsafeWalks(text)) live.add(`${file}:${finding.line}`);
+  }
+  return Object.keys(exempt)
+    .filter((key) => {
+      const file = key.slice(0, key.lastIndexOf(':'));
+      return inScope.has(file) && !live.has(key);
+    })
+    .sort();
+}
+
+/**
+ * Build the report.
+ *
+ * @param {{file: string, text: string}[]} sources Scanned sources.
+ * @param {Record<string, {criterion: string}>} exempt Permitted sites.
+ * @returns {{lines: string[], ok: boolean}} Report lines and verdict.
+ */
+export function report(sources, exempt = EXEMPT) {
+  const bad = violations(sources, exempt);
+  const stale = unusedExemptions(sources, exempt);
+  const lines = [
+    `Scanned ${sources.length} source file(s) in ${SCANNED_DIRECTORIES.join(', ')}.`,
+    'A directory test that gates traversal must use lstatSync. statSync reports a Windows',
+    'junction as a directory, and this worktree has three pointing from node_modules back into',
+    'tracked source (#4349). readdirSync withFileTypes is lstat-semantics and is safe.',
+  ];
+  if (bad.length > 0) {
+    lines.push('', 'Link-following directory test(s):');
+    for (const v of bad) lines.push(`  ${v.file}:${v.line}  ${v.shape} -- ${v.source}`);
+    lines.push(
+      'Use lstatSync and skip an entry whose stat isSymbolicLink(), or record an exemption with',
+      'the criterion that makes following a link correct there.',
+    );
+  }
+  if (stale.length > 0) {
+    lines.push('', 'Exemption(s) naming no unsafe walk:', ...stale.map((k) => `  ${k}`));
+    lines.push('The site was fixed or moved. Remove the exemption rather than leaving it to rot.');
+  }
+  if (bad.length === 0 && stale.length === 0)
+    lines.push('', 'No unjustified link-following directory test found.');
+  return { lines, ok: bad.length === 0 && stale.length === 0 };
+}
+
+function main() {
+  const root = process.cwd();
+  const { lines, ok } = report(readSources(root));
+  for (const line of lines) console.log(line);
+  process.exit(ok ? 0 : 1);
+}
+
+if (process.argv[1] && process.argv[1].endsWith('check-walk-safety.mjs')) {
+  main();
+}

--- a/tools/check-walk-safety.test.mjs
+++ b/tools/check-walk-safety.test.mjs
@@ -1,0 +1,217 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+import {
+  EXEMPT,
+  SCANNED_DIRECTORIES,
+  findUnsafeWalks,
+  lineOf,
+  readSources,
+  report,
+  unusedExemptions,
+  violations,
+} from './check-walk-safety.mjs';
+import { maskedSpans, insideLiteral } from './lib/source.mjs';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+test('flags a statSync directory test that gates recursion', () => {
+  const src = 'const st = statSync(full);\nif (st.isDirectory()) walk(full);\n';
+  const found = findUnsafeWalks(src);
+  assert.equal(found.length, 1);
+  assert.equal(found[0].shape, 'statSync().isDirectory()');
+  assert.equal(found[0].line, 1);
+});
+
+test('does not flag the lstatSync form', () => {
+  const src = 'const st = lstatSync(full);\nif (st.isDirectory()) walk(full);\n';
+  assert.deepEqual(findUnsafeWalks(src), []);
+});
+
+test('lstatSync is not matched by a suffix, and fstatSync is not either', () => {
+  // `lstatSync` ends in `statSync`; a \b-anchored pattern matches it. The gate re-checks the
+  // preceding character, so this is the assertion that keeps that check from being deleted.
+  for (const name of ['lstatSync', 'fstatSync']) {
+    assert.deepEqual(
+      findUnsafeWalks(`const st = ${name}(p);\nif (st.isDirectory()) walk(p);\n`),
+      [],
+    );
+  }
+});
+
+test('does not flag mkdirSync with recursive true', () => {
+  // The census that motivated this gate matched `recursive:\s*true` and returned six production
+  // hits, all six of them mkdirSync. Creating a tree and reading one share a spelling only.
+  const src = 'mkdirSync(dir, { recursive: true });\n';
+  assert.deepEqual(findUnsafeWalks(src), []);
+});
+
+test('flags readdirSync with recursive true', () => {
+  const found = findUnsafeWalks('const all = readdirSync(root, { recursive: true });\n');
+  assert.equal(found.length, 1);
+  assert.equal(found[0].shape, 'readdirSync({ recursive: true })');
+});
+
+test('does not flag an occurrence inside a string literal', () => {
+  const src = "const msg = 'use statSync(p).isDirectory() carefully';\n";
+  assert.deepEqual(findUnsafeWalks(src), []);
+});
+
+test('does not flag an occurrence inside a block comment', () => {
+  // This is the case that made the gate flag its own docstring on its first run: literalSpans is
+  // line-wise and returns on `//`, so a block comment read as code.
+  const src = [
+    '/**',
+    ' * if (statSync(full).isDirectory()) walk(full);',
+    ' */',
+    'const x = 1;',
+  ].join('\n');
+  assert.deepEqual(findUnsafeWalks(src), []);
+});
+
+test('does not flag an occurrence inside a regex literal', () => {
+  const src = 'const re = /statSync\\(.*isDirectory/g;\n';
+  assert.deepEqual(findUnsafeWalks(src), []);
+});
+
+test('still flags real code that follows a masked occurrence', () => {
+  // A masking bug that swallowed the rest of the file would turn the gate into a silent no-op, so
+  // the detector has to stay live after a comment and after an unterminated quote.
+  const src = [
+    '// mentions statSync(p).isDirectory() in prose',
+    "const label = 'it\\'s fine';",
+    'const st = statSync(full);',
+    'if (st.isDirectory()) walk(full);',
+  ].join('\n');
+  const found = findUnsafeWalks(src);
+  assert.equal(found.length, 1);
+  assert.equal(found[0].line, 3);
+});
+
+test('an unterminated single quote does not mask the remainder of the file', () => {
+  const spans = maskedSpans("const a = 'oops\nconst st = statSync(p);\n");
+  const idx = "const a = 'oops\nconst st = ".length;
+  assert.equal(insideLiteral(spans, idx), false);
+});
+
+test('lineOf is 1-based and counts newlines', () => {
+  assert.equal(lineOf('a\nb\nc', 0), 1);
+  assert.equal(lineOf('a\nb\nc', 2), 2);
+  assert.equal(lineOf('a\nb\nc', 4), 3);
+});
+
+test('an exemption suppresses exactly its own file and line', () => {
+  const sources = [
+    { file: 'tools/x.mjs', text: 'const st = statSync(p);\nif (st.isDirectory()) w();\n' },
+  ];
+  assert.equal(violations(sources, {}).length, 1);
+  assert.equal(violations(sources, { 'tools/x.mjs:1': { criterion: 'c' } }).length, 0);
+  assert.equal(violations(sources, { 'tools/x.mjs:2': { criterion: 'c' } }).length, 1);
+  assert.equal(violations(sources, { 'tools/y.mjs:1': { criterion: 'c' } }).length, 1);
+});
+
+test('an exemption naming no real site is reported stale', () => {
+  const sources = [{ file: 'tools/x.mjs', text: 'const st = lstatSync(p);\n' }];
+  assert.deepEqual(unusedExemptions(sources, { 'tools/x.mjs:1': { criterion: 'c' } }), [
+    'tools/x.mjs:1',
+  ]);
+});
+
+test('an exemption for a file outside the scan is not stale', () => {
+  // Staleness means a justification stopped applying, which is only knowable for a file in scope.
+  // Without this the gate reported every exemption as stale in any tree but the real one, and its
+  // own baseline control exited 1 for a reason unrelated to the defect under test.
+  const sources = [{ file: 'tools/x.mjs', text: 'const st = lstatSync(p);\n' }];
+  assert.deepEqual(unusedExemptions(sources, { 'tools/elsewhere.mjs:9': { criterion: 'c' } }), []);
+});
+
+test('every exempted file exists in the real tree', () => {
+  // The hole left by scoping staleness to scanned files: an exemption naming a deleted file is a
+  // dangling reference rather than a rotted justification, and the gate cannot see it.
+  for (const key of Object.keys(EXEMPT)) {
+    const rel = key.slice(0, key.lastIndexOf(':'));
+    assert.ok(fs.existsSync(path.join(ROOT, rel)), `${key} names a file that does not exist`);
+  }
+});
+
+test('the baseline control for the teeth fixture exits clean', () => {
+  // The violating fixture and a broken staging both exit 1. Only a passing control separates them,
+  // and here it is the assertion that caught a real defect in the gate rather than in the fixture.
+  const sources = [
+    {
+      file: 'tools/offender.mjs',
+      text: 'if (lstatSync(p).isDirectory()) walk(p);\n',
+    },
+  ];
+  assert.equal(report(sources, {}).ok, true);
+});
+
+test('every recorded exemption carries a criterion about following a link', () => {
+  // Asserting a length would invent a number; the checkable property is that the sentence is about
+  // the thing being permitted, so a future entry cannot be justified by a label.
+  for (const [key, value] of Object.entries(EXEMPT)) {
+    assert.ok(value.criterion, `${key} has no criterion`);
+    assert.match(
+      value.criterion,
+      /link|symlink|junction|follow/i,
+      `${key} criterion names no subject`,
+    );
+    assert.match(value.criterion, /\.$/, `${key} criterion is not a sentence`);
+  }
+});
+
+test('report fails on a violation and names the file and line', () => {
+  const sources = [
+    { file: 'tools/x.mjs', text: 'const st = statSync(p);\nif (st.isDirectory()) w();\n' },
+  ];
+  const { ok, lines } = report(sources);
+  assert.equal(ok, false);
+  assert.ok(lines.join('\n').includes('tools/x.mjs:1'));
+});
+
+test('report passes on a clean tree', () => {
+  const { ok } = report([{ file: 'tools/x.mjs', text: 'const st = lstatSync(p);\n' }], {});
+  assert.equal(ok, true);
+});
+
+test('readSources reaches both scanned directories and finds real files', () => {
+  const sources = readSources(ROOT);
+  const found = new Set(sources.map((s) => s.file));
+  // Named files rather than a threshold: a count would be an invented bound, and naming the gate's
+  // own source plus one file per scanned directory is what the assertion actually cares about.
+  assert.ok(found.has('tools/check-walk-safety.mjs'), 'the gate did not scan its own source');
+  for (const dir of SCANNED_DIRECTORIES) {
+    assert.ok(
+      sources.some((s) => s.file.startsWith(`${dir}/`)),
+      `no source scanned under ${dir}/`,
+    );
+  }
+});
+
+test('readSources does not descend into a link', () => {
+  // The gate must not commit the defect it detects. Junction creation needs privileges that are not
+  // guaranteed, so the assertion is on the walk's own directory test rather than on a fixture.
+  const text = fs.readFileSync(path.join(ROOT, 'tools', 'check-walk-safety.mjs'), 'utf8');
+  assert.ok(text.includes('fs.lstatSync(full)'), 'readSources must stat with lstat');
+  assert.ok(text.includes('stat.isSymbolicLink()'), 'readSources must skip a link');
+});
+
+test('the real tree has no unjustified link-following directory test', () => {
+  const { ok, lines } = report(readSources(ROOT));
+  assert.equal(ok, true, lines.join('\n'));
+});
+
+test('the fixed sites are actually fixed, not merely exempted', () => {
+  // verify-build-env's walk and the manifest test's probe predicate were changed to lstat rather
+  // than justified. If either regressed to statSync the gate would fail, but this pins the
+  // resolution so a future exemption cannot quietly become the answer instead.
+  for (const rel of ['tools/verify-build-env.mjs', 'tools/check-ai-manifest.test.mjs']) {
+    assert.ok(!Object.hasOwn(EXEMPT, rel), `${rel} must not be exempted wholesale`);
+    for (const key of Object.keys(EXEMPT)) {
+      assert.ok(!key.startsWith(`${rel}:`), `${rel} was fixed and must carry no exemption`);
+    }
+  }
+});

--- a/tools/check-walk-safety.test.mjs
+++ b/tools/check-walk-safety.test.mjs
@@ -193,10 +193,17 @@ test('readSources reaches both scanned directories and finds real files', () => 
 
 test('readSources does not descend into a link', () => {
   // The gate must not commit the defect it detects. Junction creation needs privileges that are not
-  // guaranteed, so the assertion is on the walk's own directory test rather than on a fixture.
+  // guaranteed, so the assertion is on the walk's own idiom rather than on a fixture. withFileTypes
+  // is the stronger property than lstat: a Dirent is link-safe *and* carries no check-then-use
+  // window, which is what CodeQL flagged the lstat version for.
   const text = fs.readFileSync(path.join(ROOT, 'tools', 'check-walk-safety.mjs'), 'utf8');
-  assert.ok(text.includes('fs.lstatSync(full)'), 'readSources must stat with lstat');
-  assert.ok(text.includes('stat.isSymbolicLink()'), 'readSources must skip a link');
+  assert.match(
+    text,
+    /readdirSync\(dir, \{ withFileTypes: true \}\)/,
+    'readSources must use Dirent',
+  );
+  assert.match(text, /entry\.isSymbolicLink\(\)/, 'readSources must skip a link');
+  assert.ok(!/fs\.lstatSync\(/.test(text), 'readSources should not need a per-entry stat at all');
 });
 
 test('the real tree has no unjustified link-following directory test', () => {

--- a/tools/lib/source.mjs
+++ b/tools/lib/source.mjs
@@ -128,6 +128,106 @@ function looksLikeRegexStart(text, index) {
 }
 
 /**
+ * Whole-file spans that are not executable code: strings, comments, and regex literals.
+ *
+ * Distinct from {@link literalSpans}, which takes a **single line** and deliberately omits regex
+ * spans because its callers ask "is this quote character data?" and a regex body is implementation.
+ * A caller asking "is this token a call site?" needs the opposite: a `statSync(` written inside a
+ * regex, a block comment, or a docstring is a description of a call, not a call.
+ *
+ * Block comments are the reason this exists. `literalSpans` returns on `//` and tracks nothing
+ * across lines, so a docstring line containing `statSync(x).isDirectory()` reads as code to every
+ * line-wise caller. The first run of `check-walk-safety` flagged its own docstring three times,
+ * which is the cheapest possible demonstration that a detector for an idiom must not be fooled by
+ * prose about the idiom (#4349).
+ *
+ * @param {string} source Whole file text.
+ * @returns {[number, number][]} Ascending, non-overlapping offsets.
+ */
+export function maskedSpans(source) {
+  const text = String(source);
+  const spans = [];
+  let i = 0;
+  while (i < text.length) {
+    const ch = text[i];
+    const next = text[i + 1];
+    if (ch === '/' && next === '*') {
+      const close = text.indexOf('*/', i + 2);
+      const end = close === -1 ? text.length : close + 2;
+      spans.push([i, end]);
+      i = end;
+      continue;
+    }
+    if (ch === '/' && next === '/') {
+      let end = text.indexOf('\n', i);
+      if (end === -1) end = text.length;
+      spans.push([i, end]);
+      i = end;
+      continue;
+    }
+    if (ch === "'" || ch === '"' || ch === '`') {
+      const end = closeDelimited(text, i, ch, false);
+      spans.push([i, end]);
+      i = end;
+      continue;
+    }
+    if (ch === '/' && opensRegex(text, i)) {
+      const end = closeDelimited(text, i, '/', true);
+      spans.push([i, end]);
+      i = end;
+      continue;
+    }
+    i += 1;
+  }
+  return spans;
+}
+
+/**
+ * Offset just past the closing delimiter of a literal opening at `start`.
+ *
+ * @param {string} text Whole file text.
+ * @param {number} start Offset of the opening delimiter.
+ * @param {string} delim Closing delimiter.
+ * @param {boolean} regex Whether character classes must be skipped.
+ * @returns {number} Offset just past the close, or the end of input.
+ */
+function closeDelimited(text, start, delim, regex) {
+  let i = start + 1;
+  while (i < text.length) {
+    const ch = text[i];
+    if (ch === '\\') {
+      i += 2;
+      continue;
+    }
+    if (regex && ch === '[') {
+      const close = text.indexOf(']', i + 1);
+      i = close === -1 ? text.length : close + 1;
+      continue;
+    }
+    // An unterminated string does not run to the end of the file; it ends at the newline. Without
+    // this, one stray apostrophe in a comment would mask the remainder of the file from every
+    // caller, turning a detector silently into a no-op.
+    if (!regex && delim !== '`' && ch === '\n') return i;
+    if (ch === delim) return i + 1;
+    i += 1;
+  }
+  return text.length;
+}
+
+/**
+ * Whether a `/` at `index` opens a regex literal, scanning a whole file rather than a line.
+ *
+ * @param {string} text Whole file text.
+ * @param {number} index Offset of the candidate `/`.
+ * @returns {boolean} Whether to treat it as a regex opener.
+ */
+function opensRegex(text, index) {
+  const before = text.slice(0, index).replace(/\s+$/, '');
+  if (before === '') return true;
+  return /[(,=:[!&|?{};+\-*%~^<>]$/.test(before) || /\breturn$/.test(before);
+}
+
+/**
  * True when `index` falls strictly within one of `spans`.
  *
  * The opening delimiter is treated as outside, so a match that starts at the quote itself -- an

--- a/tools/verify-build-env.mjs
+++ b/tools/verify-build-env.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: BUSL-1.1
 
-import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { existsSync, lstatSync, readdirSync, readFileSync } from 'node:fs';
 import { relative, resolve } from 'node:path';
 
 const PLACEHOLDERS = ['https://placeholder.supabase.co', 'placeholder-anon-key'];
@@ -66,7 +66,10 @@ console.log('Verified web build env: no Supabase placeholder values found.');
 function* walk(dir) {
   for (const entry of readdirSync(dir)) {
     const path = resolve(dir, entry);
-    const stats = statSync(path);
+    // lstat, not stat: statSync reports a junction as a directory, so this recursion would
+    // descend through node_modules/@finance/* back into tracked source (#4349).
+    const stats = lstatSync(path);
+    if (stats.isSymbolicLink()) continue;
     if (stats.isDirectory()) {
       yield* walk(path);
       continue;


### PR DESCRIPTION
## Summary

`statSync(p).isDirectory()` is **true** for a Windows junction; `lstatSync` is false. So the
idiom everyone reaches for first descends through a link. This worktree carries three junctions
pointing from `node_modules/@finance/*` back into tracked source.

| instrument | files seen under `node_modules/@finance` |
| --- | --- |
| walk with `statSync` | 3,720 |
| walk with `lstatSync` | 3 |
| `Get-ChildItem -Recurse -Force` | 0 |

The third row is why this is a gate. PowerShell stops at a junction, so the tool used to verify
cleanliness in these sessions is structurally blind to the hazard. A cleanup that enumerated
through one of these junctions deleted `node_modules` plus 2,825 tracked files -- every
individual delete by name, and the walk that produced the names unbounded.

## Changes

- **Fixed three walking sites.** `check-markdown-primitives.mjs` and `verify-build-env.mjs`
  now walk with `lstatSync` and skip links; `check-ai-manifest.test.mjs`'s probe predicate
  wants a real directory, not a junction to one.
- **New gate `walk:safety:check`** (gate 18), wired at `ci-lint.yml:179`, added to
  `CLAIMED_GATES`, with a `gate:teeth` entry proving it exits 1 and names the offending site.
- **New `maskedSpans` in `tools/lib/source.mjs`** covering strings, line comments, block
  comments, and regex literals.
- Two criterion-bearing exemptions where following a link is the intended semantics.
- 23 new tests (768 total); documented in `docs/guides/engineering-practice-adoption.md`.

## Three findings worth more than the fix

**The motivating census was wrong 6 times out of 6.** Grepping `recursive:\s*true` returned six
production hits, all `mkdirSync` or `watch`. Fifth consecutive syntactic detector here
corrected by execution.

**The gate flagged its own docstring.** `literalSpans` is line-wise and omits regex spans, so a
file *describing* an idiom read as one *committing* it. `check-tool-imports` shares the blind
spot and can now adopt `maskedSpans`.

**The baseline control caught a defect the violating fixture could not.** Both fixtures exited 1.
The cause was in the gate: staleness was computed against every exemption, so any tree but the
real one reported all of them stale. Rescoped to files actually scanned; the residual hole -- an
exemption naming a deleted file -- is pinned by a test rather than pretended away.

The gate is deliberately **narrow in the opposite direction**: it reports a link-following
directory test, which is broader than "a walk", because discriminating "recurses" from "merely
tests" syntactically is the same inference that produced the 6/6 false positives.
`readdirSync(dir, { withFileTypes: true })` is lstat-semantics and correctly unflagged.

## Issues

Closes #4349

## Testing

- [x] `node tools/run-tool-tests.mjs` -- 768 pass, 0 fail
- [x] All 18 gates exit 0
- [x] `npm run format:check`, `npx eslint tools scripts --max-warnings 0`, `npm run type-check`
- [x] Teeth fixture verified with a passing baseline control: violation exit 1, control exit 0
