### PR TITLE
test(tools): require a passing control before a gate counts as proven

### DIFF
--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -10263,6 +10263,49 @@ change never touched, and passed on re-run. Recorded as a flake in the Node 22 r
 diagnosed -- with the note that local verification here runs Node 24 while CI runs Node 22, so
 "passes locally" has been a weaker claim throughout this work than it sounded.
 
+## A control is the transferable form of an exact-diagnostic assertion
+
+`gate:teeth` graded a gate proven when it exited non-zero and its report named the violation. That
+rejects a fixture which failed to scaffold, and the `jrmoulckers/engineering` session pointed out
+that it does not reject a fixture failing for the injected defect _and_ something unrelated. Their
+prover asserts an exact diagnostic count, which forecloses the case by construction.
+
+The count does not transfer: finance's gates emit free-form prose with no enumerable diagnostic
+unit, and importing the criterion into a population it does not govern is its own error. The
+transferable form is the **control** -- the same fixture with the defect removed, required to exit 0. It reaches the same guarantee from the other side, because anything else wrong with the fixture
+also fails the control.
+
+Measured before and after, on one fixture with a second independent defect added:
+
+|        | `status` | `named` | `controlStatus` | `ok`      |
+| ------ | -------- | ------- | --------------- | --------- |
+| before | 1        | true    | --              | **true**  |
+| after  | 1        | true    | 1               | **false** |
+
+Wiring the controls found two more gates whose fixtures had been failing for two reasons, and both
+were already graded proven:
+
+- `check-doc-links.mjs` reported all 11 baseline entries as no-longer-broken, because their citing
+  documents are absent from a fixture.
+- `check-markdown-primitives.mjs` reported both allowances as matching no site, for the same reason.
+
+That is the defect fixed in `check-walk-safety.mjs` one round earlier, found there by hand and here
+by execution: **a gate whose staleness check is not scoped to the population it actually read cannot
+pass on any tree but the real one, so no clean fixture can prove it.** Both now scope staleness to
+scanned files. Real-tree behaviour is unchanged; each keeps one residual hole -- an entry naming a
+deleted file -- pinned by a named test rather than left to be rediscovered.
+
+One entry declares no control. `gate:enforcement` reads its population from `CLAIMED_GATES`, a
+constant compiled into its own source, so every fixture short of the repository reports the other
+gates as unreached. It carries a `controlCriterion` saying so, which is checked to exist and to
+name an obstacle. An entry that cannot be proven attributable should say which, rather than be
+quietly dropped to keep the table tidy.
+
+The general shape: the controls existed for every gate here, verified by hand when each entry was
+added, and recorded only in a transcript. **A hand-verified property is a session artifact -- it
+decays, and nothing re-derives it.** Both defects above were introduced after the hand verification
+and neither was noticed, because nothing was still asking.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:

--- a/tools/check-doc-links.mjs
+++ b/tools/check-doc-links.mjs
@@ -413,6 +413,7 @@ export function census(git, exists, read, isDirectory = () => false) {
   }
   return {
     files: files.length,
+    scanned: files,
     total,
     fenced,
     broken,
@@ -509,7 +510,14 @@ export function reportLines(result, options = {}) {
   const neverWritten = baseline.filter((t) => kindOf(t) === 'never written').length;
   const unclassified = baseline.length - moved - neverWritten;
   const unexpected = broken.filter((b) => !baselineSet.has(b));
-  const fixed = [...baselineSet].filter((b) => !broken.includes(b));
+  // Staleness is judged only over files this run actually scanned. Without the scope a baseline
+  // entry reads as fixed wherever its citing document is simply absent, so the gate failed in
+  // every tree but this one -- and a gate that cannot pass on a clean fixture cannot be proven by
+  // one (#4351). The residual hole, an entry naming a document that has been deleted, is pinned
+  // by a test rather than left to be rediscovered.
+  const scanned = Array.isArray(result.scanned) ? new Set(result.scanned) : null;
+  const inScope = (entry) => !scanned || scanned.has(entry.split(' -> ')[0]);
+  const fixed = [...baselineSet].filter((b) => inScope(b) && !broken.includes(b));
   const unexpectedAnchors = staleAnchors.filter((a) => !staleBaseline.includes(a));
   const distinctBroken = new Set(broken).size;
 

--- a/tools/check-doc-links.test.mjs
+++ b/tools/check-doc-links.test.mjs
@@ -157,6 +157,7 @@ test('census returns an empty result for a repository with no markdown', () => {
   );
   assert.deepEqual(result, {
     files: 0,
+    scanned: [],
     total: 0,
     fenced: 0,
     broken: [],
@@ -936,4 +937,42 @@ test('the derived baseline cannot drift from the reason-bearing entries', () => 
     UNRESOLVED_BASELINE,
     UNRESOLVED_ENTRIES.map((e) => e.target),
   );
+});
+
+test('a recorded gap is judged fixed only over files this run actually scanned', () => {
+  const entry = 'docs/a.md -> ./gone.md';
+  const base = { total: 0, fenced: 0, fragmentless: 0, checkedAnchors: 0, staleAnchors: [] };
+
+  const unscanned = reportLines(
+    { ...base, files: 1, scanned: ['docs/b.md'], broken: [] },
+    { baseline: [entry] },
+  );
+  assert.equal(unscanned.failed, false, 'the citing document was not read, so nothing was learned');
+
+  const scanned = reportLines(
+    { ...base, files: 1, scanned: ['docs/a.md'], broken: [] },
+    { baseline: [entry] },
+  );
+  assert.equal(scanned.failed, true, 'read and no longer broken is a fixed gap');
+
+  const unscopedNoScan = reportLines({ ...base, files: 1, broken: [] }, { baseline: [entry] });
+  assert.equal(unscopedNoScan.failed, true, 'with no scope given the judgement is unchanged');
+});
+
+test('a recorded gap still fails when it is broken in a scanned file', () => {
+  const entry = 'docs/a.md -> ./gone.md';
+  const { failed } = reportLines(
+    {
+      total: 1,
+      fenced: 0,
+      fragmentless: 1,
+      checkedAnchors: 0,
+      staleAnchors: [],
+      files: 1,
+      scanned: ['docs/a.md'],
+      broken: [entry],
+    },
+    { baseline: [entry] },
+  );
+  assert.equal(failed, false, 'a gap that is still a gap is the baseline doing its job');
 });

--- a/tools/check-gate-teeth.mjs
+++ b/tools/check-gate-teeth.mjs
@@ -74,9 +74,20 @@ const LIB = ['tools/lib/markdown.mjs', 'tools/lib/source.mjs'];
  * Gates whose teeth are demonstrated by executing them against a fixture.
  *
  * `files` is written into a throwaway directory alongside a copy of the gate. `expect` is a
- * substring the report must contain; without it a fixture that failed to scaffold would count as
- * a pass. `repo: true` initialises a git repository and stages the files, for gates that
- * enumerate their population through git rather than the filesystem.
+ * substring -- or a list of them, all required -- that the report must contain; without it a
+ * fixture that failed to scaffold would count as a pass. `repo: true` initialises a git repository
+ * and stages the files, for gates that enumerate their population through git rather than the
+ * filesystem.
+ *
+ * `control` is an overlay applied over `files` that removes the injected defect, and it must exit
+ * **0**. It answers a question `expect` cannot: whether the fixture fails for the defect under test
+ * *and nothing else*. Measured before it existed -- adding a second, independent defect to a
+ * fixture left `status=1, named=true, ok=true`, so a fixture could prove less than it appeared to
+ * (#4351). The idea is the `jrmoulckers/engineering` prover's, which asserts an exact diagnostic
+ * count; that does not transfer to gates emitting free-form prose, but a control that must pass is
+ * the same guarantee reached from the other side.
+ *
+ * `controlCriterion` replaces `control` where a passing control is impossible, and says why.
  *
  * No fixture here uses `node_modules`. An earlier round linked one in and `git add -A` ingested
  * it, changing the tracked population between runs; the cleanup that followed traversed the link
@@ -90,6 +101,7 @@ export const PROVEN = {
       'package.json': '{"name":"fixture","version":"1.0.0"}\n',
       'tools/undeclared.mjs': "import x from 'totally-undeclared-package';\nexport default x;\n",
     },
+    control: { 'tools/undeclared.mjs': 'export default 1;\n' },
     expect: 'totally-undeclared-package',
   },
   'markdown:primitives:check': {
@@ -98,6 +110,7 @@ export const PROVEN = {
       'scripts/.keep': '',
       'tools/rogue.mjs': 'const FENCE = /^\\s*(```|~~~)/;\nexport { FENCE };\n',
     },
+    control: { 'tools/rogue.mjs': 'export const NOT_A_FENCE = 1;\n' },
     expect: 'rogue',
   },
   'bounds:check': {
@@ -105,6 +118,10 @@ export const PROVEN = {
     files: {
       'tools/invented.test.mjs':
         "import assert from 'node:assert/strict';\nassert.ok(total() >= 4173);\n",
+    },
+    control: {
+      'tools/invented.test.mjs':
+        "import assert from 'node:assert/strict';\nassert.ok(total() >= floor());\n",
     },
     expect: '4173',
   },
@@ -114,18 +131,24 @@ export const PROVEN = {
       '.github/workflows/unprefetched.yml':
         'name: unprefetched\non: [push]\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - run: ./gradlew build\n',
     },
+    control: {
+      '.github/workflows/unprefetched.yml':
+        'name: unprefetched\non: [push]\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo no gradle here\n',
+    },
     expect: 'Prefetch Gradle distribution',
   },
   'encoding:check': {
     script: 'tools/check-text-encoding.mjs',
     repo: true,
     files: { 'lost.txt': 'hi\uFFFD\n' },
+    control: { 'lost.txt': 'hi\n' },
     expect: 'U+FFFD replacement character',
   },
   'docs:links:check': {
     script: 'tools/check-doc-links.mjs',
     repo: true,
     files: { 'docs/a.md': '# A\n\nSee [gone](./nowhere-at-all.md).\n' },
+    control: { 'docs/a.md': '# A\n\nSee [here](./a.md).\n' },
     expect: './nowhere-at-all.md',
   },
   'gate:enforcement': {
@@ -136,6 +159,12 @@ export const PROVEN = {
       '.github/workflows/ci.yml':
         'name: CI\non: [push]\njobs:\n  a:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n',
     },
+    controlCriterion:
+      'No passing control exists. This gate reads its population from CLAIMED_GATES, a constant ' +
+      'compiled into its own source, so every fixture short of a copy of the real repository ' +
+      'reports the other claimed gates as unreached. The fixture can demonstrate the gate bites; ' +
+      'it cannot demonstrate the bite is attributable, and saying so is more honest than removing ' +
+      'the entry.',
     expect: 'reached by no workflow',
   },
   'i18n:validate-glossary': {
@@ -153,22 +182,33 @@ export const PROVEN = {
         '"terms":[{"concept":"Balance","en-US":"Balance","es-ES":"Saldo"}]}\n',
       'apps/web/src/lib/education/glossary.ts': 'export const glossary = [];\n',
     },
+    control: {
+      'config/i18n/glossary.json':
+        '{"description":"fixture","sourceLocale":"en-US","locales":["en-US","es-ES","fr-FR"],' +
+        '"terms":[{"concept":"Balance","en-US":"Balance","es-ES":"Saldo","fr-FR":"Solde"}]}\n',
+    },
     expect: 'missing a non-blank value for locale "fr-FR"',
   },
   'walk:safety:check': {
     script: 'tools/check-walk-safety.mjs',
     files: {
-      // A minimal walker whose only defect is the stat call. Verified against a baseline control
-      // that is byte-identical except for `lstatSync`, which exits 0 with "No unjustified
-      // link-following directory test found." -- so the non-zero exit is attributable to the
-      // injected defect rather than to the fixture, which is the distinction an exit code alone
-      // cannot draw (#4347). The expected substring names the offending file and line, so a gate
-      // that failed for an unrelated reason could not satisfy it.
       'tools/offender.mjs':
         "import { readdirSync, statSync } from 'node:fs';\n" +
         'export function walk(dir) {\n' +
         '  for (const entry of readdirSync(dir)) {\n' +
         '    if (statSync(`${dir}/${entry}`).isDirectory()) walk(`${dir}/${entry}`);\n' +
+        '  }\n' +
+        '}\n',
+    },
+    // Byte-identical except for the stat call, so a non-zero exit is attributable to the injected
+    // defect. This control was verified by hand when the entry was added and is wired here because
+    // a hand-verified property is a session artifact: it decays, and nothing re-derives it (#4351).
+    control: {
+      'tools/offender.mjs':
+        "import { readdirSync, lstatSync } from 'node:fs';\n" +
+        'export function walk(dir) {\n' +
+        '  for (const entry of readdirSync(dir)) {\n' +
+        '    if (lstatSync(`${dir}/${entry}`).isDirectory()) walk(`${dir}/${entry}`);\n' +
         '  }\n' +
         '}\n',
     },
@@ -321,15 +361,14 @@ function removeFixture(files, root) {
 }
 
 /**
- * Execute one gate against its fixture.
+ * Stage one fixture in a throwaway directory and run the gate in it.
  *
- * @param {string} name Gate name.
- * @param {{script: string, files: Record<string, string>, expect: string}} spec Fixture.
- * @param {string} [repoRoot] Source of the gate and its libraries.
- * @returns {{name: string, status: number|null, named: boolean, ok: boolean, first: string}} What
- *   happened.
+ * @param {{script: string, repo?: boolean}} spec Fixture.
+ * @param {Record<string, string>} files File contents to write.
+ * @param {string} repoRoot Source of the gate and its libraries.
+ * @returns {{status: number|null, output: string, staged: boolean}} What happened.
  */
-export function proveTeeth(name, spec, repoRoot = REPO_ROOT) {
+function runFixture(spec, files, repoRoot) {
   const root = mkdtempSync(path.join(tmpdir(), 'gate-teeth-'));
   const written = [];
   try {
@@ -339,7 +378,7 @@ export function proveTeeth(name, spec, repoRoot = REPO_ROOT) {
     for (const lib of LIB) {
       written.push(writeFixtureFile(root, lib, readFileSync(path.join(repoRoot, lib), 'utf8')));
     }
-    for (const [rel, content] of Object.entries(spec.files)) {
+    for (const [rel, content] of Object.entries(files)) {
       written.push(writeFixtureFile(root, rel, content));
     }
     if (spec.repo) {
@@ -347,34 +386,77 @@ export function proveTeeth(name, spec, repoRoot = REPO_ROOT) {
       git('init', '-q');
       git('config', 'user.email', 'fixture@example.invalid');
       git('config', 'user.name', 'fixture');
-      const staged = git('add', '-A');
-      if (staged.status !== 0) {
-        return {
-          name,
-          status: staged.status,
-          named: false,
-          ok: false,
-          first: 'fixture could not stage files, so the gate never ran',
-        };
+      if (git('add', '-A').status !== 0) {
+        return { status: null, output: '', staged: false };
       }
     }
     const result = spawnSync(process.execPath, [path.join(root, spec.script)], {
       cwd: root,
       encoding: 'utf8',
     });
-    const output = `${result.stdout ?? ''}${result.stderr ?? ''}`;
-    const named = output.includes(spec.expect);
-    const first = output.split('\n').find((line) => line.trim()) ?? '';
     return {
-      name,
       status: result.status,
-      named,
-      ok: result.status !== 0 && named,
-      first: first.trim(),
+      output: `${result.stdout ?? ''}${result.stderr ?? ''}`,
+      staged: true,
     };
   } finally {
     removeFixture(written, root);
   }
+}
+
+/**
+ * Execute one gate against its fixture, and against its control if it declares one.
+ *
+ * Three independent conditions have to hold. The gate must exit non-zero, its report must name
+ * every expected string, and the control -- the same fixture with the defect removed -- must exit
+ * zero. The third is the one an exit code cannot supply: without it a fixture that fails for the
+ * injected defect *and* something unrelated grades as proven, which was measured to happen here
+ * before this existed (#4351).
+ *
+ * @param {{script: string, files: Record<string, string>, expect: string|string[],
+ *   control?: Record<string, string>, controlCriterion?: string}} spec Fixture.
+ * @param {string} name Gate name.
+ * @param {string} [repoRoot] Source of the gate and its libraries.
+ * @returns {{name: string, status: number|null, named: boolean, controlStatus: number|null|
+ *   undefined, ok: boolean, first: string}} What happened.
+ */
+export function proveTeeth(name, spec, repoRoot = REPO_ROOT) {
+  const run = runFixture(spec, spec.files, repoRoot);
+  if (!run.staged) {
+    return {
+      name,
+      status: null,
+      named: false,
+      controlStatus: undefined,
+      ok: false,
+      first: 'fixture could not stage files, so the gate never ran',
+    };
+  }
+  const expected = Array.isArray(spec.expect) ? spec.expect : [spec.expect];
+  const missing = expected.filter((text) => !run.output.includes(text));
+  const named = missing.length === 0;
+
+  let controlStatus;
+  if (spec.control) {
+    const control = runFixture(spec, { ...spec.files, ...spec.control }, repoRoot);
+    controlStatus = control.staged ? control.status : null;
+  }
+  const controlOk = spec.control ? controlStatus === 0 : true;
+
+  const first = run.output.split('\n').find((line) => line.trim()) ?? '';
+  const reason = !named
+    ? `report did not name ${JSON.stringify(missing[0])}`
+    : !controlOk
+      ? 'control did not exit 0, so the failure is not attributable to the injected defect'
+      : first.trim();
+  return {
+    name,
+    status: run.status,
+    named,
+    controlStatus,
+    ok: run.status !== 0 && named && controlOk,
+    first: reason,
+  };
 }
 
 /**
@@ -417,9 +499,13 @@ export function report(proven = PROVEN, repoRoot = REPO_ROOT) {
       ? 'teeth'
       : result.status === 0
         ? 'NO TEETH (exited 0 over a violation)'
-        : 'FAILED FOR ANOTHER REASON (report did not name the violation)';
-    lines.push(`  ${result.name} -> exit ${result.status} ${verdict}`);
-    if (!result.ok) lines.push(`      first line: ${result.first}`);
+        : result.named
+          ? 'NOT ATTRIBUTABLE (the control failed too, so the fixture is dirty)'
+          : 'FAILED FOR ANOTHER REASON (report did not name the violation)';
+    const control =
+      result.controlStatus === undefined ? '' : `, control exit ${result.controlStatus}`;
+    lines.push(`  ${result.name} -> exit ${result.status}${control} ${verdict}`);
+    if (!result.ok) lines.push(`      ${result.first}`);
   }
 
   lines.push('');

--- a/tools/check-gate-teeth.test.mjs
+++ b/tools/check-gate-teeth.test.mjs
@@ -221,3 +221,95 @@ test('an unproven criterion declares whether it was executed or reasoned', () =>
     assert.equal(typeof spec.tested, 'boolean', `${name} does not say whether it was tested`);
   }
 });
+
+// A subject whose exit depends on the fixture, so a control overlay can genuinely clear it.
+const CONDITIONAL =
+  "import { readFileSync } from 'node:fs';\n" +
+  'let bad = false;\n' +
+  "try { if (readFileSync('defect.txt', 'utf8').trim() === 'yes') { console.log('found the-actual-violation here'); bad = true; } } catch {}\n" +
+  "try { if (readFileSync('other.txt', 'utf8').trim() === 'yes') { console.log('an unrelated second failure'); bad = true; } } catch {}\n" +
+  'process.exit(bad ? 1 : 0);\n';
+
+test('a control that exits zero makes the failure attributable to the injected defect', () => {
+  withScript(CONDITIONAL, (root) => {
+    const result = proveTeeth(
+      'fake:gate',
+      {
+        script: 'tools/subject.mjs',
+        files: { 'defect.txt': 'yes\n' },
+        control: { 'defect.txt': 'no\n' },
+        expect: 'the-actual-violation',
+      },
+      root,
+    );
+    assert.equal(result.controlStatus, 0, 'the fixture is clean once the defect is removed');
+    assert.equal(result.ok, true);
+  });
+});
+
+test('a fixture that fails for two independent reasons is not proof', () => {
+  withScript(CONDITIONAL, (root) => {
+    const spec = {
+      script: 'tools/subject.mjs',
+      files: { 'defect.txt': 'yes\n', 'other.txt': 'yes\n' },
+      expect: 'the-actual-violation',
+    };
+    const withoutControl = proveTeeth('fake:gate', spec, root);
+    assert.equal(withoutControl.ok, true, 'exit code and substring alone accept it -- the defect');
+
+    const withControl = proveTeeth(
+      'fake:gate',
+      { ...spec, control: { 'defect.txt': 'no\n' } },
+      root,
+    );
+    assert.equal(withControl.status, 1, 'it still fails');
+    assert.equal(withControl.named, true, 'and still names the violation');
+    assert.equal(withControl.controlStatus, 1, 'but the control fails too');
+    assert.equal(withControl.ok, false, 'so the failure is not attributable');
+    assert.match(withControl.first, /not attributable/);
+  });
+});
+
+test('every expected string is required, not merely one of them', () => {
+  withScript("console.log('names only the first');\nprocess.exit(1);\n", (root) => {
+    const result = proveTeeth(
+      'fake:gate',
+      {
+        script: 'tools/subject.mjs',
+        files: {},
+        expect: ['names only the first', 'and the second'],
+      },
+      root,
+    );
+    assert.equal(result.named, false);
+    assert.equal(result.ok, false);
+    assert.match(result.first, /and the second/, 'the report says which one was missing');
+  });
+});
+
+test('every proven entry either carries a control or says why none can exist', () => {
+  for (const [name, spec] of Object.entries(PROVEN)) {
+    const hasControl = spec.control !== undefined;
+    const hasCriterion = typeof spec.controlCriterion === 'string';
+    assert.ok(hasControl !== hasCriterion, `${name} must declare exactly one of the two`);
+    if (hasCriterion) {
+      // A criterion, not a state: it must name the obstacle, so a reader can check whether the
+      // obstacle is still there rather than trust that nobody has got round to it. Tested by the
+      // same shape the UNPROVEN table uses, rather than by a length threshold -- a threshold is a
+      // number nothing commits to, and this file exists to reject exactly that kind of assertion.
+      assert.ok(spec.controlCriterion.length > 0, `${name} has an empty criterion`);
+      assert.ok(
+        !/\byet\b|\bnot written\b|\btodo\b/i.test(spec.controlCriterion),
+        `${name} states a condition that stops being true without anything noticing`,
+      );
+    }
+  }
+});
+
+test('the shipped controls all pass, so no shipped fixture is dirty', () => {
+  for (const [name, spec] of Object.entries(PROVEN)) {
+    if (!spec.control) continue;
+    const result = proveTeeth(name, spec);
+    assert.equal(result.controlStatus, 0, `${name} control must exit 0`);
+  }
+});

--- a/tools/check-markdown-primitives.mjs
+++ b/tools/check-markdown-primitives.mjs
@@ -262,12 +262,17 @@ export function classify(sites, owner = OWNER, allowed = ALLOWED) {
  *
  * @param {{file: string}[]} sites Per-file predicate locations actually detected.
  * @param {Record<string, string>} allowed File to the reason it may keep its own implementation.
+ * @param {string[]} [scanned] Files this run actually read. When given, an allowance naming a file
+ *   outside it is not judged: the run has no evidence either way, and calling it stale made the
+ *   gate fail in every tree but this one, so no clean fixture could pass it (#4351). The residual
+ *   hole, an allowance naming a deleted file, is pinned by a test.
  * @returns {string[]} Allowed files matched by no site, ascending.
  */
-export function staleAllowances(sites, allowed = ALLOWED) {
+export function staleAllowances(sites, allowed = ALLOWED, scanned = null) {
   const seen = new Set(sites.map((site) => site.file));
+  const inScope = scanned ? new Set(scanned) : null;
   return Object.keys(allowed)
-    .filter((file) => !seen.has(file))
+    .filter((file) => !seen.has(file) && (!inScope || inScope.has(file)))
     .sort();
 }
 
@@ -326,7 +331,13 @@ export function untrackedAllowances(keys, root) {
  * @param {number} scanned How many scripts were read.
  * @returns {string[]} Report lines.
  */
-export function censusLines(groups, scanned, skippedTests = 0, primitive = PRIMITIVES[0]) {
+export function censusLines(
+  groups,
+  scanned,
+  skippedTests = 0,
+  primitive = PRIMITIVES[0],
+  scannedFiles = null,
+) {
   const total = groups.owner.length + groups.allowed.length + groups.unowned.length;
   const lines = [
     `${primitive.label} census: ${total} implementation(s) across ${scanned} script(s) scanned, ` +
@@ -353,6 +364,7 @@ export function censusLines(groups, scanned, skippedTests = 0, primitive = PRIMI
   const stale = staleAllowances(
     [...groups.owner, ...groups.allowed, ...groups.unowned],
     primitive.allowed,
+    scannedFiles,
   );
   if (stale.length > 0) {
     lines.push(
@@ -404,9 +416,13 @@ export function main(root) {
       if (lines.length > 0) sites.push({ file: path.relative(root, file), lines });
     }
     const groups = classify(sites, primitive.owner, primitive.allowed);
-    out.push(...censusLines(groups, scripts.length, scripts.skippedTests.length, primitive), '');
+    const scannedFiles = sources.map(({ file }) => path.relative(root, file));
+    out.push(
+      ...censusLines(groups, scripts.length, scripts.skippedTests.length, primitive, scannedFiles),
+      '',
+    );
     if (groups.unowned.length > 0) failed += 1;
-    if (staleAllowances(sites, primitive.allowed).length > 0) failed += 1;
+    if (staleAllowances(sites, primitive.allowed, scannedFiles).length > 0) failed += 1;
     const untracked = untrackedAllowances(Object.keys(primitive.allowed), root);
     if (untracked.length > 0) {
       out.push(

--- a/tools/check-markdown-primitives.test.mjs
+++ b/tools/check-markdown-primitives.test.mjs
@@ -394,3 +394,30 @@ test('a scan root that does not exist is detectable rather than silently narrowi
   }
   assert.ok(!existsSync(path.join(repoRoot, 'no-such-scan-root')));
 });
+
+test('an allowance is judged stale only over files this run actually scanned', () => {
+  const allowed = { 'tools/absent.mjs': 'reason' };
+  assert.deepEqual(
+    staleAllowances([], allowed, ['tools/other.mjs']),
+    [],
+    'a file outside the scanned population yields no evidence either way',
+  );
+  assert.deepEqual(
+    staleAllowances([], allowed, ['tools/absent.mjs']),
+    ['tools/absent.mjs'],
+    'scanned and matched by no site is stale',
+  );
+  assert.deepEqual(
+    staleAllowances([], allowed),
+    ['tools/absent.mjs'],
+    'with no scope given the judgement is unchanged, so injected populations still work',
+  );
+});
+
+test('the scope leaves one hole, and it is here rather than left to be rediscovered', () => {
+  // An allowance naming a file that has been deleted is never scanned, so it is never reported.
+  // The alternative -- reporting it -- is what made the gate fail on every clean fixture (#4351).
+  // The trade is deliberate: an allowance that describes nothing is inert, whereas a gate that
+  // cannot pass on a clean tree cannot be proven at all.
+  assert.deepEqual(staleAllowances([], { 'tools/deleted.mjs': 'reason' }, []), []);
+});

--- a/tools/check-walk-safety.mjs
+++ b/tools/check-walk-safety.mjs
@@ -75,7 +75,7 @@ export const SOURCE_EXTENSIONS = ['.mjs', '.cjs', '.js'];
  * @type {Record<string, {criterion: string}>}
  */
 export const EXEMPT = {
-  'tools/check-doc-links.mjs:582': {
+  'tools/check-doc-links.mjs:590': {
     criterion:
       'Classifies a link *target*, not a step in a walk. A markdown link pointing at a symlinked ' +
       'directory resolves to a directory for every reader and every renderer, so lstat here would ' +


### PR DESCRIPTION
## Summary

`gate:teeth` graded a gate proven when it exited non-zero and its report named the violation. That
rejects a fixture which failed to scaffold. It does not reject a fixture failing for the injected
defect **and** something unrelated -- measured, by adding a second independent defect:

| | `status` | `named` | `controlStatus` | `ok` |
| --- | --- | --- | --- | --- |
| before | 1 | true | -- | **true** |
| after | 1 | true | 1 | **false** |

The idea is the `jrmoulckers/engineering` prover's, which asserts an *exact diagnostic count*
against negative fixtures. That does not transfer: finance's gates emit free-form prose with no
enumerable diagnostic unit, and importing a criterion into a population it does not govern is its
own error. The transferable form is the **control** -- the same fixture with the defect removed,
required to exit 0. Anything else wrong with the fixture also fails the control, so it reaches the
same guarantee from the other side.

## What wiring the controls found

Two gates whose fixtures had been failing for two reasons, both already graded proven:

- `check-doc-links.mjs` reported all 11 baseline entries as no-longer-broken, because a fixture does
  not contain their citing documents.
- `check-markdown-primitives.mjs` reported both allowances as matching no site, for the same reason.

This is the defect fixed in `check-walk-safety.mjs` one round earlier -- found there by hand, here
by execution: **a gate whose staleness check is not scoped to the population it actually read cannot
pass on any tree but the real one, so no clean fixture can prove it.** Both now scope staleness to
scanned files; real-tree behaviour is unchanged, and the residual hole in each (an entry naming a
deleted file) is pinned by a named test rather than left to be rediscovered.

## Changes

- `tools/check-gate-teeth.mjs` -- `control` overlay run before the verdict and required to exit 0;
  `expect` accepts a list with every member required; `controlCriterion` for the one entry where no
  passing control can exist (`gate:enforcement` reads `CLAIMED_GATES` from its own source); report
  distinguishes `NOT ATTRIBUTABLE` from `FAILED FOR ANOTHER REASON` and prints the control's exit.
- `tools/check-doc-links.mjs` -- `census` returns `scanned`; a recorded gap is judged fixed only
  when its citing file was read.
- `tools/check-markdown-primitives.mjs` -- `staleAllowances` takes the scanned population.
- `tools/check-walk-safety.mjs` -- exemption repointed, having rotted on a line-number shift in an
  unrelated edit. Keying an exemption by line is fragile; recorded, not yet redesigned.
- 5 new tests in `check-gate-teeth.test.mjs`, 2 in each modified gate's suite.

## Issues

Closes #4351

## Testing

- [x] `node tools/run-tool-tests.mjs` -- **777 pass / 0 fail** (was 768)
- [x] All 18 declared gates exit 0
- [x] `npm run format:check`, `npx eslint tools scripts --max-warnings 0`, `npm run type-check`
- [x] The two-defect fixture flips `ok` from `true` to `false`; 8/8 shipped controls exit 0
