### PR TITLE
fix(tools): mask whole-file spans when reading bound markers (#4353)

### DIFF
--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -10306,6 +10306,65 @@ added, and recorded only in a transcript. **A hand-verified property is a sessio
 decays, and nothing re-derives it.** Both defects above were introduced after the hand verification
 and neither was noticed, because nothing was still asking.
 
+## A masking pair: the first defect decides whether the second is observable
+
+An upstream session reported two defects in one checker and, after a two-arm fixture, found they
+were one ordered mechanism rather than two observations: the earlier one consumes the file, so
+the later one is not merely unfixed but _unmeasurable in exactly the population where it would
+matter_. That class reproduces in finance, in a gate this repository wrote itself.
+
+`bounds:check` requires every numeric bound in a test to be either derived or annotated with an
+`unsourced-bound:` marker. `markerReason` looked for the marker with the **line-wise**
+`stripLiterals`, so a line inside a multi-line template literal carries no quote, nothing is
+stripped, and text the author never wrote as an annotation is accepted as one.
+
+Two arms, identical invented bound `assert.ok(total() > 4173)`:
+
+| arm | marker                                   | exit | report                                 |
+| --- | ---------------------------------------- | ---- | -------------------------------------- |
+| A   | none                                     | 1    | names `armB.test.mjs:5 >4173`          |
+| B   | inside a template literal, 3 lines above | 0    | "Every bound is annotated or derived." |
+
+This is a **false negative** -- the dangerous direction. A false positive is noise a human
+resolves; a false negative is a green build that has excused the thing the gate exists to catch.
+
+The fix is whole-file masking: `censusFile` now detects against
+`maskSource(source, { comments: false })` rather than the raw lines, and reports text from the
+original so line numbers still point where a reader expects. `maskSource` blanks masked spans to
+spaces and preserves every newline, so a line-wise caller gets whole-file correctness without
+changing shape.
+
+### Why comments stay visible here, and only here
+
+`maskedSpans` masks comments by default, which is right for a caller asking _"is this token a
+call site?"_. It is wrong for a caller reading **an annotation the author deliberately wrote in a
+comment** -- masking would erase every annotation and turn the false negative into a total
+failure. Hence a `{ comments }` option on the one primitive rather than a second implementation,
+which `markdown:primitives:check` would flag as duplication in any case. Two callers can want
+opposite answers from the same primitive; that is a parameter, not a fork.
+
+### Direction, measured across the other call sites
+
+Seven call sites use the line-wise primitives (`check-assertion-bounds.mjs:105,125,155,217`,
+`check-citation-enumerations.mjs:185`, `check-markdown-primitives.mjs:181`,
+`check-tool-imports.mjs:114`). Only the marker one is a false negative; the rest over-count and
+so fail loudly. Only the marker path was changed. **Sharing a defective primitive does not mean
+sharing a defect of equal severity -- the direction depends on what the caller does with the
+answer**, and a blanket migration would have been a larger diff for no safety gain.
+
+### Two corrections owed
+
+- The first probe reported that `maskedSpans` lacks template-literal support. It does not.
+  PowerShell's backtick is an escape character and silently ate the template delimiters, so the
+  probe measured a different string than the one written. `maskedSpans` was correct all along;
+  the sole cause was `markerReason`'s line-wise call. **A harness that transforms its own input
+  produces a root cause about a program that was never run.**
+- The upstream defect itself -- a pragma tested against raw text, so a pragma inside a fence or a
+  literal excuses the file -- exists in finance **byte-identically**, in the vendored
+  `config/engineering/citations/check-citations.mjs`. It has **zero reach**: `citations-check:
+ignore-file` occurs 0 times in this repository. The vendored file must not diverge, so this is
+  an upstream report rather than a local patch -- an instance of _reach is not delta_.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:

--- a/tools/check-assertion-bounds.mjs
+++ b/tools/check-assertion-bounds.mjs
@@ -81,7 +81,7 @@ const EXISTENCE = new Set(['>0', '>=1', '<1', '<=0', '>=0', '<0']);
  * @returns {string} The line with literal contents replaced by spaces.
  */
 export { stripLiterals } from './lib/source.mjs';
-import { stripLiterals } from './lib/source.mjs';
+import { maskSource, stripLiterals } from './lib/source.mjs';
 
 /**
  * Extract every numeric-literal *inequality* from a line of source.
@@ -242,13 +242,18 @@ export function isJudged(line) {
  */
 export function censusFile(file, source) {
   const lines = source.split('\n');
+  // Detection runs against the source with string, template, and regex bodies blanked, while the
+  // report quotes the untouched line. Comments stay visible because the marker is written in one.
+  // Masking is whole-file: the line-wise primitive cannot see a template literal that spans lines,
+  // so a marker inside one excused a real bound (#4353).
+  const masked = maskSource(source, { comments: false }).split('\n');
   const bounds = [];
   const reversed = [];
   let existence = 0;
   let derived = 0;
 
   for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
+    const line = masked[i];
     if (line.trimStart().startsWith('*') || line.trimStart().startsWith('//')) continue;
     if (!isJudged(line)) continue;
 
@@ -265,8 +270,8 @@ export function censusFile(file, source) {
         file,
         line: i + 1,
         token: comparison.token,
-        annotated: hasMarker(lines, i),
-        bare: hasBareMarker(lines, i),
+        annotated: hasMarker(masked, i),
+        bare: hasBareMarker(masked, i),
         text: lines[i].trim(),
       });
     }

--- a/tools/check-assertion-bounds.test.mjs
+++ b/tools/check-assertion-bounds.test.mjs
@@ -388,3 +388,40 @@ test('the CLI exits zero on the clean tree', () => {
   const out = execFileSync(process.execPath, [TOOL], { encoding: 'utf8' });
   assert.match(out, /Every bound is annotated or derived/);
 });
+
+// The marker is honoured in a comment and ignored in data. Written with fromCharCode so this file
+// does not itself contain a template literal carrying the marker, which is the very case under test.
+const BT = String.fromCharCode(96);
+
+test('a marker inside a multi-line template literal does not annotate a bound', () => {
+  const source =
+    'const doc = ' +
+    BT +
+    '\n' +
+    'unsourced-bound: this is data, not an annotation\n' +
+    BT +
+    ';\n' +
+    'assert.ok(total() > 4173);\n';
+  const result = censusFile('fixture.test.mjs', source);
+  assert.equal(result.bounds.length, 1, 'the bound is still found');
+  assert.equal(
+    result.bounds[0].annotated,
+    false,
+    'a line-wise strip sees no quote on the marker line and lets data excuse a real bound',
+  );
+});
+
+test('a marker in an ordinary comment still annotates, so the fix is not merely disabling it', () => {
+  const source =
+    '// unsourced-bound: nothing in the tree commits to this number\n' +
+    'assert.ok(total() > 4173);\n';
+  const result = censusFile('fixture.test.mjs', source);
+  assert.equal(result.bounds.length, 1);
+  assert.equal(result.bounds[0].annotated, true);
+});
+
+test('a comparison written inside a template literal is not counted as a bound', () => {
+  const source = 'const doc = ' + BT + '\n' + 'assert.ok(total() > 4173);\n' + BT + ';\n';
+  const result = censusFile('fixture.test.mjs', source);
+  assert.equal(result.bounds.length, 0, 'prose about a bound is not a bound');
+});

--- a/tools/lib/source.mjs
+++ b/tools/lib/source.mjs
@@ -142,9 +142,15 @@ function looksLikeRegexStart(text, index) {
  * prose about the idiom (#4349).
  *
  * @param {string} source Whole file text.
+ * @param {{comments?: boolean}} [options] `comments: false` masks only literals and regex bodies,
+ *   leaving comments visible. Callers asking "is this token a call site?" want comments masked;
+ *   callers reading an annotation the author wrote *in* a comment must not, or the annotation
+ *   disappears along with the prose. Both questions are legitimate and they are not the same
+ *   question, which is the distinction this file already draws between the two span functions.
  * @returns {[number, number][]} Ascending, non-overlapping offsets.
  */
-export function maskedSpans(source) {
+export function maskedSpans(source, options = {}) {
+  const { comments = true } = options;
   const text = String(source);
   const spans = [];
   let i = 0;
@@ -154,14 +160,14 @@ export function maskedSpans(source) {
     if (ch === '/' && next === '*') {
       const close = text.indexOf('*/', i + 2);
       const end = close === -1 ? text.length : close + 2;
-      spans.push([i, end]);
+      if (comments) spans.push([i, end]);
       i = end;
       continue;
     }
     if (ch === '/' && next === '/') {
       let end = text.indexOf('\n', i);
       if (end === -1) end = text.length;
-      spans.push([i, end]);
+      if (comments) spans.push([i, end]);
       i = end;
       continue;
     }
@@ -239,4 +245,31 @@ function opensRegex(text, index) {
  */
 export function insideLiteral(spans, index) {
   return spans.some(([start, end]) => index > start && index < end);
+}
+
+/**
+ * The source with masked spans blanked, preserving every offset and line break.
+ *
+ * Line-wise callers get whole-file correctness without changing shape: split the result and the
+ * line numbers still line up with the original, so a report can quote the untouched line while the
+ * detection runs against the masked one.
+ *
+ * The line-wise alternative is what this replaces. `stripLiterals` sees one line at a time, so a
+ * marker sitting inside a multi-line template literal is on a line with no quote on it and survives
+ * untouched -- which let a file excuse a real bound with text it never wrote as an annotation
+ * (#4353).
+ *
+ * @param {string} source Whole file text.
+ * @param {{comments?: boolean}} [options] Passed to {@link maskedSpans}.
+ * @returns {string} Same length as the input.
+ */
+export function maskSource(source, options = {}) {
+  const text = String(source);
+  const chars = [...text];
+  for (const [start, end] of maskedSpans(text, options)) {
+    for (let i = start; i < end && i < chars.length; i += 1) {
+      if (chars[i] !== '\n') chars[i] = ' ';
+    }
+  }
+  return chars.join('');
 }

--- a/tools/lib/source.test.mjs
+++ b/tools/lib/source.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { stripLiterals } from './source.mjs';
+import { maskSource, maskedSpans, stripLiterals } from './source.mjs';
 
 const BT = String.fromCharCode(96);
 
@@ -41,4 +41,48 @@ test('documented limits are real, so a reader does not over-trust the approximat
     !interpolated.includes('a ') || interpolated.includes('${'),
     'an interpolation containing a quote is not parsed; the docstring must keep saying so',
   );
+});
+
+test('maskSource preserves length and every line break, so offsets still line up', () => {
+  const source = 'const a = ' + BT + '\n  hidden\n' + BT + ';\nconst b = 1;\n';
+  const masked = maskSource(source);
+  assert.equal(masked.length, source.length);
+  assert.equal(masked.split('\n').length, source.split('\n').length);
+  assert.ok(!masked.includes('hidden'), 'the template body is blanked');
+  assert.ok(masked.includes('const b = 1;'), 'code outside it is untouched');
+});
+
+test('a template literal spanning lines is masked, which no line-wise strip can do', () => {
+  const source = 'const a = ' + BT + '\nmarker-text\n' + BT + ';\n';
+  const at = source.indexOf('marker-text');
+  assert.ok(
+    maskedSpans(source).some(([s, e]) => at >= s && at < e),
+    'whole-file masking covers it',
+  );
+  assert.equal(
+    stripLiterals('marker-text'),
+    'marker-text',
+    'the line alone carries no quote, so the line-wise strip leaves it -- the defect in #4353',
+  );
+});
+
+test('comments can be left visible, because an annotation is written in one', () => {
+  const source = '// unsourced-bound: a reason\nconst a = 1;\n';
+  const at = source.indexOf('unsourced-bound');
+  assert.ok(
+    maskedSpans(source).some(([s, e]) => at >= s && at < e),
+    'masked by default, for callers asking whether a token is a call site',
+  );
+  assert.ok(
+    !maskedSpans(source, { comments: false }).some(([s, e]) => at >= s && at < e),
+    'left alone for callers reading what the author wrote in the comment',
+  );
+});
+
+test('a string literal is masked whether or not comments are', () => {
+  const source = "const a = 'hidden';\n";
+  const at = source.indexOf('hidden');
+  for (const options of [{}, { comments: false }]) {
+    assert.ok(maskedSpans(source, options).some(([s, e]) => at >= s && at < e));
+  }
 });


### PR DESCRIPTION
## Summary

`bounds:check` accepted an `unsourced-bound:` marker written inside a multi-line template
literal as a real annotation, because `markerReason` used the line-wise `stripLiterals`. That is
a **false negative** -- a green build that excused the thing the gate exists to catch.

Two arms, identical invented bound `assert.ok(total() > 4173)`:

| arm | marker | before | after |
| --- | --- | --- | --- |
| A | none | exit 1 | exit 1 |
| B | in a template literal | **exit 0** | exit 1, names `armB.test.mjs:5 >4173` |

## Changes

- `tools/lib/source.mjs` -- `maskedSpans(source, options)` gains `{ comments = true }`; new
  `maskSource(source, options)` blanks masked spans to spaces, preserving newlines and offsets.
  Comments must stay visible for this caller: the annotation *is* a comment, so masking them
  would erase every annotation.
- `tools/check-assertion-bounds.mjs` -- `censusFile` detects against the masked source and
  reports text from the original. Real-tree census byte-identical before and after
  (72 files, 12 numeric bounds, 48 existence, 0 reversed; 6 derived, 12 annotated, 0 neither).
- 3 bounds tests + 4 source-primitive tests.
- `docs/guides/engineering-practice-adoption.md` -- the masking-pair section, the
  false-negative/false-positive direction split across the 7 line-wise call sites, and two
  corrections owed.

Only the marker call site was changed. The other six over-count, so they fail loudly; sharing a
defective primitive does not mean sharing a defect of equal severity.

## Issues

Closes #4353

## Testing

- [x] `node tools/run-tool-tests.mjs` -- 784 pass, 0 fail
- [x] all 18 declared gates exit 0
- [x] `npm run format:check`, `npx eslint tools scripts --max-warnings 0`, `npm run type-check`