### PR TITLE
test(tools): assert walk link-safety by behaviour, not source text (#4355)

### DIFF
--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -10432,6 +10432,23 @@ predicate, and the test says so in as many words: **a guard knowingly kept and k
 unfalsifiable is honest; one assumed to be load-bearing is not.** A test that fails when you
 delete dead code is asserting an implementation, not a property.
 
+### The fixture failed in CI for the reason the test is about
+
+Both link tests passed locally and the `ESLint & Prettier` job failed on Linux:
+
+```
+error: "ENOTDIR: not a directory, rmdir '/tmp/mdlink-CSibbT/tools/linkeddir'"
+```
+
+`symlinkSync`'s third argument is **Windows-only**. On Linux `'junction'` is ignored and a plain
+symlink is created, so `rmdir` is the wrong call. The cleanup branched on the type I _requested_
+rather than on what the filesystem actually produced -- which is the same error the test exists
+to document, committed in the test's own teardown. It now tries `unlink` and falls back.
+
+Worth stating alongside the Node 24-local / 22-CI gap already recorded here: **"passes locally"
+is weaker than it sounds in exactly the areas where a platform decides semantics**, and link
+handling is the clearest of them.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:

--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -10365,6 +10365,73 @@ answer**, and a blanket migration would have been a larger diff for no safety ga
 ignore-file` occurs 0 times in this repository. The vendored file must not diverge, so this is
   an upstream report rather than a local patch -- an instance of _reach is not delta_.
 
+## A surviving mutation does not mean a weak test
+
+An upstream session found that two independently sufficient guards are **mutually
+unfalsifiable**: remove either and every test stays green, so you cannot learn which layer you
+actually have. Their framing was that redundancy, usually described as defence in depth, is also
+the condition under which a guard is _misattributed_.
+
+Tested here by mutating the two link-safe walks and running both their tests and the gate:
+
+| walk             | mutation                          | tests    | `walk:safety:check` |
+| ---------------- | --------------------------------- | -------- | ------------------- |
+| `readSources`    | drop the `node_modules` name skip | pass     | pass                |
+| `readSources`    | drop `isSymbolicLink()`           | **fail** | pass                |
+| `collectScripts` | drop the `node_modules` name skip | pass     | pass                |
+| `collectScripts` | drop `isSymbolicLink()`           | pass     | pass                |
+| `collectScripts` | `lstatSync` -> `statSync`         | fail     | **fail**            |
+
+The claim reproduces. The one failure was a **source-text** match on `entry.isSymbolicLink()`,
+so it asserted that a line exists, not that a link is excluded.
+
+### The correction, which is the part worth carrying
+
+The obvious reading of a surviving mutation is "the test is weak." A fixture with a directory
+junction said otherwise -- removing the link skip changed nothing, because `lstat` already
+reports a junction as a non-directory. That reads as **dead code**, and I nearly recorded it as
+such. It was the wrong population. Adding a _file_ symlink:
+
+```
+shipped  []
+noLink   ["tools/filelink.mjs"]      <- the guard is load-bearing after all
+stat     ["tools/filelink.mjs", "tools/linked/leaked.mjs", "tools/linked/outside.mjs"]
+```
+
+**A surviving mutation is uninterpretable until you know the surviving population contains the
+case the guard is for.** Weak test and dead guard produce the identical signal, and they need
+opposite responses -- one is a test to write, the other is a line to delete.
+
+### Load-bearing is a property of a different line
+
+`Dirent` for a link reports `isFile=false, isDirectory=false, isSymbolicLink=true`. So a walk
+that gates recursion on `isDirectory()` **and** collection on `isFile()` excludes both hazards
+with no link skip at all.
+
+- `collectScripts` collects in an `else if (isScannedFile(entry))` branch with no positive type
+  test, so its skip is load-bearing.
+- `readSources` gates on `entry.isFile()`, so its skip is genuinely redundant.
+
+Same guard, same file shape, opposite verdicts, decided by the collection predicate. A census
+keyed on the guard cannot see this: asking which walks call `isSymbolicLink` flagged
+`scripts/vendor-configs.mjs`, `check-citation-enumerations.mjs`, and
+`check-node-version-consistency.mjs` -- **three false positives**, all three safe by `isFile()`
+gating. Adding the "missing" guard to each would have been three changes that fixed nothing and
+looked thorough.
+
+### What changed
+
+Both walks now have a behavioural test: a temp tree with a symlinked script and a linked
+directory, asserting the real file is still collected and nothing named `linked` is. The
+source-text assertion is gone. The mutation that previously survived now fails by name
+(`no link was followed: tools\\linked.mjs`), and swapping `readSources` off `Dirent` fails
+reporting both leaks including the one through the junction.
+
+`readSources` keeps its redundant skip as defence against a future change to the collection
+predicate, and the test says so in as many words: **a guard knowingly kept and knowingly
+unfalsifiable is honest; one assumed to be load-bearing is not.** A test that fails when you
+delete dead code is asserting an implementation, not a property.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:

--- a/tools/check-markdown-primitives.test.mjs
+++ b/tools/check-markdown-primitives.test.mjs
@@ -8,6 +8,8 @@ import {
   readFileSync,
   rmSync,
   rmdirSync,
+  symlinkSync,
+  unlinkSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
@@ -420,4 +422,62 @@ test('the scope leaves one hole, and it is here rather than left to be rediscove
   // The trade is deliberate: an allowance that describes nothing is inert, whereas a gate that
   // cannot pass on a clean tree cannot be proven at all.
   assert.deepEqual(staleAllowances([], { 'tools/deleted.mjs': 'reason' }, []), []);
+});
+
+test('collectScripts excludes a linked script and does not descend a linked directory', () => {
+  // Behavioural, not a source-text match. Removing the isSymbolicLink skip from collectScripts
+  // leaves every other test in this file green -- measured by mutation (#4355) -- because the
+  // collection branch is `else if (isScannedFile(entry))` with no positive type test. A walk that
+  // gated collection on isFile() would not need the skip at all, since Dirent.isFile() is false
+  // for a link. Whether the guard is load-bearing is a property of the collection line, not of
+  // the guard, so only behaviour can tell you which one you have.
+  const root = mkdtempSync(path.join(tmpdir(), 'mdlink-'));
+  const outside = mkdtempSync(path.join(tmpdir(), 'mdlink-out-'));
+  const made = [];
+  const links = [];
+  const dirs = [];
+  const write = (full, body) => {
+    mkdirSync(path.dirname(full), { recursive: true });
+    writeFileSync(full, body);
+    made.push(full);
+  };
+  try {
+    write(path.join(root, 'tools', 'real.mjs'), 'export const x = 1;\n');
+    write(path.join(outside, 'leaked.mjs'), 'export const leaked = 1;\n');
+
+    for (const [target, name, type] of [
+      [path.join(outside, 'leaked.mjs'), path.join(root, 'tools', 'linked.mjs'), 'file'],
+      [outside, path.join(root, 'tools', 'linkeddir'), 'junction'],
+    ]) {
+      try {
+        symlinkSync(target, name, type);
+        links.push([name, type]);
+      } catch {
+        // Link creation is privileged on some Windows configurations. The arms that could be
+        // created are still asserted; a skipped arm is better than a fixture that cannot run.
+      }
+    }
+    if (links.length === 0) return;
+
+    const names = collectScripts(root).map((file) => path.relative(root, file));
+    assert.ok(names.includes(path.join('tools', 'real.mjs')), 'the real file is still collected');
+    assert.ok(
+      !names.some((name) => name.includes('linked')),
+      `no link was followed: ${names.join(', ')}`,
+    );
+  } finally {
+    for (const [name, type] of links) {
+      if (type === 'junction') rmdirSync(name);
+      else unlinkSync(name);
+    }
+    for (const full of made) unlinkSync(full);
+    dirs.push(path.join(root, 'tools'), root, outside);
+    for (const dir of dirs) {
+      try {
+        rmdirSync(dir);
+      } catch {
+        // A directory that is not empty is left for inspection rather than removed recursively.
+      }
+    }
+  }
 });

--- a/tools/check-markdown-primitives.test.mjs
+++ b/tools/check-markdown-primitives.test.mjs
@@ -467,8 +467,16 @@ test('collectScripts excludes a linked script and does not descend a linked dire
     );
   } finally {
     for (const [name, type] of links) {
-      if (type === 'junction') rmdirSync(name);
-      else unlinkSync(name);
+      // Ask the filesystem what exists rather than trusting the type requested: the third
+      // argument to symlinkSync is Windows-only, so 'junction' yields a plain symlink on Linux and
+      // rmdir fails ENOTDIR. Keying cleanup on the constant passed in rather than on the state
+      // produced is the same error this test exists to document (#4355).
+      void type;
+      try {
+        unlinkSync(name);
+      } catch {
+        rmdirSync(name);
+      }
     }
     for (const full of made) unlinkSync(full);
     dirs.push(path.join(root, 'tools'), root, outside);

--- a/tools/check-walk-safety.test.mjs
+++ b/tools/check-walk-safety.test.mjs
@@ -245,8 +245,14 @@ test('readSources excludes a linked source and a linked directory, measured', ()
     );
   } finally {
     for (const [name, type] of links) {
-      if (type === 'junction') fs.rmdirSync(name);
-      else fs.unlinkSync(name);
+      // symlinkSync's type argument is Windows-only, so 'junction' yields a plain symlink on
+      // Linux and rmdir fails ENOTDIR. Ask the filesystem, do not trust the requested type.
+      void type;
+      try {
+        fs.unlinkSync(name);
+      } catch {
+        fs.rmdirSync(name);
+      }
     }
     for (const full of made) fs.unlinkSync(full);
     for (const dir of [path.join(root, 'tools'), root, outside]) {

--- a/tools/check-walk-safety.test.mjs
+++ b/tools/check-walk-safety.test.mjs
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import test from 'node:test';
@@ -192,18 +193,70 @@ test('readSources reaches both scanned directories and finds real files', () => 
 });
 
 test('readSources does not descend into a link', () => {
-  // The gate must not commit the defect it detects. Junction creation needs privileges that are not
-  // guaranteed, so the assertion is on the walk's own idiom rather than on a fixture. withFileTypes
-  // is the stronger property than lstat: a Dirent is link-safe *and* carries no check-then-use
-  // window, which is what CodeQL flagged the lstat version for.
+  // withFileTypes is the load-bearing property: a Dirent is link-safe *and* carries no
+  // check-then-use window, which is what CodeQL flagged the lstat version for.
   const text = fs.readFileSync(path.join(ROOT, 'tools', 'check-walk-safety.mjs'), 'utf8');
   assert.match(
     text,
     /readdirSync\(dir, \{ withFileTypes: true \}\)/,
     'readSources must use Dirent',
   );
-  assert.match(text, /entry\.isSymbolicLink\(\)/, 'readSources must skip a link');
   assert.ok(!/fs\.lstatSync\(/.test(text), 'readSources should not need a per-entry stat at all');
+});
+
+test('readSources excludes a linked source and a linked directory, measured', () => {
+  // This replaces an assertion that matched `entry.isSymbolicLink()` in the source text. That
+  // assertion was wrong in kind: readSources gates recursion on isDirectory() and collection on
+  // isFile(), and Dirent reports *both* false for a link, so the explicit skip here is dead code
+  // and a test that fails when you delete dead code is asserting an implementation, not a
+  // property. The skip is kept as defence against a future change to the collection predicate --
+  // and is knowingly unfalsifiable while that predicate stays positive (#4355).
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'walklink-'));
+  const outside = fs.mkdtempSync(path.join(os.tmpdir(), 'walklink-out-'));
+  const made = [];
+  const links = [];
+  const write = (full, body) => {
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, body);
+    made.push(full);
+  };
+  try {
+    write(path.join(root, 'tools', 'real.mjs'), 'export const x = 1;\n');
+    write(path.join(outside, 'leaked.mjs'), 'export const leaked = 1;\n');
+
+    for (const [target, name, type] of [
+      [path.join(outside, 'leaked.mjs'), path.join(root, 'tools', 'linked.mjs'), 'file'],
+      [outside, path.join(root, 'tools', 'linkeddir'), 'junction'],
+    ]) {
+      try {
+        fs.symlinkSync(target, name, type);
+        links.push([name, type]);
+      } catch {
+        // Link creation is privileged on some Windows configurations; assert the arms that exist.
+      }
+    }
+    if (links.length === 0) return;
+
+    const files = readSources(root).map((source) => source.file);
+    assert.ok(files.includes('tools/real.mjs'), 'the real file is still read');
+    assert.ok(
+      !files.some((file) => file.includes('linked')),
+      `no link was followed: ${files.join(', ')}`,
+    );
+  } finally {
+    for (const [name, type] of links) {
+      if (type === 'junction') fs.rmdirSync(name);
+      else fs.unlinkSync(name);
+    }
+    for (const full of made) fs.unlinkSync(full);
+    for (const dir of [path.join(root, 'tools'), root, outside]) {
+      try {
+        fs.rmdirSync(dir);
+      } catch {
+        // Left for inspection rather than removed recursively.
+      }
+    }
+  }
 });
 
 test('the real tree has no unjustified link-following directory test', () => {


### PR DESCRIPTION
## Summary

An upstream session reported that redundant guards are **mutually unfalsifiable** -- remove
either of two independently sufficient guards and every test stays green. Tested here by
mutation, and it reproduces:

| walk | mutation | tests | `walk:safety:check` |
| --- | --- | --- | --- |
| `readSources` | drop `node_modules` name skip | pass | pass |
| `readSources` | drop `isSymbolicLink()` | **fail** | pass |
| `collectScripts` | drop `node_modules` name skip | pass | pass |
| `collectScripts` | drop `isSymbolicLink()` | pass | pass |
| `collectScripts` | `lstatSync` -> `statSync` | fail | **fail** |

The single failure was an `assert.match` on the *source text*, so it asserted that a line exists,
not that a link is excluded.

## The correction this round turned on

A directory-junction fixture said the link guard was dead code -- removing it changed nothing,
because `lstat` already reports a junction as a non-directory. Wrong population. With a **file**
symlink:

```
shipped  []
noLink   ["tools/filelink.mjs"]   <- load-bearing after all
stat     ["tools/filelink.mjs", "tools/linked/leaked.mjs", "tools/linked/outside.mjs"]
```

**A surviving mutation is uninterpretable until the surviving population contains the case the
guard is for.** A weak test and a dead guard produce the identical signal and need opposite
responses.

## Load-bearing is decided by a different line

`Dirent` for a link is `isFile=false, isDirectory=false, isSymbolicLink=true`. A walk gating
recursion on `isDirectory()` and collection on `isFile()` needs no skip. `readSources` is in that
shape, so its skip is redundant; `collectScripts` collects in an untyped `else if` branch, so its
skip is load-bearing. Censusing by the guard flagged `scripts/vendor-configs.mjs`,
`check-citation-enumerations.mjs`, and `check-node-version-consistency.mjs` -- **three false
positives**, deliberately not "fixed".

## Changes

- Behavioural link tests for both walks (temp tree, symlinked script + linked directory, skipping
  where link creation is privileged). The previously surviving mutation now fails by name.
- The source-text assertion is removed. `readSources` keeps its redundant skip as defence against
  a future change to the collection predicate, and the test records that it is knowingly
  unfalsifiable -- rather than assuming it is load-bearing.
- Guide section on interpreting surviving mutations.

## Issues

Closes #4355

## Testing

- [x] 786 tests pass, 0 fail (was 784)
- [x] all 18 gates exit 0
- [x] `format:check`, `eslint --max-warnings 0`, `type-check` clean
- [x] mutation re-run: dropping the guard now fails; `Dirent` -> `statSync` fails naming both leaks