### PR TITLE
ci(workflows): correct the release smoke test's fork rationale (#4362)

### DIFF
--- a/.github/workflows/reusable-release-smoke-test.yml
+++ b/.github/workflows/reusable-release-smoke-test.yml
@@ -5,22 +5,29 @@
 # Runs quick sanity checks against built artifacts to verify they are functional
 # before promoting to production or advancing a staged rollout.
 #
-# This is a Finance-local reusable workflow (multi-platform: android/ios/web/
-# windows) and is intentionally NOT the canon `reusable-smoke-test.yml` defined
-# in jrmoulckers/.github (a generic single-job web-only smoke test). It was
-# renamed from `reusable-smoke-test.yml` to `reusable-release-smoke-test.yml`
-# to remove an accidental filename collision with that canon workflow — see
-# jrmoulckers/.github#60. Finance calls this file only via a relative
-# `uses: ./.github/workflows/...` path and does not consume the backbone
-# version under either name.
-# Canonical comparison: jrmoulckers/.github@97ff60ec21321563fa0fc7ba80015261e7dcd6fa
-# Finance delta: the canonical workflow is a single web smoke job; this workflow
-# validates four native-first platforms and therefore cannot migrate without
-# dropping Android, iOS, and Windows release coverage.
+# This is a Finance-local copy awaiting removal — not a defended deviation.
+# Canon now ships `reusable-native-smoke-test.yml` in jrmoulckers/.github with
+# the same shape as this file: a `validate` job, one job per platform selected
+# through a `platforms` input (android/ios/web/windows), and a `summary` job
+# reducing the per-platform verdicts to one gateable `result` output. It was
+# promoted into canon *from this workflow* (jrmoulckers/.github#113), so the
+# Finance delta is zero and migrating drops no platform coverage.
+#
+# The file was renamed from `reusable-smoke-test.yml` to
+# `reusable-release-smoke-test.yml` to clear a filename collision with canon's
+# unrelated web-only `reusable-smoke-test.yml` — see jrmoulckers/.github#60.
+# Finance still calls this copy only via a relative
+# `uses: ./.github/workflows/...` path and consumes no backbone version yet.
+#
+# Migration is sequenced, not settled: finance's `optIn.workflows` in the
+# backbone `studio.config.json` is `[]` and the sync manifest fails validation
+# on undeclared uses, so repointing rc-branch-tag.yml and release-train.yml at
+# the canonical workflow must wait for jrmoulckers/.github#118. Tracked by #4364.
+# Canonical comparison: jrmoulckers/.github@f0bacf77dbdf0f5394793031875700b515ac2a1d
 #
 # Called by: rc-branch-tag.yml, release-train.yml
 #
-# Issue: #1147, jrmoulckers/.github#60
+# Issue: #1147, #4362, jrmoulckers/.github#60
 # =============================================================================
 
 name: Reusable Release Smoke Test

--- a/docs/ops/workflow-reuse-assessment.md
+++ b/docs/ops/workflow-reuse-assessment.md
@@ -29,7 +29,7 @@ $all | Where-Object { $_ -notmatch '@[0-9a-f]{40}$' -and $_ -notmatch '^\./' }
 
 ## Overlap with the backbone reusables
 
-The backbone publishes 8 reusables. Seven finance workflows overlap one.
+The backbone publishes 10 reusables. Seven finance workflows overlap one.
 
 | finance workflow                  | Lines | Backbone counterpart                                       | Verdict                            |
 | --------------------------------- | ----- | ---------------------------------------------------------- | ---------------------------------- |
@@ -39,7 +39,7 @@ The backbone publishes 8 reusables. Seven finance workflows overlap one.
 | `deploy-preview.yml`              | 394   | `reusable-deploy-preview.yml` + `reusable-perf-budget.yml` | **Divergent — partial candidate**  |
 | `deploy-pages.yml`                | 86    | `reusable-deploy-pages.yml`                                | **Closest candidate**              |
 | `reusable-detect-changes.yml`     | 64    | `reusable-change-detection.yml`                            | **Divergent — already reconciled** |
-| `reusable-release-smoke-test.yml` | 307   | `reusable-smoke-test.yml`                                  | **Divergent — do not migrate**     |
+| `reusable-release-smoke-test.yml` | 307   | `reusable-native-smoke-test.yml`                           | **Equivalent — migrate**           |
 
 ### Superset — migration would lose enforcement
 
@@ -69,14 +69,25 @@ prefixes and exact SHAs, while every finance required-check caller passes glob-b
 filters. Migration would change every caller's filter contract and is not parity-safe. **This is
 not a vendored copy** — it is a documented, deliberately different adapter. No action.
 
-**`reusable-release-smoke-test.yml`** — a 6-job per-platform release gate (Android, iOS, web,
-Windows, validate, summary). The backbone's `reusable-smoke-test.yml` is a single-artifact
-build-and-probe with an HTTP retry loop. Different shape entirely; not a substitute.
-
 **`deploy-preview.yml`** — 5 jobs. The `lighthouse` job overlaps `reusable-perf-budget.yml`
 (which takes `bundle-budget-kb`, `lhci-min-performance`, `lhci-min-accessibility`), and the
 build/upload half overlaps `reusable-deploy-preview.yml`. The PR-comment and cleanup jobs have
 no counterpart. A partial migration is plausible but touches a PR-visible surface.
+
+### Equivalent — migration sequenced
+
+**`reusable-release-smoke-test.yml`** — a 6-job per-platform release gate (Android, iOS, web,
+Windows, validate, summary). This row read "do not migrate" against the backbone's web-only
+`reusable-smoke-test.yml`, but that is no longer the comparison: canon ships
+`reusable-native-smoke-test.yml`, with the same shape — a `validate` job, one job per platform
+selected through a `platforms` input, and a `summary` job reducing the verdicts to a single
+gateable `result`. It is the same shape because it was promoted into canon **from this file**
+(jrmoulckers/.github#113), so the delta is zero and migrating drops no platform coverage.
+
+Migration is sequenced rather than settled: finance's `optIn.workflows` in the backbone
+`studio.config.json` is `[]` and the sync manifest fails validation on undeclared uses, so
+repointing the callers must wait for jrmoulckers/.github#118. The header was corrected under
+#4362; the migration itself is #4364.
 
 ### Best candidate
 

--- a/tools/check-test-independence.mjs
+++ b/tools/check-test-independence.mjs
@@ -37,9 +37,9 @@ import { execFileSync } from 'node:child_process';
  */
 export const DUPLICATION_BASELINE = [
   'check-node-version-consistency.test.mjs:107 ~ check-node-version-consistency.mjs:425',
-  'check-workflow-security.test.mjs:337 ~ check-workflow-security.mjs:608',
-  'check-workflow-security.test.mjs:338 ~ check-workflow-security.mjs:609',
-  'check-workflow-security.test.mjs:339 ~ check-workflow-security.mjs:610',
+  'check-workflow-security.test.mjs:337 ~ check-workflow-security.mjs:618',
+  'check-workflow-security.test.mjs:338 ~ check-workflow-security.mjs:619',
+  'check-workflow-security.test.mjs:339 ~ check-workflow-security.mjs:620',
 ];
 
 /** Operations whose presence makes a line a candidate for carrying a rule. */

--- a/tools/check-workflow-security.mjs
+++ b/tools/check-workflow-security.mjs
@@ -17,7 +17,6 @@ import { load as loadYaml } from 'js-yaml';
 
 const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const workflowDirectory = join(repositoryRoot, '.github', 'workflows');
-const canonicalWorkflowSha = '97ff60ec21321563fa0fc7ba80015261e7dcd6fa';
 const attestationActionSha = '4d101475d8b20a2381f78447822ac1eab6504dd8';
 const productionPowerSyncImage =
   'journeyapps/powersync-service:1.23.3@sha256:b6b22fa7d0d862f04bdff62846e656756d17bcf3dd6eca399a0633671051438b';
@@ -35,10 +34,21 @@ const privilegedWorkflows = new Set([
   'reusable-release-smoke-test.yml',
 ]);
 
+// Each local reusable is reviewed against canon independently, so the canonical comparison SHA is
+// per-file rather than global: `reusable-detect-changes.yml` is a defended deviation still measured
+// against the commit its adapter rationale was reviewed at, while `reusable-release-smoke-test.yml`
+// was re-checked under #4362 against a canon that has since absorbed it as
+// `reusable-native-smoke-test`. A shared constant would force one file's recheck to restamp the
+// other, which is exactly the unreviewed drift these baselines exist to catch.
 const localReusableBaselines = {
-  'reusable-detect-changes.yml': '73a26b45af9ff6254e6982b63b336dc4a9a2bdd785d7ffbdaae4094d2ae90697',
-  'reusable-release-smoke-test.yml':
-    'cb8de56b54292447ab67941b56e1f08c3c2fa0cfa3b8b533eddacc6fce5c9f02',
+  'reusable-detect-changes.yml': {
+    canonicalSha: '97ff60ec21321563fa0fc7ba80015261e7dcd6fa',
+    contentHash: '73a26b45af9ff6254e6982b63b336dc4a9a2bdd785d7ffbdaae4094d2ae90697',
+  },
+  'reusable-release-smoke-test.yml': {
+    canonicalSha: 'f0bacf77dbdf0f5394793031875700b515ac2a1d',
+    contentHash: '3c6a90f99e9a8cf7c08bec0ed825b583a48884068710ba3e028c15641aad3f05',
+  },
 };
 
 const requiredEnvironmentJobs = {
@@ -583,16 +593,16 @@ export function scanWorkflowSecurity(workflows, productionCompose = '') {
     report('deploy/docker-compose.yml', 'production container images must not use latest tags');
   }
 
-  for (const [file, expectedHash] of Object.entries(localReusableBaselines)) {
+  for (const [file, { canonicalSha, contentHash }] of Object.entries(localReusableBaselines)) {
     const workflow = workflows[file] ?? '';
-    if (!workflow.includes(`Canonical comparison: jrmoulckers/.github@${canonicalWorkflowSha}`)) {
-      report(file, `must document canonical comparison at ${canonicalWorkflowSha}`);
+    if (!workflow.includes(`Canonical comparison: jrmoulckers/.github@${canonicalSha}`)) {
+      report(file, `must document canonical comparison at ${canonicalSha}`);
     }
     const actualHash = sha256(normalizeReviewedPins(workflow));
-    if (actualHash !== expectedHash) {
+    if (actualHash !== contentHash) {
       report(
         file,
-        `reviewed local reusable drifted (expected ${expectedHash}, found ${actualHash}); ` +
+        `reviewed local reusable drifted (expected ${contentHash}, found ${actualHash}); ` +
           'action pin rotations are excluded from this baseline, so this reflects a change ' +
           'to the workflow itself and needs review',
       );


### PR DESCRIPTION
## Summary

The header on `.github/workflows/reusable-release-smoke-test.yml` justified keeping the workflow local with a claim canon has since invalidated — that canon offered only a web-only `reusable-smoke-test.yml`, and that finance therefore "cannot migrate without dropping Android, iOS, and Windows release coverage."

Canon now ships **`reusable-native-smoke-test.yml`**: a `validate` job, one job per platform selected through a `platforms` input (android/ios/web/windows), and a `summary` job reducing the verdicts to a single gateable `result` output. It has that shape because it was promoted into canon **from this very file** (jrmoulckers/.github#113), so the stated "Finance delta" is zero and the header argued it could not migrate to a workflow it seeded.

This is **STEP 1 of #4362 only** — the header correction. Step 2 (repointing callers, deleting the local file) is blocked upstream and is filed as #4364.

## Why a comment matters here

Canon's guidance in `.github/instructions/workflow.instructions.md` is explicit that a vendored copy of a backbone workflow is a silent fork — upstream fixes never reach it and nothing flags the divergence. The header is the only record of *why* this fork exists, so as long as it read as a settled decision the fork looked deliberate and no one re-checked it. That is precisely how it survived the promotion that invalidated it.

## Changes

- **`.github/workflows/reusable-release-smoke-test.yml`** — header comment only. Drops the "web-only" and "would drop platform coverage" claims, names `reusable-native-smoke-test`, cites jrmoulckers/.github#113 (the promotion) and #118 (the opt-in that unblocks migration), and refreshes the comparison stamp to `f0bacf77dbdf0f5394793031875700b515ac2a1d` (current canon `main`). **No change to `name`, `on`, inputs, secrets, outputs, `permissions`, or any job** — behaviour-neutral.
- **`tools/check-workflow-security.mjs`** — the canonical comparison SHA becomes **per-file**. It was a single shared constant asserted against *both* local reusables, so refreshing this file's stamp would have forced `reusable-detect-changes.yml` to restamp as well — an unreviewed move for a separately defended deviation, and exactly the drift these baselines exist to catch. Also recomputes the content-hash baseline, which a header edit necessarily drifts.
- **`docs/ops/workflow-reuse-assessment.md`** — carried the same retracted claim (verdict "Divergent — do not migrate" against the web-only counterpart, and "Different shape entirely; not a substitute"). Corrected, and the stale count of published backbone reusables updated from 8 to 10.

`reusable-detect-changes.yml` is deliberately untouched and stays pinned at `97ff60ec…`.

## Why migration is not in this PR

Finance's `optIn.workflows` in the backbone `studio.config.json` is `[]`, and the sync manifest **fails validation on undeclared uses**. Repointing `rc-branch-tag.yml` and `release-train.yml` before jrmoulckers/.github#118 lands would break finance's next sync validation. Splitting it this way keeps the incorrect claim from sitting in the tree waiting on an upstream PR.

## Issues

Closes #4362

Follow-up: #4364 (the actual migration, blocked on jrmoulckers/.github#118)

## Testing

- [x] `npm run workflow:security:check` — passes; 31 workflows scanned, 30/30 named assertions present
- [x] `npm run workflow:security:test` — 29/29 pass, including the control "the reviewed workflows as committed trip neither guard"
- [x] `npm run format:check` — clean
- [x] `npm run ci:check:quick` — passes
- [x] `npm run docs:links:check` — all 246 cross-file section links and 2797 anchors resolve
- [x] `npm run citations:enumerations:check` — clean
- [x] `npx eslint tools/check-workflow-security.mjs --max-warnings 0` — clean