### PR TITLE
fix(tools): a failed control outranks a report that names nothing (#4357)

### DIFF
--- a/docs/guides/engineering-practice-adoption.md
+++ b/docs/guides/engineering-practice-adoption.md
@@ -10449,6 +10449,60 @@ Worth stating alongside the Node 24-local / 22-CI gap already recorded here: **"
 is weaker than it sounds in exactly the areas where a platform decides semantics**, and link
 handling is the clearest of them.
 
+## The mutation a count cannot see, and the verdict that pointed at the wrong file
+
+An upstream session mutated its validator to append an error unconditionally -- a validator that
+rejects every valid input in existence. Its 470-line prover passed clean, because every
+assertion in it is _invalid input must fail_, and the negative fixtures' diagnostics and counts
+were untouched. **A count criterion is powerless against a mutation that adds no diagnostic to
+any negative fixture.**
+
+That is the axis `gate:teeth` bought when it declined the count and adopted a `control` instead
+(#4351). Tested rather than assumed, by mutating `tools/check-text-encoding.mjs`:
+
+| mutation   | gate on real tree | `gate:teeth` | caught by                                    |
+| ---------- | ----------------- | ------------ | -------------------------------------------- |
+| reject-all | exit 1            | **exit 1**   | the control (valid input stopped passing)    |
+| accept-all | exit 0            | **exit 1**   | the violating fixture (exit 0 over a defect) |
+
+Both directions caught, by different halves. Neither half alone would do: the fixture cannot see
+reject-all and the control cannot see accept-all. **The two criteria foreclose disjoint classes,
+and having the stricter-looking one is not having both.**
+
+### The defect the experiment surfaced
+
+The reject-all run was caught with the _wrong reason_:
+
+```
+encoding:check -> exit 1, control exit 1 FAILED FOR ANOTHER REASON (report did not name the violation)
+```
+
+True, and misleading. A gate rejecting everything emits a report that names nothing, so `named`
+is false -- but that is a **symptom**; the control exiting 1 is the **cause**. The precedence in
+`report` tested `named` first, so it blamed the message text and would have sent a reader to the
+report strings while valid input had quietly stopped passing. Fixed: the control is tested
+first, and the wording no longer asserts a dirty fixture when a rejecting gate is equally
+consistent with the evidence.
+
+**A verdict that is true can still be wrong, when what it names is not what a reader should go
+and look at.** Both branches of the precedence now have a test, so the reordering cannot swallow
+the case it displaced.
+
+### The harness assertion this round adopted
+
+The upstream session's first mutation attempt _did not mutate_ -- a CRLF anchor against an LF
+file, `String.Replace` matching nothing and returning the original. Unguarded, that run would
+have produced exactly the evidence the hypothesis wanted, with a normal exit and no trace. Every
+mutation in this round therefore asserts that the text actually changed before running anything:
+
+```powershell
+if ($mutated -eq $orig) { throw "mutation did not apply" }
+```
+
+**A mutation test that silently fails to mutate is a negative control at zero** -- the same
+two-reasons-at-once hole as a fixture that fails to scaffold, but in the direction that leaves
+no evidence.
+
 ## Worth hoisting up
 
 Finance-invented, generic, and absent from the shared layers:

--- a/tools/check-gate-teeth.mjs
+++ b/tools/check-gate-teeth.mjs
@@ -495,12 +495,18 @@ export function report(proven = PROVEN, repoRoot = REPO_ROOT) {
 
   lines.push(`Executed ${results.length} gate(s) against a violating fixture:`);
   for (const result of results) {
+    // A failed control is tested before `named`, because it is the cause and `named` is a
+    // symptom. A gate mutated to reject everything exits 1 with a report that names nothing, and
+    // the earlier ordering blamed the report -- sending a reader to the message text when the
+    // fact that mattered was that valid input had stopped passing (#4357).
+    const controlFailed = result.controlStatus !== undefined && result.controlStatus !== 0;
     const verdict = result.ok
       ? 'teeth'
       : result.status === 0
         ? 'NO TEETH (exited 0 over a violation)'
-        : result.named
-          ? 'NOT ATTRIBUTABLE (the control failed too, so the fixture is dirty)'
+        : controlFailed
+          ? 'NOT ATTRIBUTABLE (the control failed too: a dirty fixture, or a gate that has ' +
+            'stopped accepting valid input)'
           : 'FAILED FOR ANOTHER REASON (report did not name the violation)';
     const control =
       result.controlStatus === undefined ? '' : `, control exit ${result.controlStatus}`;

--- a/tools/check-gate-teeth.test.mjs
+++ b/tools/check-gate-teeth.test.mjs
@@ -313,3 +313,53 @@ test('the shipped controls all pass, so no shipped fixture is dirty', () => {
     assert.equal(result.controlStatus, 0, `${name} control must exit 0`);
   }
 });
+
+test('a gate that has stopped accepting valid input is diagnosed by its control', () => {
+  // Mutating a real gate to reject everything (#4357) produced exit 1 with a report naming
+  // nothing, and the verdict blamed the report -- sending a reader to the message text when the
+  // fact that mattered was that valid input had stopped passing. `named` is the symptom; the
+  // control is the cause, so the control is tested first.
+  const REJECT_ALL = "console.error('some unrelated complaint');\nprocess.exit(1);\n";
+  withScript(REJECT_ALL, (root) => {
+    const specs = {
+      'fake:gate': {
+        script: 'tools/subject.mjs',
+        files: { 'defect.txt': 'yes\n' },
+        control: { 'defect.txt': 'no\n' },
+        expect: 'the-actual-violation',
+      },
+    };
+    const { failed, lines } = report(specs, root);
+    assert.equal(failed, true);
+    const line = lines.find((entry) => entry.includes('fake:gate'));
+    assert.match(line, /NOT ATTRIBUTABLE/, 'the control failure is the diagnosis');
+    assert.ok(
+      !line.includes('FAILED FOR ANOTHER REASON'),
+      `the report naming must not outrank the control: ${line}`,
+    );
+    assert.match(line, /control exit 1/, 'and the control exit is shown');
+  });
+});
+
+test('a report that names nothing while the control passes still blames the report', () => {
+  // The other side of the precedence, so the reordering cannot silently swallow this case.
+  const WRONG_COMPLAINT =
+    "import { readFileSync } from 'node:fs';\n" +
+    'let bad = false;\n' +
+    "try { if (readFileSync('defect.txt', 'utf8').trim() === 'yes') { console.log('something else went wrong'); bad = true; } } catch {}\n" +
+    'process.exit(bad ? 1 : 0);\n';
+  withScript(WRONG_COMPLAINT, (root) => {
+    const specs = {
+      'fake:gate': {
+        script: 'tools/subject.mjs',
+        files: { 'defect.txt': 'yes\n' },
+        control: { 'defect.txt': 'no\n' },
+        expect: 'the-actual-violation',
+      },
+    };
+    const { lines } = report(specs, root);
+    const line = lines.find((entry) => entry.includes('fake:gate'));
+    assert.match(line, /FAILED FOR ANOTHER REASON/);
+    assert.match(line, /control exit 0/);
+  });
+});


### PR DESCRIPTION
## Summary

An upstream session mutated its validator to reject **all** valid input; its 470-line prover
passed clean, because every assertion in it is *invalid input must fail* and the negative
fixtures' diagnostics and counts were untouched. A count criterion cannot see that mutation.

That is the axis `gate:teeth` bought when it declined the count and adopted a `control` (#4351).
Measured here by mutating `tools/check-text-encoding.mjs`:

| mutation | gate on real tree | `gate:teeth` | caught by |
| --- | --- | --- | --- |
| reject-all | exit 1 | **exit 1** | the control |
| accept-all | exit 0 | **exit 1** | the violating fixture |

Both caught, by different halves -- the fixture cannot see reject-all, the control cannot see
accept-all.

## The defect this surfaced

reject-all was caught with the **wrong reason**:

```
encoding:check -> exit 1, control exit 1 FAILED FOR ANOTHER REASON (report did not name the violation)
```

True but misleading. A gate rejecting everything names nothing, so `named` is false -- a symptom.
The control exiting 1 is the cause. The precedence tested `named` first, so the verdict pointed
a reader at the report strings while valid input had quietly stopped passing.

Now:

```
encoding:check -> exit 1, control exit 1 NOT ATTRIBUTABLE (the control failed too: a dirty
fixture, or a gate that has stopped accepting valid input)
```

The wording no longer asserts a dirty fixture when a rejecting gate fits the same evidence.

## Changes

- `tools/check-gate-teeth.mjs` -- control failure is tested before `named`; widened wording.
- `tools/check-gate-teeth.test.mjs` -- tests for **both** branches, so the reordering cannot
  swallow the case it displaced.
- Guide section, including the harness rule adopted this round: every mutation asserts the text
  actually changed before running anything. A mutation that silently fails to apply produces
  exactly the evidence its hypothesis wants, with a normal exit and no trace.

## Issues

Closes #4357

## Testing

- [x] 788 tests pass, 0 fail (was 786)
- [x] all 18 gates exit 0
- [x] `format:check`, `eslint --max-warnings 0`, `type-check` clean
- [x] reject-all mutation re-run against the fix: verdict now names the control