### PR TITLE
chore(eng): refresh vendored engineering configs to v0.145.0

### DIFF
--- a/config/engineering/citations/check-citations.mjs
+++ b/config/engineering/citations/check-citations.mjs
@@ -97,7 +97,7 @@ const DEFAULT_INDEX =
 // copy is otherwise indistinguishable from a current one — a consumer reported
 // a missing check that had shipped several releases earlier, having run an old
 // copy that could not tell them so.
-const TOOL_VERSION = '10';
+const TOOL_VERSION = '11';
 // Citations live in source comments as often as in prose. A consumer filed two
 // wrong citations against themselves in `.ts` files, then ran this tool over
 // that repository and got `41 citations, all IDs exist`, exit 0 -- because the
@@ -330,13 +330,14 @@ async function scanFile(file) {
   const hits = [];
   const links = [];
   const titled = [];
+  const duplicated = [];
   const raw = await readFile(file, 'utf8');
   // A file that builds citation fixtures contains IDs that are wrong on
   // purpose. The opt-out is a pragma in the file itself rather than a filename
   // convention, because a convention silently covers files nobody chose, and a
   // silent skip is how this checker returned green over the two wrong citations
   // that prompted widening the extension set. Skips are counted and printed.
-  if (IGNORE_PRAGMA.test(raw)) return { hits, links, titled, ignored: true };
+  if (IGNORE_PRAGMA.test(raw)) return { hits, links, titled, duplicated, ignored: true };
   const lines = raw.split(/\r?\n/);
   lines.forEach((text, i) => {
     for (const [, label, href] of text.matchAll(ID_LINK)) {
@@ -408,8 +409,34 @@ async function scanFile(file) {
     for (const [, id, paren] of text.matchAll(TITLED)) {
       titled.push({ file, line: i + 1, id, claimed: paren.trim() });
     }
+
+    // The naming convention this checker encourages collides with a style it
+    // did not anticipate: a repository that already italicises principle names
+    // in prose ends up stating the name twice —
+    //
+    //   [`ENG-ARCH-003` (Durable decisions)](…) *Durable decisions* requires…
+    //
+    // Both halves are correct, so every existing check passes. An adopter found
+    // three of these, and they clustered on their highest-value citations,
+    // because prose emphasises a name exactly where the name is load-bearing.
+    // That is the shape worth catching: the convention did the most damage where
+    // the author had been most careful.
+    //
+    // Warned, not failed. The redundancy is a consequence of following advice
+    // given here, and failing a consumer's pipeline for complying with it would
+    // be the wrong end of the stick.
+    for (const match of text.matchAll(TITLED)) {
+      const name = match[2].trim();
+      const rest = text.slice(match.index + match[0].length, match.index + match[0].length + 200);
+      const emphasised = new RegExp(
+        `(\\*\\*?|__?)${name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\1`,
+      );
+      if (emphasised.test(rest)) {
+        duplicated.push({ file, line: i + 1, id: match[1], name });
+      }
+    }
   });
-  return { hits, links, titled };
+  return { hits, links, titled, duplicated };
 }
 
 // Compare loosely: case, surrounding punctuation and internal whitespace are
@@ -442,6 +469,7 @@ async function main() {
   const citations = [];
   const links = [];
   const titled = [];
+  const duplicatedNames = [];
   const ignoredFiles = [];
   for (const file of files) {
     const scanned = await scanFile(file);
@@ -452,6 +480,7 @@ async function main() {
     citations.push(...scanned.hits);
     links.push(...scanned.links);
     titled.push(...scanned.titled);
+    duplicatedNames.push(...scanned.duplicated);
   }
 
   const unknown = citations.filter((c) => !known.has(c.id));
@@ -701,9 +730,30 @@ async function main() {
       (titled.length > 0 ? `, and ${titled.length} stated name(s) match` : '') +
       '.',
   );
+
+  // Reported after the pass line, because it is not a correctness problem and
+  // must not read as one. It is a redundancy this repository's own convention
+  // introduces into prose that already emphasises principle names.
+  if (duplicatedNames.length > 0) {
+    console.log(
+      `\nRedundant: ${duplicatedNames.length} citation(s) state the principle name twice.\n`,
+    );
+    for (const d of duplicatedNames) {
+      console.log(
+        `  ${d.file}:${d.line}  ${d.id} — "${d.name}" is both parenthesised and emphasised`,
+      );
+    }
+    console.log(
+      '\nBoth halves are correct, which is why every other check here passes. This\n' +
+        'is not a failure and nothing is blocked. Drop whichever reads worse — the\n' +
+        'parenthesised name earns its place when the ID appears without prose around\n' +
+        'it. Expect these to cluster on your most important citations, since prose\n' +
+        'emphasises a name exactly where the name is load-bearing.',
+    );
+  }
   reportScope(ignoredFiles);
   console.log(
-    `checker v${TOOL_VERSION}; checks run: IDs, stated names, range members` +
+    `checker v${TOOL_VERSION}; checks run: IDs, stated names, duplicated names, range members` +
       (opts.links ? ', link paths, link anchors' : ' (link paths SKIPPED via --no-links)') +
       `. Index: ${opts.index}`,
   );

--- a/engineering-configs.lock.json
+++ b/engineering-configs.lock.json
@@ -1,7 +1,7 @@
 {
   "repository": "jrmoulckers/engineering",
-  "ref": "v0.134.0",
-  "fetchedAt": "2026-08-12T22:22:17.563Z",
+  "ref": "v0.145.0",
+  "fetchedAt": "2026-08-15T06:34:05.498Z",
   "refresh": "node scripts/vendor-configs.mjs <newer-ref>",
   "tool": {
     "sha256": "e90b941c586de11b0ca828cdf6a0387f4ed607bf041a91d2f49418c4ad733324",
@@ -30,7 +30,7 @@
     },
     "config/engineering/citations/check-citations.mjs": {
       "source": "scripts/check-citations.mjs",
-      "sha256": "9fcd3bd8465e4e5ad8dc72d355ffdb51c7b4d4c34d637ddab5043ca4dfc3fc3c"
+      "sha256": "9aae825e1d5cfa2563f92e0bda5d90972c7bbc61dc42405af2285f4cd6556cb2"
     }
   }
 }


### PR DESCRIPTION
## Summary

`engineering-configs.lock.json` was pinned at **v0.134.0** while [`jrmoulckers/engineering`](https://github.com/jrmoulckers/engineering) had advanced **11 releases** to v0.145.0. `npm run eng:vendor:check` reports staleness as a deliberately **non-failing notice**, so it never surfaces on its own — the drift only ends if someone schedules it as work.

Found during an audit of finance's onboarding to the studio / product / engineering / .github authority repos.

## Changes

- Refreshed the vendored engineering configs to `v0.145.0`
- Only one file changed content: `config/engineering/citations/check-citations.mjs` (checker **v10 → v11**), which adds a warn-only "duplicated principle name" check
- The other five vendored files are byte-identical across the 11 releases

### Why `--set prettier,citations`

The bare `node scripts/vendor-configs.mjs v0.145.0` refused to run, and correctly so:

```
error: this would add 6 file(s) the lock does not cover:
  - config/engineering/tsconfig/base.json
  ... (5 more)
       The lock covers [prettier, citations].
```

v0.145.0 ships a new `tsconfig` set. Adopting it would widen finance's vendored surface, which belongs to #4038 (blocked on a `read:packages` grant), not to a version refresh. Scoping to `--set prettier,citations` refreshes in place and leaves the surface unchanged.

## Testing

- [x] `npm run eng:vendor:check` — `6 vendored file(s) match engineering-configs.lock.json at v0.145.0`, no staleness notice
- [x] `npm run eng:citations` — `93 citation(s) across 34 principle(s) in 4723 file(s); all IDs exist, and 37 stated name(s) match`
- [x] `npm run citations:enumerations:check` — passes
- [x] `npm run ci:check` — format + lint + type-check all pass
- [x] `npm run format:check && npx eslint . --max-warnings 0` — clean
- [x] Re-ran `eng:vendor:check` **after** committing, to confirm `lint-staged`'s `prettier --write` did not rewrite the upstream-owned vendored bytes and break the SHA-256 match

### One note on the new v11 check

The new duplicated-name check reports exactly one hit, and it is inside the vendored checker's **own explanatory comment** — the example it uses to document the rule:

```
config\engineering\citations\check-citations.mjs:417  ENG-ARCH-003 — "Durable decisions" is both parenthesised and emphasised
```

No finance-authored prose triggers it. The finding is warn-only, does not block, and is not actionable here since the file is upstream-owned.

## Issues

Closes #4360